### PR TITLE
fix target shape when batch size equals to 1

### DIFF
--- a/torchnet/meter/classerrormeter.py
+++ b/torchnet/meter/classerrormeter.py
@@ -19,7 +19,7 @@ class ClassErrorMeter(meter.Meter):
         if torch.is_tensor(output):
             output = output.cpu().squeeze().numpy()
         if torch.is_tensor(target):
-            target = target.cpu().squeeze().numpy()
+            target = np.atleast_1d(target.cpu().squeeze().numpy())
         elif isinstance(target, numbers.Number):
             target = np.asarray([target])
         if np.ndim(output) == 1:


### PR DESCRIPTION
When target only contains one element, the shape of its numpy array will be `()`,  `assert target.shape[0] == output.shape[0]` will report errors. `np.atleast_1d` fix it.