### PR TITLE
Update transform.py

### DIFF
--- a/torchnet/transform.py
+++ b/torchnet/transform.py
@@ -30,7 +30,7 @@ def tablemergekeys():
         return mergetbl
     return mergekeys
 
-tableapply = lambda f: lambda d: dict(map(lambda (k,v): (k, f(v)), d.iteritems()))
+tableapply = lambda f: lambda d: dict(map(lambda k,v: (k, f(v)), d.iteritems()))
 
 def makebatch(merge = None):
     if merge:


### PR DESCRIPTION
Fixed invalid syntax for the lambda function. Lambda functions of two variables don't need parentheses.