### PR TITLE
Fix bug in MovingAverageValueMeter

### DIFF
--- a/torchnet/meter/movingaveragevaluemeter.py
+++ b/torchnet/meter/movingaveragevaluemeter.py
@@ -27,6 +27,6 @@ class MovingAverageValueMeter(meter.Meter):
     def value(self):
         n = min(self.n, self.windowsize)
         mean = self.sum / max(1, n)
-        std = math.sqrt((self.var - n * mean * mean) / max(1, n-1))
+        std = math.sqrt(max((self.var - n * mean * mean) / max(1, n-1), 0))
         return mean, std
 


### PR DESCRIPTION
Fix numerical problem in MovingAverageValueMeter.

The bug can be reproduced by the following:
```
from torchnet import meter
m = meter.MovingAverageValueMeter(10)
m.reset()
for _ in range(100):
    m.add(1e-20)
    m.value()
```

and it would give
```
Traceback (most recent call last):
  File "a.py", line 6, in <module>
    m.value()
  File "/home/joe/anaconda2/lib/python2.7/site-packages/torchnet/meter/movingaveragevaluemeter.py", line 30, in value
    std = math.sqrt((self.var - n * mean * mean) / max(1, n-1))
ValueError: math domain error
```