### PR TITLE
Add more datasets

### DIFF
--- a/test/test_datasets.py
+++ b/test/test_datasets.py
@@ -103,6 +103,20 @@ class TestDatasets(unittest.TestCase):
         self.assertEqual(len(splitdataset), 1)
         self.assertEqual(splitdataset[0], 3)
 
+    def testSplitDataset_fractions(self):
+        h = [0, 1, 2, 3]
+        listdataset = dataset.ListDataset(elem_list=h)
+        splitdataset = dataset.SplitDataset(listdataset, {'train': 0.75,
+                                                          'val': 0.25})
+
+        splitdataset.select('train')
+        self.assertEqual(len(splitdataset), 3)
+        self.assertEqual(splitdataset[2], 2)
+
+        splitdataset.select('val')
+        self.assertEqual(len(splitdataset), 1)
+        self.assertEqual(splitdataset[0], 3)
+
     def testConcatDataset(self):
         l1 = dataset.ListDataset(elem_list=[0, 1, 2, 3])
         l2 = dataset.ListDataset(elem_list=[10, 11, 13])

--- a/test/test_datasets.py
+++ b/test/test_datasets.py
@@ -90,5 +90,31 @@ class TestDatasets(unittest.TestCase):
         self.assertEqual(len(d), 5)
         # TODO: every item should appear exactly once
 
+    def testSplitDataset(self):
+        h = [0, 1, 2, 3]
+        listdataset = dataset.ListDataset(elem_list=h)
+        splitdataset = dataset.SplitDataset(listdataset, {'train': 3, 'val': 1})
+
+        splitdataset.select('train')
+        self.assertEqual(len(splitdataset), 3)
+        self.assertEqual(splitdataset[2], 2)
+
+        splitdataset.select('val')
+        self.assertEqual(len(splitdataset), 1)
+        self.assertEqual(splitdataset[0], 3)
+
+    def testConcatDataset(self):
+        l1 = dataset.ListDataset(elem_list=[0, 1, 2, 3])
+        l2 = dataset.ListDataset(elem_list=[10, 11, 13])
+        concatdataset = dataset.ConcatDataset([l1, l2])
+
+        self.assertEqual(len(concatdataset), 7)
+        self.assertEqual(concatdataset[0], 0)
+        self.assertEqual(concatdataset[3], 3)
+        self.assertEqual(concatdataset[4], 10)
+        self.assertEqual(concatdataset[6], 13)
+
+
+
 if __name__ == '__main__':
     unittest.main()

--- a/torchnet/dataset/__init__.py
+++ b/torchnet/dataset/__init__.py
@@ -5,3 +5,4 @@ from .transformdataset import TransformDataset
 from .resampledataset import ResampleDataset
 from .shuffledataset import ShuffleDataset
 from .concatdataset import ConcatDataset
+from .splitdataset import SplitDataset

--- a/torchnet/dataset/__init__.py
+++ b/torchnet/dataset/__init__.py
@@ -4,3 +4,4 @@ from .tensordataset import TensorDataset
 from .transformdataset import TransformDataset
 from .resampledataset import ResampleDataset
 from .shuffledataset import ShuffleDataset
+from .concatdataset import ConcatDataset

--- a/torchnet/dataset/concatdataset.py
+++ b/torchnet/dataset/concatdataset.py
@@ -1,0 +1,36 @@
+from .dataset import Dataset
+import numpy as np
+
+
+class ConcatDataset(Dataset):
+    """
+    Dataset to concatenate multiple datasets.
+
+    Purpose: useful to assemble different existing datasets, possibly
+    large-scale datasets as the concatenation operation is done in an
+    on-the-fly manner.
+
+    Args:
+        datasets (iterable): List of datasets to be concatenated
+    """
+
+    def __init__(self, datasets):
+        super(ConcatDataset, self).__init__()
+
+        self.datasets = list(datasets)
+        assert len(datasets) > 0, 'datasets should not be an empty iterable'
+        self.cum_sizes = np.cumsum([len(x) for x in self.datasets])
+
+    def __len__(self):
+        return self.cum_sizes[-1]
+
+    def __getitem__(self, idx):
+        super(ConcatDataset, self).__getitem__(idx)
+        dataset_index = self.cum_sizes.searchsorted(idx, 'right')
+
+        if dataset_index == 0:
+            dataset_idx = idx
+        else:
+            dataset_idx = idx - self.cum_sizes[dataset_index - 1]
+
+        return self.datasets[dataset_index][dataset_idx]

--- a/torchnet/dataset/listdataset.py
+++ b/torchnet/dataset/listdataset.py
@@ -36,11 +36,6 @@ class ListDataset(Dataset):
         if isinstance(elem_list, str):
             with open(elem_list) as f:
                 self.list = [line.replace('\n', '') for line in f]
