### PR TITLE
Updates confusionmeter.py for case with addition of batch of size 1

### DIFF
--- a/torchnet/meter/confusionmeter.py
+++ b/torchnet/meter/confusionmeter.py
@@ -37,8 +37,12 @@ class ConfusionMeter(meter.Meter):
                 assumed to be provided as one-hot vectors
 
         """
-        predicted = predicted.cpu().squeeze().numpy()
-        target = target.cpu().squeeze().numpy()
+	try:
+            predicted = predicted.cpu().squeeze().numpy()
+            target = target.cpu().squeeze().numpy()
+	except:
+	    predicted = predicted.cpu().numpy()
+	    target = target.cpu().numpy
 
         assert predicted.shape[0] == target.shape[0], \
             'number of targets and predicted outputs do not match'


### PR DESCRIPTION
Updates confusionmeter.py to take care of the situation where a batch of size 1 is added to a confusionmeter object. 

Whenever a mini-batch of size 1 is added to the confusion meter object by calling the `add` method on the confusion meter object, an Assertion Error is raised. 

'number of targets and predicted outputs do not match'

When the batch is added to confusion meter, the following lines of  code are executed in the `add` function

```
predicted = predicted.cpu().squeeze().numpy()
target = target.cpu().squeeze().numpy()

assert predicted.shape[0] == target.shape[0], \
'number of targets and predicted outputs do not match'
```
This works fine when the batch size when, when `predicted` is Tensor of shape (N,K) where N is the batch size and K is the number of classes.  Target is a Tensor of shape (N,), and then after the above code is run, the subsequent arrays are of shapes (N,K) and (N,) respectively, so the above assertion evaluates to true. 

However, when N is equal to 1, the array resulting from `predicted` is a (K,) sized one, and it unnecessarily raises an assertion error. The fix is not to call squeeze() function on batches containing a tensor of shape (1,K). 