### PR TITLE
ClassErrorMeter has issue with batchsize=1

### DIFF
--- a/test/test_meters.py
+++ b/test/test_meters.py
@@ -85,7 +85,6 @@ class TestMeters(unittest.TestCase):
             target = torch.range(0, 0)
         mtr.add(output, target)
         err = mtr.value()
-
         self.assertEqual(err, [0], "All should be correct")
 
 

--- a/test/test_meters.py
+++ b/test/test_meters.py
@@ -78,7 +78,7 @@ class TestMeters(unittest.TestCase):
 
     def testClassErrorMeteri_batch1(self):
         mtr = meter.ClassErrorMeter(topk=[1])
-        output = torch.eye(1)
+        output = torch.ones(3)
         if hasattr(torch, "arange"):
             target = torch.arange(0, 1)
         else:

--- a/test/test_meters.py
+++ b/test/test_meters.py
@@ -87,7 +87,6 @@ class TestMeters(unittest.TestCase):
         err = mtr.value()
         self.assertEqual(err, [0], "All should be correct")
 
-
     def testConfusionMeter(self):
         mtr = meter.ConfusionMeter(k=3)
 

--- a/test/test_meters.py
+++ b/test/test_meters.py
@@ -78,7 +78,7 @@ class TestMeters(unittest.TestCase):
 
     def testClassErrorMeteri_batch1(self):
         mtr = meter.ClassErrorMeter(topk=[1])
-        output = torch.ones(3)
+        output = torch.tensor([1, 0, 0])
         if hasattr(torch, "arange"):
             target = torch.arange(0, 1)
         else:
@@ -88,10 +88,6 @@ class TestMeters(unittest.TestCase):
 
         self.assertEqual(err, [0], "All should be correct")
 
-        target[0] = 0
-        mtr.add(output, target)
-        err = mtr.value()
-        self.assertEqual(err, [50.0], "Half should be correct")
 
     def testConfusionMeter(self):
         mtr = meter.ConfusionMeter(k=3)

--- a/test/test_meters.py
+++ b/test/test_meters.py
@@ -76,6 +76,23 @@ class TestMeters(unittest.TestCase):
         err = mtr.value()
         self.assertEqual(err, [50.0], "Half should be correct")
 
+    def testClassErrorMeteri_batch1(self):
+        mtr = meter.ClassErrorMeter(topk=[1])
+        output = torch.eye(1)
+        if hasattr(torch, "arange"):
+            target = torch.arange(0, 1)
+        else:
+            target = torch.range(0, 0)
+        mtr.add(output, target)
+        err = mtr.value()
+
+        self.assertEqual(err, [0], "All should be correct")
+
+        target[0] = 0
+        mtr.add(output, target)
+        err = mtr.value()
+        self.assertEqual(err, [50.0], "Half should be correct")
+
     def testConfusionMeter(self):
         mtr = meter.ConfusionMeter(k=3)
 

--- a/torchnet/meter/classerrormeter.py
+++ b/torchnet/meter/classerrormeter.py
@@ -18,7 +18,7 @@ class ClassErrorMeter(meter.Meter):
     def add(self, output, target):
         if torch.is_tensor(output):
             output = output.cpu().squeeze().numpy()
-        if torch.is_tensor(target):
+        if torch.is_tensor(target) and target.shape[0] != 1:
             target = target.cpu().squeeze().numpy()
         elif isinstance(target, numbers.Number):
             target = np.asarray([target])

--- a/torchnet/meter/classerrormeter.py
+++ b/torchnet/meter/classerrormeter.py
@@ -18,7 +18,7 @@ class ClassErrorMeter(meter.Meter):
     def add(self, output, target):
         if torch.is_tensor(output):
             output = output.cpu().squeeze().numpy()
-        if torch.is_tensor(target) and target.shape[0] != 1:
+        if torch.is_tensor(target) and len(target.shape) != 1:
             target = target.cpu().squeeze().numpy()
         elif isinstance(target, numbers.Number):
             target = np.asarray([target])

--- a/torchnet/meter/classerrormeter.py
+++ b/torchnet/meter/classerrormeter.py
@@ -18,8 +18,11 @@ class ClassErrorMeter(meter.Meter):
     def add(self, output, target):
         if torch.is_tensor(output):
             output = output.cpu().squeeze().numpy()
-        if torch.is_tensor(target) and len(target.shape) != 1:
-            target = target.cpu().squeeze().numpy()
+        if torch.is_tensor(target):
+            if len(target.shape) != 1:
+                target = target.cpu().squeeze().numpy()
+            else:
+                target = target.cpu().numpy()
         elif isinstance(target, numbers.Number):
             target = np.asarray([target])
         if np.ndim(output) == 1:


### PR DESCRIPTION
The ClassErrorMeter has a problem with batchsize=1. This can be recreated with the test (or any other run with batchsize=1). What happens is that the squeeze operation eliminates the dimension and creates a zero-dimensional tensor.

The proposed fix is simple and just checks for this one specific case using the shape of the target. Other fixes are possible as long as the case of batchsize=1 avoids the squeeze.