### PR TITLE
Fixing visdom window creation when win parameter passed to VisdomPlotLogger

### DIFF
--- a/torchnet/logger/visdomlogger.py
+++ b/torchnet/logger/visdomlogger.py
@@ -129,7 +129,7 @@ class VisdomPlotLogger(BaseVisdomLogger):
         self.chart = valid_plot_types[plot_type]
 
     def log(self, *args, **kwargs):
-        if self.win is not None:
+        if self.viz.win_exists(win=self.win, env=self.env):
             if len(args) != 2:
                 raise ValueError("When logging to {}, must pass in x and y values (and optionally z).".format(
                     type(self)))

--- a/torchnet/logger/visdomlogger.py
+++ b/torchnet/logger/visdomlogger.py
@@ -129,7 +129,7 @@ class VisdomPlotLogger(BaseVisdomLogger):
         self.chart = valid_plot_types[plot_type]
 
     def log(self, *args, **kwargs):
-        if self.viz.win_exists(win=self.win, env=self.env):
+        if self.win is not None and self.viz.win_exists(win=self.win, env=self.env):
             if len(args) != 2:
                 raise ValueError("When logging to {}, must pass in x and y values (and optionally z).".format(
                     type(self)))


### PR DESCRIPTION
VisdomPlotLogger when passed the win option expected the window to already be present else it silently exits doing nothing. Typically following the visdom api, the parameter should be used such that if the window doesn't exist - it should create a window with that name.
Fixing that issue in this PR.