### PR TITLE
Docstrings and cosmetic fixes

### DIFF
--- a/torchnet/dataset/batchdataset.py
+++ b/torchnet/dataset/batchdataset.py
@@ -36,7 +36,7 @@ class BatchDataset(Dataset):
         perm (function, optional): Function used to shuffle the dataset before
             batching. `perm(idx, size)` should return the shuffled index of
             `idx`th sample. By default, the function is the identity.
-            merge (function, optional): Function to control batching behaviour.
+        merge (function, optional): Function to control batching behaviour.
              `transform.makebatch(merge)` is used to make the batch. Default is
              None.
         policy (str, optional): Policy to handle the corner cases when the

--- a/torchnet/dataset/batchdataset.py
+++ b/torchnet/dataset/batchdataset.py
@@ -5,49 +5,59 @@ from .. import transform
 
 class BatchDataset(Dataset):
     """
-    Given a `dataset`, `tnt.BatchDataset` merges samples from this dataset to
-    form a new sample which can be interpreted as a batch (of size
-    `batchsize`).
-    The `merge` function controls how the batch is performed. It is a closure
-    taking a Lua array as input containing all occurrences (for a given batch)
-    of a field of the sample, and returning the aggregated version of these
-    occurrences. By default the occurrences are supposed to be tensors, and
-    they aggregated along the first dimension.
-    More formally, if the i-th sample of the underlying dataset is written as:
-    ```lua
-    {input=<input_i>, target=<target_i>}
-    ```
-    assuming only two fields `input` and `target` in the sample, then `merge()`
-    will be passed tables of the form:
-    ```lua
-    {<input_i_1>, <input_i_2>, ... <input_i_n>}
-    ```
-    or
-    ```lua
-    {<target_i_1>, <target_i_2>, ... <target_i_n>}
-    ```
-    with `n` being the batch size.
+    Dataset which batches the data from a given dataset.
+
+    Given a `dataset`, `BatchDataset` merges samples from this dataset to
+    form a new sample which can be interpreted as a batch of size `batchsize`.
+
+    The `merge` function controls how the batching is performed. By default
+    the occurrences are supposed to be tensors, and they aggregated along the
+    first dimension.
+
     It is often important to shuffle examples while performing the batch
-    operation. `perm(idx, size)` is a closure which returns the shuffled index
+    operation. `perm(idx, size)` is a function which returns the shuffled index
     of the sample at position `idx` in the underlying dataset. For convenience,
-    the `size` of the underlying dataset is also passed to the closure. By
-    default, the closure is the identity.
+    the `size` of the underlying dataset is also passed to the function. By
+    default, the function is the identity.
+
     The underlying dataset size might or might not be always divisible by
     `batchsize`.  The optional `policy` string specify how to handle corner
-    cases:
-      - `include-last` makes sure all samples of the underlying dataset will be
-        seen, batches will be of size equal or inferior to `batchsize`.
-      - `skip-last` will skip last examples of the underlying dataset if it's
-        size is not properly divisible. Batches will be always of size equal to
-        `batchsize`.
-      - `divisible-only` will raise an error if the underlying dataset has not
-        a size divisible by `batchsize`.
+    cases.
+
     Purpose: the concept of batch is problem dependent. In *torchnet*, it is up
     to the user to interpret a sample as a batch or not. When one wants to
     assemble samples from an existing dataset into a batch, then
-    `tnt.BatchDataset` is suited for the job. Sometimes it is however more
+    `BatchDataset` is suited for the job. Sometimes it is however more
     convenient to write a dataset from scratch providing "batched" samples.
+
+    Args:
+        dataset (Dataset): Dataset to be batched.
+        batchsize (int): Size of the batch.
+        perm (function, optional): Function used to shuffle the dataset before
+            batching. `perm(idx, size)` should return the shuffled index of
+            `idx`th sample. By default, the function is the identity.
+            merge (function, optional): Function to control batching behaviour.
+             `transform.makebatch(merge)` is used to make the batch. Default is
+             None.
+        policy (str, optional): Policy to handle the corner cases when the
+            underlying dataset size is not divisible by `batchsize`. One of
+            (`include-last`, `skip-last`, `divisible-only`).
+
+            - `include-last` makes sure all samples of the underlying dataset
+               will be seen, batches will be of size equal or inferior to
+               `batchsize`.
+            - `skip-last` will skip last examples of the underlying dataset if
+               its size is not properly divisible. Batches will be always of
+               size equal to `batchsize`.
+            - `divisible-only` will raise an error if the underlying dataset
+               has not a size divisible by `batchsize`.
+        filter (function, optional): Function to filter the sample before
+            batching. If `filter(sample)` is True, then sample is included for
+            batching. Otherwise, it is excluded. By default, `filter(sample)`
+            returns True for any `sample`.
+
     """
