### PR TITLE
Fix issue #47: AverageValueMeter is unstable when the variance is ver…

### DIFF
--- a/test/test_meters.py
+++ b/test/test_meters.py
@@ -18,6 +18,33 @@ class TestMeters(unittest.TestCase):
 
         self.assertTrue(np.isnan(mean))
 
+    def testAverageValueMeter2(self):
+	"""Test the case of near-zero variance.
+
+	The test compares the results to numpy, and uses
+        isclose() to allow for some small differences in
+        the results, which are due to slightly different arithmetic
+	operations and order.
+	"""
+    	def isclose(a, b, rel_tol=1e-09, abs_tol=0.0):
+            return abs(a-b) <= max(rel_tol * max(abs(a), abs(b)), abs_tol)
+
+	m = meter.AverageValueMeter()
+	samples = [0.7] * 10
+    	truth = np.array([])
+    	for sample in samples:
+            truth = np.append(truth, sample)
+            m.add(sample)
+            mean, std = m.value()
+
+            self.assertTrue(isclose(truth.mean(), mean))
+            self.assertTrue(
+		(math.isnan(std) and math.isnan(truth.std(ddof=1))) or
+                # When there is one sample in the dataset, numpy returns NaN and
+                # AverageValueMeter returns Inf.  We forgive AverageValueMeter :-)
+                (math.isinf(std) and math.isnan(truth.std(ddof=1))) or
+                isclose(std, truth.std(ddof=1), abs_tol=1e-07))
+
     def testClassErrorMeter(self):
         mtr = meter.ClassErrorMeter(topk=[1])
         output = torch.eye(3)

--- a/torchnet/meter/averagevaluemeter.py
+++ b/torchnet/meter/averagevaluemeter.py
@@ -2,29 +2,40 @@ import math
 from . import meter
 import numpy as np
 
+
 class AverageValueMeter(meter.Meter):
     def __init__(self):
         super(AverageValueMeter, self).__init__()
         self.reset()
 
     def add(self, value, n = 1):
-        self.sum += value
-        self.var += value * value
         self.n += n
+        if self.n == 1:
+            self.m_oldM = value
+            self.m_newM = value;
+            self.m_S = 0.0
+        else:
+            self.m_newM = self.m_oldM + (value - self.m_oldM)/float(self.n);
+            self.m_S += (value - self.m_oldM) * (value - self.m_newM);
+
+            # set up for next iteration
+            self.m_oldM = self.m_newM;
 
     def value(self):
         n = self.n
         if n == 0:
             mean, std = np.nan, np.nan
         elif n == 1:
-            return self.sum, np.inf
+            return self.m_newM, np.nan
         else:
-            mean = self.sum / n
-            std = math.sqrt( (self.var - n * mean * mean) / (n - 1.0) )
+            mean = self.m_newM
+            variance = self.m_S/(self.n - 1.0)
+            std = math.sqrt(variance)
         return mean, std
 
     def reset(self):
-        self.sum = 0.0
         self.n = 0
-        self.var = 0.0
+        self.m_oldM = 0.0
+        self.m_newM = 0.0
+        self.m_S = 0.0
 


### PR DESCRIPTION
The implementation of the standard-deviation calculation in torchnet.meter.AverageValueMeter
is numerically unstable and can lead to a negative value of the variance.  See line 23:
    (self.var - n * mean * mean) / (n - 1.0)

This negative value triggers a "ValueError: math domain error" exception when we try to take
the square-root of it.

The reason is explained well by John D. Cook in his blog post:
https://www.johndcook.com/blog/standard_deviation/

Specifically, Mr. Cook says: “If the x‘s are large and the differences between them small,
direct evaluation of the equation above would require computing a small number as the difference
of two large numbers, a red flag for numerical computing. The loss of precision can be so bad that
the expression above evaluates to a negative number even though variance is always positive.”

I’ve created a test case showing an example where the calculation of the standard deviation triggers
 an exception when a negative variance is used to calculate the standard deviation.
I’ve also created a fix, based on John D. Cook’s implementation of B.P. Welford’s variance computation
algorithm, which is attached. The credit goes entirely to Mr. Cook, as I used his implementation.
I even preserved his variable naming, although I made one small change: instead of using m_oldS and
m_newS, I used one variable (m_S) because there is no need for two variables.

I'm using Python 2.7.12, Pytorch 0.2.0_3