### PR TITLE
Fix the partition naming bug

### DIFF
--- a/torchnet/dataset/splitdataset.py
+++ b/torchnet/dataset/splitdataset.py
@@ -41,7 +41,7 @@ class SplitDataset(Dataset):
             'partition sizes cannot be negative'
         assert max(partitions.values()) > 0, 'all partitions cannot be empty'
 
-        self.partition_names = list(self.partitions.keys())
+        self.partition_names = sorted(list(self.partitions.keys()))
         self.partition_index = {partition: i for i, partition in
                                 enumerate(self.partition_names)}
 


### PR DESCRIPTION
This bug caused https://github.com/pytorch/tnt/issues/67. Fixed using a sort for the names of the partitions.