### PR TITLE
Deploy with pip

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,4 +33,4 @@ jobs:
       skip_cleanup: true
       on:
         tags: true
-        branch: deploy-pypi
+        branch: master

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ import shutil
 import sys
 from setuptools import setup, find_packages
 
-VERSION = '0.0.3.1'
+VERSION = '0.0.4'
 
 long_description = "Simple tools for logging and visualizing, loading and training"
 


### PR DESCRIPTION
To deploy with pip, include a git tag in the commit. Travis CI will then deploy to PyPI (pip).