### PR TITLE
Update confusionmeter.py

### DIFF
--- a/torchnet/meter/confusionmeter.py
+++ b/torchnet/meter/confusionmeter.py
@@ -37,8 +37,8 @@ class ConfusionMeter(meter.Meter):
                 assumed to be provided as one-hot vectors
 
         """
-        predicted = predicted.cpu().squeeze().numpy()
-        target = target.cpu().squeeze().numpy()
+        predicted = predicted.cpu().numpy()
+        target = target.cpu().numpy()
 
         assert predicted.shape[0] == target.shape[0], \
             'number of targets and predicted outputs do not match'


### PR DESCRIPTION
`squeeze()` will make `assert predicted.shape[0] == target.shape[0]` fail  when `N = 1`