### PR TITLE
Update to work with pytorch 0.1.11

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,8 +4,8 @@ python:
     - 2.7
 
 install:
-    - wget -q https://s3.amazonaws.com/pytorch/whl/cu75/torch-0.1.7.post2-cp27-none-linux_x86_64.whl
-    - travis_retry pip install torch-0.1.7.post2-cp27-none-linux_x86_64.whl
+    - wget -q http://download.pytorch.org/whl/cu75/torch-0.1.11.post5-cp27-none-linux_x86_64.whl
+    - travis_retry pip install torch-0.1.11.post5-cp27-none-linux_x86_64.whl
     - travis_retry pip install -r requirements.txt
     - travis_retry pip install --upgrade numpy
     - travis_retry pip install .

--- a/test/test_datasets.py
+++ b/test/test_datasets.py
@@ -103,6 +103,12 @@ class TestDatasets(unittest.TestCase):
         self.assertEqual(len(splitdataset), 1)
         self.assertEqual(splitdataset[0], 3)
 
+        # test fluent api
+        splitdataset = listdataset.split({'train': 3, 'val': 1})
+        splitdataset.select('train')
+        self.assertEqual(len(splitdataset), 3)
+        self.assertEqual(splitdataset[2], 2)
+
     def testSplitDataset_fractions(self):
         h = [0, 1, 2, 3]
         listdataset = dataset.ListDataset(elem_list=h)

--- a/torchnet/dataset/dataset.py
+++ b/torchnet/dataset/dataset.py
@@ -25,3 +25,6 @@ class Dataset(object):
 
     def parallel(self, *args, **kwargs):
         return DataLoader(self, *args, **kwargs)
+
+    def split(self, *args, **kwargs):
+        return torchnet.dataset.SplitDataset(self, *args, **kwargs)

--- a/torchnet/dataset/shuffledataset.py
+++ b/torchnet/dataset/shuffledataset.py
@@ -54,8 +54,6 @@ class ShuffleDataset(ResampleDataset):
             gen = torch.default_generator
 
         if self.replacement:
-            self.perm = torch.LongTensor(len(self)).random_(gen,
-                                                            len(self.dataset))
+            self.perm = torch.LongTensor(len(self)).random_(len(self.dataset), generator=gen)
         else:
-            self.perm = torch.randperm(
-                gen, len(self.dataset)).narrow(0, 0, len(self))
+            self.perm = torch.randperm(len(self.dataset), generator=gen).narrow(0, 0, len(self))


### PR DESCRIPTION
* bump travis to test with 0.1.11
* add `.split()` method to dataset
* fix `generator` argument in `randperm`