-        elif torch.is_tensor(elem_list):
-            assert isinstance(elem_list, torch.LongTensor), \
-                "Only torch.LongTensor supported as list"
-            assert elem_list.dim() == 1
-            self.list = elem_list
         else:
             # just assume iterable
             self.list = elem_list

--- a/torchnet/dataset/listdataset.py
+++ b/torchnet/dataset/listdataset.py
@@ -6,9 +6,9 @@ class ListDataset(Dataset):
     """
     Dataset which loads data from a list using given function.
 
-    Considering a `elem_list` (can be a `string`, `torch.LongTensor`, or any
-    other iterable) i-th sample of a dataset will be returned by
-    `load(elem_list[i])`, where `load()` is a function provided by the user.
+    Considering a `elem_list` (can be an iterable or a `string` ) i-th sample
+    of a dataset will be returned by `load(elem_list[i])`, where `load()`
+    is a function provided by the user.
 
     If `path` is provided, `elem_list` is assumed to be a list of strings, and
     each element `elem_list[i]` will prefixed by `path/` when fed to `load()`.

--- a/torchnet/dataset/listdataset.py
+++ b/torchnet/dataset/listdataset.py
@@ -6,9 +6,9 @@ class ListDataset(Dataset):
     """
     Dataset which loads data from a list using given function.
 
-    Considering a `elem_list` (can be a `string`, `torch.LongTensor`, or any other
-    iterable) i-th sample of a dataset will be returned by `load(elem_list[i])`,
-    where `load()` is a function provided by the user.
+    Considering a `elem_list` (can be a `string`, `torch.LongTensor`, or any
+    other iterable) i-th sample of a dataset will be returned by
+    `load(elem_list[i])`, where `load()` is a function provided by the user.
 
     If `path` is provided, `elem_list` is assumed to be a list of strings, and
     each element `elem_list[i]` will prefixed by `path/` when fed to `load()`.
@@ -21,15 +21,16 @@ class ListDataset(Dataset):
         elem_list (iterable/str): List of arguments which will be passed to
             `load` function. It can also be a path to file with each line
             containing the arguments to `load`
