### PR TITLE
Add step interval and hook

### DIFF
--- a/torchnet/engine/engine.py
+++ b/torchnet/engine/engine.py
@@ -43,7 +43,8 @@ class Engine(object):
                     self.hook('on_step', state)
                 else:
                     closure()
-                    if (state['t'] + 1) % step_interval == 0:
+                    if (state['t'] + 1) % step_interval == 0 \
+                            or state['t'] == state['maxepoch'] - 1:
                         state['optimizer'].step()
                         state['optimizer'].zero_grad()
                         self.hook('on_step', state)


### PR DESCRIPTION
1. Allow a `n`-sample interval between optimization steps.  It is useful when it's too hard to process the batch in parallel.

2. add hook `on_step` when taking an optimization step.