### PR TITLE
Make return object for auc of consistent type.

### DIFF
--- a/torchnet/meter/aucmeter.py
+++ b/torchnet/meter/aucmeter.py
@@ -50,7 +50,7 @@ class AUCMeter(meter.Meter):
     def value(self):
         # case when number of elements added are 0
         if self.scores.shape[0] == 0:
-            return 0.5
+            return (0.5, 0.0, 0.0)
 
         # sorting the arrays
         scores, sortind = torch.sort(torch.from_numpy(


### PR DESCRIPTION
Unlike non-zero size case, returned object in special case is only float of auc score. But it should be tuple having all 3 values.