-        load (function): Function which loads the data. i-th sample is returned
-            by `load(elem_list[i])`.
+        load (function, optional): Function which loads the data.
+            i-th sample is returned by `load(elem_list[i])`. By default `load`
+            is identity i.e, `lambda x: x`
         path (str, optional): Defaults to None. If a string is provided,
             `elem_list` is assumed to be a list of strings, and each element
             `elem_list[i]` will prefixed by this string when fed to `load()`.
 
     """
 
-    def __init__(self, elem_list, load, path=None):
+    def __init__(self, elem_list, load=lambda x: x, path=None):
         super(ListDataset, self).__init__()
 
         if isinstance(elem_list, str):

--- a/torchnet/dataset/shuffledataset.py
+++ b/torchnet/dataset/shuffledataset.py
@@ -41,9 +41,21 @@ class ShuffleDataset(ResampleDataset):
         self.replacement = replacement
         self.resample()
 
-    def resample(self):
+    def resample(self, seed=None):
+        """Resample the dataset.
+
+        Args:
+            seed (int, optional): Seed for resampling. By default no seed is
+            used.
+        """
+        if seed is not None:
+            gen = torch.manual_seed(seed)
+        else:
+            gen = torch.default_generator
+
         if self.replacement:
-            self.perm = torch.LongTensor(len(self)).random_(len(self.dataset))
+            self.perm = torch.LongTensor(len(self)).random_(gen,
+                                                            len(self.dataset))
         else:
             self.perm = torch.randperm(
-                len(self.dataset)).narrow(0, 0, len(self))
+                gen, len(self.dataset)).narrow(0, 0, len(self))

--- a/torchnet/dataset/splitdataset.py
+++ b/torchnet/dataset/splitdataset.py
@@ -1,0 +1,83 @@
+from .dataset import Dataset
+import numpy as np
+
+class SplitDataset(Dataset):
+    """
+    Dataset to partition a given dataset.
+
+    Partition a given `dataset`, according to the specified `partitions`. Use
+    the method `select()` to select the current partition in use.
+
+    The `partitions` is a dictionary where a key is a user-chosen string
+    naming the partition, and value is a number representing the weight (as a
+    number between 0 and 1) or the size (in number of samples) of the
+    corresponding partition.
+
+    Partioning is achieved linearly (no shuffling). See `ShuffleDataset` if you
+    want to shuffle the dataset before partitioning.
+
+    Args:
+        dataset (Dataset): Dataset to be split.
+        partitions (dict): Dictionary where key is a user-chosen string
+            naming the partition, and value is a number representing the weight
+            (as a number between 0 and 1) or the size (in number of samples)
+            of the corresponding partition.
+        initial_partition (str, optional): Initial parition to be selected.
+
+    """
+
+    def __init__(self, dataset, partitions, initial_partition=None):
+        super(SplitDataset, self).__init__()
+
+        self.dataset = dataset
+        self.partitions = partitions
+
+        # A few assertions
+        assert isinstance(partitions, dict), 'partitions must be a dict'
+        assert len(partitions) >= 2, \
+            'SplitDataset should have at least two partitions'
+        assert min(partitions.values()) >= 0, \
+            'partition sizes cannot be negative'
+        assert max(partitions.values()) > 0, 'all partitions cannot be empty'
+
+        self.partition_names = list(self.partitions.keys())
+        self.partition_sizes = [self.partitions[parition] for parition in
+                                self.partition_names]
+        self.partition_cum_sizes = np.cumsum(self.partition_sizes)
+        self.partition_index = {partition: i for i, partition in
+                                enumerate(self.partition_names)}
+
+        # if partition sizes are fractions, convert to sizes:
+        if sum(self.partition_sizes) <= 1:
+            self.partition_sizes = [round(x * len(dataset)) for x in
+                                    self.partition_sizes]
+        else:
+            for x in self.partition_sizes:
+                assert x == int(x), ('partition sizes should be integer'
+                                     ' numbers, or sum up to <= 1 ')
+
+        if initial_partition is not None:
+            self.select(initial_partition)
+
+    def select(self, partition):
+        """
+        Select the parition.
+
+        Args:
+            partition (str): Partition to be selected.
+        """
+        self.current_partition_idx = self.partition_index[partition]
+
+    def __len__(self):
+        try:
+            return self.partition_sizes[self.current_partition_idx]
+        except AttributeError:
+            raise ValueError("Select a partition before accessing data.")
+
+    def __getitem__(self, idx):
+        super(SplitDataset, self).__getitem__(idx)
+        try:
+            offset = self.partition_cum_sizes[self.current_partition_idx]
+            return self.dataset[int(offset) + idx]
+        except AttributeError:
+            raise ValueError("Select a partition before accessing data.")

--- a/torchnet/dataset/splitdataset.py
+++ b/torchnet/dataset/splitdataset.py
@@ -41,12 +41,11 @@ class SplitDataset(Dataset):
         assert max(partitions.values()) > 0, 'all partitions cannot be empty'
 
         self.partition_names = list(self.partitions.keys())
-        self.partition_sizes = [self.partitions[parition] for parition in
-                                self.partition_names]
-        self.partition_cum_sizes = np.cumsum(self.partition_sizes)
         self.partition_index = {partition: i for i, partition in
                                 enumerate(self.partition_names)}
 
+        self.partition_sizes = [self.partitions[parition] for parition in
+                                self.partition_names]
         # if partition sizes are fractions, convert to sizes:
         if sum(self.partition_sizes) <= 1:
             self.partition_sizes = [round(x * len(dataset)) for x in
@@ -55,6 +54,8 @@ class SplitDataset(Dataset):
             for x in self.partition_sizes:
                 assert x == int(x), ('partition sizes should be integer'
                                      ' numbers, or sum up to <= 1 ')
+
+        self.partition_cum_sizes = np.cumsum(self.partition_sizes)
 
         if initial_partition is not None:
             self.select(initial_partition)

--- a/torchnet/dataset/splitdataset.py
+++ b/torchnet/dataset/splitdataset.py
@@ -77,7 +77,10 @@ class SplitDataset(Dataset):
     def __getitem__(self, idx):
         super(SplitDataset, self).__getitem__(idx)
         try:
-            offset = self.partition_cum_sizes[self.current_partition_idx]
-            return self.dataset[int(offset) + idx]
+            if self.current_partition_idx == 0:
+                return self.dataset[idx]
+            else:
+                offset = self.partition_cum_sizes[self.current_partition_idx - 1]
+                return self.dataset[int(offset) + idx]
         except AttributeError:
             raise ValueError("Select a partition before accessing data.")


### PR DESCRIPTION
Added:
* SplitDataset
* ConcatDataset

Made `load` an optional parameter in `ListDataset` so that it can be used as `TableDataset`.

Added `seed` to resample in `ShuffleDataset`

I don't understand why `elem_list` has to `torch.LongTensor` if tensor in `ListDataset` (see [here](https://github.com/pytorch/tnt/pull/15/commits/8fafb5520d624fe182267fc82f600c5cca44cfdc#diff-d4468c8c095acb0bd76eff37ee0159c0R39)). It seems pointless.

Sasank.