### PR TITLE
 use torch.arange instead of torch.range which was removed in version 0.3; provide current value in averagevaluemeter.py

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,8 @@ What's been ported so far:
    * TensorDataset [new]
    * TransformDataset
  * Meters:
+   * APMeter
+   * mAPMeter
    * AverageValueMeter
    * AUCMeter
    * ClassErrorMeter

--- a/example/mnist_with_visdom.py
+++ b/example/mnist_with_visdom.py
@@ -4,7 +4,7 @@
         - the Visdom server must be running at start!
 
     Example:
-        $ python -m visdom.server & 
+        $ python -m visdom.server -port 8097 & 
         $ python mnist_with_visdom.py
 """
 from tqdm import tqdm
@@ -64,11 +64,12 @@ def main():
     classerr = tnt.meter.ClassErrorMeter(accuracy=True)
     confusion_meter = tnt.meter.ConfusionMeter(10, normalized=True)
 
-    train_loss_logger = VisdomPlotLogger('line', opts={'title': 'Train Loss'})
-    train_err_logger = VisdomPlotLogger('line', opts={'title': 'Train Class Error'})
-    test_loss_logger = VisdomPlotLogger('line', opts={'title': 'Test Loss'})
-    test_err_logger = VisdomPlotLogger('line', opts={'title': 'Test Class Error'})
-    confusion_logger = VisdomLogger('heatmap', opts={'title': 'Confusion matrix', 
+    port = 8097
+    train_loss_logger = VisdomPlotLogger('line', port=port, opts={'title': 'Train Loss'})
+    train_err_logger = VisdomPlotLogger('line', port=port, opts={'title': 'Train Class Error'})
+    test_loss_logger = VisdomPlotLogger('line', port=port, opts={'title': 'Test Loss'})
+    test_err_logger = VisdomPlotLogger('line', port=port, opts={'title': 'Test Class Error'})
+    confusion_logger = VisdomLogger('heatmap', port=port, opts={'title': 'Confusion matrix', 
                                                      'columnnames': list(range(10)), 
                                                      'rownames': list(range(10))})
 

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ import shutil
 import sys
 from setuptools import setup, find_packages
 
-VERSION = '0.0.2'
+VERSION = '0.0.1'
 
 long_description = "an abstraction to train neural networks"
 
@@ -12,9 +12,9 @@ setup_info = dict(
     # Metadata
     name='torchnet',
     version=VERSION,
-    author='Barry Kui',
-    author_email='xukui.cs@gmail.com',
-    url='https://github.com/barrykui/tnt',
+    author='Sergey Zagoruyko',
+    author_email='sergey.zagoruyko@enpc.fr',
+    url='https://github.com/pytorch/tnt',
     description='an abstraction to train neural networks',
     long_description=long_description,
     license='BSD',

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ import shutil
 import sys
 from setuptools import setup, find_packages
 
-VERSION = '0.0.1'
+VERSION = '0.0.2'
 
 long_description = "an abstraction to train neural networks"
 
@@ -12,9 +12,9 @@ setup_info = dict(
     # Metadata
     name='torchnet',
     version=VERSION,
-    author='Sergey Zagoruyko',
-    author_email='sergey.zagoruyko@enpc.fr',
-    url='https://github.com/pytorch/tnt',
+    author='Barry Kui',
+    author_email='xukui.cs@gmail.com',
+    url='https://github.com/barrykui/tnt',
     description='an abstraction to train neural networks',
     long_description=long_description,
     license='BSD',

--- a/test/test_datasets.py
+++ b/test/test_datasets.py
@@ -46,7 +46,7 @@ class TestDatasets(unittest.TestCase):
     def testTensorDataset(self):
         # dict input
         data = {
-                # 'input': torch.range(0,7),
+                # 'input': torch.arange(0,8),
                 'input': np.arange(0,8),
                 'target': np.arange(0,8),
                 }
@@ -66,7 +66,7 @@ class TestDatasets(unittest.TestCase):
         self.assertEqual(a[1], d[1][0])
 
     def testBatchDataset(self):
-        t = torch.range(0,15).long()
+        t = torch.arange(0,16).long()
         batchsize = 8
         d = dataset.ListDataset(t, lambda x: {'input': x})
         d = dataset.BatchDataset(d, batchsize)

--- a/test/test_datasets.py
+++ b/test/test_datasets.py
@@ -66,7 +66,10 @@ class TestDatasets(unittest.TestCase):
         self.assertEqual(a[1], d[1][0])
 
     def testBatchDataset(self):
-        t = torch.arange(0,16).long()
+	if hasattr(torch,"arange"):
+           t = torch.arange(0,16).long()
+	else:
+           t = torch.range(0,15).long()
         batchsize = 8
         d = dataset.ListDataset(t, lambda x: {'input': x})
         d = dataset.BatchDataset(d, batchsize)

--- a/test/test_meters.py
+++ b/test/test_meters.py
@@ -21,7 +21,7 @@ class TestMeters(unittest.TestCase):
     def testClassErrorMeter(self):
         mtr = meter.ClassErrorMeter(topk=[1])
         output = torch.eye(3)
-        target = torch.range(0, 2)
+        target = torch.arange(0, 3)
         mtr.add(output, target)
         err = mtr.value()
 
@@ -38,7 +38,7 @@ class TestMeters(unittest.TestCase):
         mtr = meter.ConfusionMeter(k=3)
 
         output = torch.Tensor([[.8, 0.1, 0.1], [10, 11, 10], [0.2, 0.2, .3]])
-        target = torch.range(0, 2)
+        target = torch.arange(0, 3)
         mtr.add(output, target)
 
         conf_mtrx = mtr.value()

--- a/test/test_meters.py
+++ b/test/test_meters.py
@@ -21,7 +21,10 @@ class TestMeters(unittest.TestCase):
     def testClassErrorMeter(self):
         mtr = meter.ClassErrorMeter(topk=[1])
         output = torch.eye(3)
-        target = torch.arange(0, 3)
+	if hasattr(torch,"arange"):
+           target = torch.arange(0, 3)
+        else:
+           target = torch.range(0, 2)
         mtr.add(output, target)
         err = mtr.value()
 
@@ -38,7 +41,10 @@ class TestMeters(unittest.TestCase):
         mtr = meter.ConfusionMeter(k=3)
 
         output = torch.Tensor([[.8, 0.1, 0.1], [10, 11, 10], [0.2, 0.2, .3]])
-        target = torch.arange(0, 3)
+	if hasattr(torch,"arange"):
+           target = torch.arange(0, 3)
+        else:
+           target = torch.range(0, 2)
         mtr.add(output, target)
 
         conf_mtrx = mtr.value()

--- a/torchnet/logger/visdomlogger.py
+++ b/torchnet/logger/visdomlogger.py
@@ -23,12 +23,12 @@ class BaseVisdomLogger(Logger):
     def viz(self):
         return self._viz
 
-    def __init__(self, fields=None, win=None, env=None, port=8097, opts={}):
+    def __init__(self, fields=None, win=None, env=None, opts={}, port=8097):
         super(BaseVisdomLogger, self).__init__(fields)
         self.win = win
         self.env = env
         self.opts = opts
-        self._viz = visdom.Visdom(port)
+        self._viz = visdom.Visdom(port=port)
 
     def log(self, *args, **kwargs):
         raise NotImplementedError("log not implemented for BaseVisdomLogger, which is an abstract class.")
@@ -68,7 +68,7 @@ class VisdomSaver(object):
     def __init__(self, envs=None, port=8097):
         super(VisdomSaver, self).__init__()
         self.envs = envs
-        self.viz = visdom.Visdom(port)
+        self.viz = visdom.Visdom(port=port)
 
     def save(self, *args, **kwargs):
         self.viz.save(self.envs)
@@ -79,7 +79,7 @@ class VisdomLogger(BaseVisdomLogger):
         A generic Visdom class that works with the majority of Visdom plot types.
     '''
 
-    def __init__(self, plot_type, fields=None, win=None, env=None, port=8097, opts={}):
+    def __init__(self, plot_type, fields=None, win=None, env=None, opts={}, port=8097):
         '''
             Args:
                 fields: Currently unused
@@ -107,7 +107,7 @@ class VisdomLogger(BaseVisdomLogger):
 
 class VisdomPlotLogger(BaseVisdomLogger):
     
-    def __init__(self, plot_type, fields=None, win=None, env=None, port=8097,  opts={}):
+    def __init__(self, plot_type, fields=None, win=None, env=None, opts={}, port=8097):
         '''
             Args:
                 fields: Currently unused
@@ -161,7 +161,7 @@ class VisdomTextLogger(BaseVisdomLogger):
     '''
     valid_update_types = ['REPLACE', 'APPEND']
 
-    def __init__(self, fields=None, win=None, env=None, port=8097, opts={}, update_type=valid_update_types[0]):
+    def __init__(self, fields=None, win=None, env=None, opts={}, update_type=valid_update_types[0], port=8097):
         '''
             Args:
                 fields: Currently unused

--- a/torchnet/meter/apmeter.py
+++ b/torchnet/meter/apmeter.py
@@ -105,7 +105,10 @@ class APMeter(meter.Meter):
         if self.scores.numel() == 0:
             return 0
         ap = torch.zeros(self.scores.size(1))
-        rg = torch.arange(1, self.scores.size(0)+1).float()
+	if hasattr(torch, "arange"):
+           rg = torch.arange(1, self.scores.size(0)+1).float()
+	else:
+	   rg = torch.range(1, self.scores.size(0)).float()
         if self.weights.numel() > 0:
             weight = self.weights.new(self.weights.size())
             weighted_truth = self.weights.new(self.weights.size())

--- a/torchnet/meter/apmeter.py
+++ b/torchnet/meter/apmeter.py
@@ -105,7 +105,7 @@ class APMeter(meter.Meter):
         if self.scores.numel() == 0:
             return 0
         ap = torch.zeros(self.scores.size(1))
-        rg = torch.range(1, self.scores.size(0)).float()
+        rg = torch.arange(1, self.scores.size(0)+1).float()
         if self.weights.numel() > 0:
             weight = self.weights.new(self.weights.size())
             weighted_truth = self.weights.new(self.weights.size())

--- a/torchnet/meter/averagevaluemeter.py
+++ b/torchnet/meter/averagevaluemeter.py
@@ -8,23 +8,27 @@ class AverageValueMeter(meter.Meter):
         self.reset()
 
     def add(self, value, n = 1):
+        self.val = val
         self.sum += value
         self.var += value * value
         self.n += n
 
-    def value(self):
-        n = self.n
-        if n == 0:
-            mean, std = np.nan, np.nan
-        elif n == 1:
+        if self.n == 0:
+            self.mean, self.std = np.nan, np.nan
+        elif self.n == 1:
             return self.sum, np.inf
         else:
-            mean = self.sum / n
-            std = math.sqrt( (self.var - n * mean * mean) / (n - 1.0) )
-        return mean, std
+            self.mean = self.sum / self.n
+            self.std = math.sqrt( (self.var - self.n * self.mean * self.mean) / (self.n - 1.0) )
+
+    def value(self):
+	return self.mean, self.std
 
     def reset(self):
-        self.sum = 0.0
         self.n = 0
+        self.sum = 0.0
         self.var = 0.0
+	self.val = 0.0
+	self.mean = np.nan
+	self.std = np.nan
 

--- a/torchnet/meter/averagevaluemeter.py
+++ b/torchnet/meter/averagevaluemeter.py
@@ -6,9 +6,10 @@ class AverageValueMeter(meter.Meter):
     def __init__(self):
         super(AverageValueMeter, self).__init__()
         self.reset()
+        self.val = 0
 
     def add(self, value, n = 1):
-        self.val = val
+        self.val = value
         self.sum += value
         self.var += value * value
         self.n += n
@@ -16,7 +17,7 @@ class AverageValueMeter(meter.Meter):
         if self.n == 0:
             self.mean, self.std = np.nan, np.nan
         elif self.n == 1:
-            return self.sum, np.inf
+            self.mean, self.std = self.sum, np.inf
         else:
             self.mean = self.sum / self.n
             self.std = math.sqrt( (self.var - self.n * self.mean * self.mean) / (self.n - 1.0) )


### PR DESCRIPTION
Update to work with pytorch 0.3.0
-  use torch.arange instead of torch.range which was removed in version 0.3; 
           -  test/test_meters.py
           -  test/test_datasets.py
           -  torchnet/meter/apmeter.py

-  support specifying the port of visdom 

-  provide current value averagevaluemeter.py by using meter.val. Also meter.val, meter.mean, meter.std could be used to get the value.