### PR TITLE
APMeter pytorch 0.4 fix

### DIFF
--- a/torchnet/meter/apmeter.py
+++ b/torchnet/meter/apmeter.py
@@ -134,5 +134,5 @@ class APMeter(meter.Meter):
             precision = tp.div(rg)
 
             # compute average precision
-            ap[k] = precision[truth.byte()].sum() / max(truth.sum(), 1)
+            ap[k] = precision[truth.byte()].sum() / max(float(truth.sum()), 1)
         return ap


### PR DESCRIPTION
Fix #84, should be backwards compatible