+
     def __init__(self,
                  dataset,
                  batchsize,
@@ -71,7 +81,7 @@ class BatchDataset(Dataset):
             return int(math.floor(float(len(self.dataset) / self.batchsize)))
         elif self.policy == 'divisible-only':
             assert len(self.dataset) % self.batchsize == 0, \
-                    'dataset size is not divisible by batch size'
+                'dataset size is not divisible by batch size'
             return len(self.dataset) / self.batchsize
         else:
             assert False, 'invalid policy (include-last | skip-last | \
@@ -79,15 +89,19 @@ class BatchDataset(Dataset):
 
     def __getitem__(self, idx):
         super(BatchDataset, self).__getitem__(idx)
-        samples = []
         maxidx = len(self.dataset)
+
+        samples = []
         for i in range(0, self.batchsize):
             j = idx * self.batchsize + i
             if j >= maxidx:
                 break
+
             j = self.perm(j, maxidx)
             sample = self.dataset[j]
+
             if self.filter(sample):
                 samples.append(sample)
+
         samples = self.makebatch(samples)
         return samples

--- a/torchnet/dataset/listdataset.py
+++ b/torchnet/dataset/listdataset.py
@@ -32,10 +32,10 @@ class ListDataset(Dataset):
         super(ListDataset, self).__init__()
         if isinstance(elem_list, str):
             with open(elem_list) as f:
-                self.list = [line.replace('\n','') for line in f]
+                self.list = [line.replace('\n', '') for line in f]
         elif torch.is_tensor(elem_list):
             assert isinstance(elem_list, torch.LongTensor), \
-                    "Only torch.LongTensor supported as list"
+                "Only torch.LongTensor supported as list"
             assert elem_list.dim() == 1
             self.list = elem_list
         else:

--- a/torchnet/dataset/listdataset.py
+++ b/torchnet/dataset/listdataset.py
@@ -28,8 +28,10 @@ class ListDataset(Dataset):
             `elem_list[i]` will prefixed by this string when fed to `load()`.
 
     """
+
     def __init__(self, elem_list, load, path=None):
         super(ListDataset, self).__init__()
+
         if isinstance(elem_list, str):
             with open(elem_list) as f:
                 self.list = [line.replace('\n', '') for line in f]
@@ -41,7 +43,8 @@ class ListDataset(Dataset):
         else:
             # just assume iterable
             self.list = elem_list
-        self.path = path 
+
+        self.path = path
         self.load = load
 
     def __len__(self):
@@ -49,6 +52,7 @@ class ListDataset(Dataset):
 
     def __getitem__(self, idx):
         super(ListDataset, self).__getitem__(idx)
+
         if self.path is not None:
             return self.load("%s/%s" % (self.path, self.list[idx]))
         else:

--- a/torchnet/dataset/listdataset.py
+++ b/torchnet/dataset/listdataset.py
@@ -4,15 +4,29 @@ import torch
 
 class ListDataset(Dataset):
     """
-    Considering a `list` (can be a `string`, `torch.LongTensor`, or any other
-    iterable) i-th sample of a dataset will be returned by `load(list[i])`,
-    where `load()` is a closure provided by the user.
+    Dataset which loads data from a list using given function.
 
-    If `path` is provided, list is assumed to be a list of string, and will
-    each element `list[i]` will prefixed by `path/` when fed to `load()`.
+    Considering a `elem_list` (can be a `string`, `torch.LongTensor`, or any other
+    iterable) i-th sample of a dataset will be returned by `load(elem_list[i])`,
+    where `load()` is a function provided by the user.
+
+    If `path` is provided, `elem_list` is assumed to be a list of strings, and
+    each element `elem_list[i]` will prefixed by `path/` when fed to `load()`.
+
     Purpose: many low or medium-scale datasets can be seen as a list of files
     (for example representing input samples). For this list of file, a target
     can be often inferred in a simple manner.
+
+    Args:
+        elem_list (iterable/str): List of arguments which will be passed to
+            `load` function. It can also be a path to file with each line
+            containing the arguments to `load`
+        load (function): Function which loads the data. i-th sample is returned
+            by `load(elem_list[i])`.
+        path (str, optional): Defaults to None. If a string is provided,
+            `elem_list` is assumed to be a list of strings, and each element
+            `elem_list[i]` will prefixed by this string when fed to `load()`.
+
     """
     def __init__(self, elem_list, load, path=None):
         super(ListDataset, self).__init__()

--- a/torchnet/dataset/resampledataset.py
+++ b/torchnet/dataset/resampledataset.py
@@ -7,31 +7,28 @@ class ResampleDataset(Dataset):
 
     Given a `dataset`, creates a new dataset which will (re-)sample from this
     underlying dataset using the provided `sampler(dataset, idx)` function.
+
     If `size` is provided, then the newly created dataset will have the
     specified `size`, which might be different than the underlying dataset
-    size.
-
-    If `size` is not provided, then the new dataset will have the same size
-    as the underlying one.
-
-    `dataset` corresponds to the underlying dataset provided at construction, and
-    `idx` may take a value between 1 to `size`. It must return an index in the range
-    acceptable for the underlying dataset.
+    size. If `size` is not provided, then the new dataset will have the same
+    size as the underlying one.
 
     Purpose: shuffling data, re-weighting samples, getting a subset of the
-    data. Note that an important sub-class is ([tnt.ShuffleDataset](#ShuffleDataset)),
-    provided for convenience.
+    data. Note that an important sub-class `ShuffleDataset` is provided for
+    convenience.
 
     Args:
         dataset (Dataset): Dataset to be resampled.
         sampler (function, optional): Function used for sampling. `idx`th
-            sample is returned by `sampler(dataset, i)`. By default
+            sample is returned by `dataset[sampler(dataset, idx)]`. By default
             `sampler(dataset, idx)` is the identity, simply returning `idx`.
+            `sampler(dataset, idx)` must return an index in the range
+            acceptable for the underlying `dataset`.
         size (int, optional): Desired size of the dataset after resampling. By
             default, the new dataset will have the same size as the underlying
             one.
     """
-    def __init__(self, dataset, sampler=lambda ds,idx: idx, size=None):
+    def __init__(self, dataset, sampler=lambda ds, idx: idx, size=None):
         super(ResampleDataset, self).__init__()
         self.dataset = dataset
         self.sampler = sampler

--- a/torchnet/dataset/resampledataset.py
+++ b/torchnet/dataset/resampledataset.py
@@ -3,16 +3,17 @@ from .dataset import Dataset
 
 class ResampleDataset(Dataset):
     """
+    Dataset which resamples a given dataset.
+
     Given a `dataset`, creates a new dataset which will (re-)sample from this
-    underlying dataset using the provided `sampler(dataset, idx)` closure.
+    underlying dataset using the provided `sampler(dataset, idx)` function.
     If `size` is provided, then the newly created dataset will have the
     specified `size`, which might be different than the underlying dataset
     size.
 
     If `size` is not provided, then the new dataset will have the same size
-    than the underlying one.
+    as the underlying one.
 
-    By default `sampler(dataset, idx)` is the identity, simply `return`ing `idx`.
     `dataset` corresponds to the underlying dataset provided at construction, and
     `idx` may take a value between 1 to `size`. It must return an index in the range
     acceptable for the underlying dataset.
@@ -20,6 +21,15 @@ class ResampleDataset(Dataset):
     Purpose: shuffling data, re-weighting samples, getting a subset of the
     data. Note that an important sub-class is ([tnt.ShuffleDataset](#ShuffleDataset)),
     provided for convenience.
+
+    Args:
+        dataset (Dataset): Dataset to be resampled.
+        sampler (function, optional): Function used for sampling. `idx`th
+            sample is returned by `sampler(dataset, i)`. By default
+            `sampler(dataset, idx)` is the identity, simply returning `idx`.
+        size (int, optional): Desired size of the dataset after resampling. By
+            default, the new dataset will have the same size as the underlying
+            one.
     """
     def __init__(self, dataset, sampler=lambda ds,idx: idx, size=None):
         super(ResampleDataset, self).__init__()

--- a/torchnet/dataset/resampledataset.py
+++ b/torchnet/dataset/resampledataset.py
@@ -28,6 +28,7 @@ class ResampleDataset(Dataset):
             default, the new dataset will have the same size as the underlying
             one.
     """
+
     def __init__(self, dataset, sampler=lambda ds, idx: idx, size=None):
         super(ResampleDataset, self).__init__()
         self.dataset = dataset
@@ -40,6 +41,8 @@ class ResampleDataset(Dataset):
     def __getitem__(self, idx):
         super(ResampleDataset, self).__getitem__(idx)
         idx = self.sampler(self.dataset, idx)
+
         if idx < 0 or idx >= len(self.dataset):
             raise IndexError('out of range')
+
         return self.dataset[idx]

--- a/torchnet/dataset/shuffledataset.py
+++ b/torchnet/dataset/shuffledataset.py
@@ -4,16 +4,30 @@ import torch
 
 class ShuffleDataset(ResampleDataset):
     """
-    `tnt.ShuffleDataset` is a sub-class of
-    [tnt.ResampleDataset](#ResampleDataset) provided for convenience.
-    It samples uniformly from the given `dataset` with, or without
-    `replacement`. The chosen partition can be redrawn by calling
-    [resample()](#ShuffleDataset.resample).
+    Dataset which shuffles a given dataset.
+
+    `ShuffleDataset` is a sub-class of `ResampleDataset` provided for
+    convenience. It samples uniformly from the given `dataset` with, or without
+    `replacement`. The chosen partition can be redrawn by calling `resample()`
+
     If `replacement` is `true`, then the specified `size` may be larger than
     the underlying `dataset`.
     If `size` is not provided, then the new dataset size will be equal to the
     underlying `dataset` size.
+
     Purpose: the easiest way to shuffle a dataset!
+
+    Args:
+        dataset (Dataset): Dataset to be shuffled.
+        size (int, optional): Desired size of the shuffled dataset. If
+            `replacement` is `true`, then can be larger than the `len(dataset)`.
+            By default, the new dataset will have the same size as `dataset`.
+        replacement (bool, optional): True if uniform sampling is to be done
+            with replacement. False otherwise. Defaults to false.
+
+    Raises:
+        ValueError: If `size` is larger than the size of the underlying dataset
+            and `replacement` is False.
     """
     def __init__(self, dataset, size=None, replacement=False):
         if size and not replacement and size > len(dataset):

--- a/torchnet/dataset/shuffledataset.py
+++ b/torchnet/dataset/shuffledataset.py
@@ -29,18 +29,21 @@ class ShuffleDataset(ResampleDataset):
         ValueError: If `size` is larger than the size of the underlying dataset
             and `replacement` is False.
     """
+
     def __init__(self, dataset, size=None, replacement=False):
         if size and not replacement and size > len(dataset):
             raise ValueError('size cannot be larger than underlying dataset \
                     size when sampling without replacement')
+
         super(ShuffleDataset, self).__init__(dataset,
-                lambda dataset, idx: self.perm[idx], size)
+                                             lambda dataset, idx: self.perm[idx],
+                                             size)
         self.replacement = replacement
         self.resample()
-    
+
     def resample(self):
         if self.replacement:
             self.perm = torch.LongTensor(len(self)).random_(len(self.dataset))
         else:
-            self.perm = torch.randperm(len(self.dataset)).narrow(0, 0, len(self))
-
+            self.perm = torch.randperm(
+                len(self.dataset)).narrow(0, 0, len(self))

--- a/torchnet/dataset/tensordataset.py
+++ b/torchnet/dataset/tensordataset.py
@@ -24,19 +24,22 @@ class TensorDataset(Dataset):
     Args:
         data (dict/list/tensor/ndarray): Data for the dataset.
     """
+
     def __init__(self, data):
         super(TensorDataset, self).__init__()
+
         if isinstance(data, dict):
             assert len(data) > 0, "Should have at least one element"
             # check that all fields have the same size
             n_elem = len(list(data.values())[0])
             for v in data.values():
-                assert len(v) == n_elem
+                assert len(v) == n_elem, "All values must have the same size"
         elif isinstance(data, list):
             assert len(data) > 0, "Should have at least one element"
             n_elem = len(data[0])
             for v in data:
-                assert len(v) == n_elem
+                assert len(v) == n_elem, "All elements must have the same size"
+
         self.data = data
 
     def __len__(self):

--- a/torchnet/dataset/tensordataset.py
+++ b/torchnet/dataset/tensordataset.py
@@ -50,7 +50,7 @@ class TensorDataset(Dataset):
     def __getitem__(self, idx):
         super(TensorDataset, self).__getitem__(idx)
         if isinstance(self.data, dict):
-            return {k: v[idx] for k,v in self.data.items()}
+            return {k: v[idx] for k, v in self.data.items()}
         elif isinstance(self.data, list):
             return [v[idx] for v in self.data]
         elif torch.is_tensor(self.data) or isinstance(self.data, np.ndarray):

--- a/torchnet/dataset/tensordataset.py
+++ b/torchnet/dataset/tensordataset.py
@@ -5,10 +5,24 @@ import numpy as np
 
 class TensorDataset(Dataset):
     """
-    Accept:
-     * dict of tensors or numpy arrays
-     * list of tensors or numpy arrays
-     * tensor or numpy array
+    Dataset from a tensor or array or list or dict.
+
+    `TensorDataset` provides a way to create a dataset out of the data that is
+    already loaded into memory. It accepts data in the following forms:
+
+    tensor or numpy array
+        `idx`th sample is `data[idx]`
+
+    dict of tensors or numpy arrays
+        `idx`th sample is `{k: v[idx] for k, v in data.items()}`
+
+    list of tensors or numpy arrays
+        `idx`th sample is `[v[idx] for v in data]`
+
+    Purpose: Easy way to create a dataset out of standard data structures.
+
+    Args:
+        data (dict/list/tensor/ndarray): Data for the dataset.
     """
     def __init__(self, data):
         super(TensorDataset, self).__init__()

--- a/torchnet/dataset/transformdataset.py
+++ b/torchnet/dataset/transformdataset.py
@@ -25,13 +25,16 @@ class TransformDataset(Dataset):
         transforms (function/dict): Function or dict with function as values.
             These functions will be applied to data.
     """
+
     def __init__(self, dataset, transforms):
         super(TransformDataset, self).__init__()
+
         assert isinstance(transforms, dict) or callable(transforms), \
             'expected a dict of transforms or a function'
         if isinstance(transforms, dict):
             for k, v in transforms.items():
                 assert callable(v), str(k) + ' is not a function'
+
         self.dataset = dataset
         self.transforms = transforms
 
@@ -41,9 +44,11 @@ class TransformDataset(Dataset):
     def __getitem__(self, idx):
         super(TransformDataset, self).__getitem__(idx)
         z = self.dataset[idx]
+
         if isinstance(self.transforms, dict):
             for k, transform in self.transforms.items():
                 z[k] = transform(z[k])
         else:
             z = self.transforms(z)
+
         return z

--- a/torchnet/dataset/transformdataset.py
+++ b/torchnet/dataset/transformdataset.py
@@ -11,7 +11,7 @@ class TransformDataset(Dataset):
 
     `transform` can also be a dict with functions as values. In this case, it
     is assumed that `dataset[idx]` is a dict which has all the keys in
-    `transform`. Then, `transform[key]` is applied to dataset[idx][key] for 
+    `transform`. Then, `transform[key]` is applied to dataset[idx][key] for
     each key in `transform`
 
     The size of the new dataset is equal to the size of the underlying

--- a/torchnet/dataset/transformdataset.py
+++ b/torchnet/dataset/transformdataset.py
@@ -3,19 +3,27 @@ from .dataset import Dataset
 
 class TransformDataset(Dataset):
     """
-    Given a closure `transform()`, and a `dataset`, `tnt.TransformDataset`
-    applies the closure in an on-the-fly manner when querying a sample with
-    `tnt.Dataset.__getitem__()`.
+    Dataset which transforms a given dataset with a given function.
 
-    If key is provided, the closure is applied to the sample field specified
-    by `key` (only). The closure must return the new corresponding field value.
-    If key is not provided, the closure is applied on the full sample. The
-    closure must return the new sample table.
+    Given a function `transform`, and a `dataset`, `TransformDataset` applies
+    the function in an on-the-fly manner when querying a sample with
+    `__getitem__(idx)` and therefore returning `transform[dataset[idx]]`.
+
+    `transform` can also be a dict with functions as values. In this case, it
+    is assumed that `dataset[idx]` is a dict which has all the keys in
+    `transform`. Then, `transform[key]` is applied to dataset[idx][key] for 
+    each key in `transform`
 
     The size of the new dataset is equal to the size of the underlying
     `dataset`.
+
     Purpose: when performing pre-processing operations, it is convenient to be
     able to perform on-the-fly transformations to a dataset.
+
+    Args:
+        dataset (Dataset): Dataset which has to be transformed.
+        transforms (function/dict): Function or dict with function as values.
+            These functions will be applied to data.
     """
     def __init__(self, dataset, transforms):
         super(TransformDataset, self).__init__()


### PR DESCRIPTION
Hi,

I've edited/written Google style docstrings for each of the classes in torch.datasets. I didn't write doctoring for `Dataset` owing to #13. 

I've also made a few cosmetic changes to make code more readable/pep8 complaint.

Sasank.