### PR TITLE
Modified MeterLogger setting to localhost.

### DIFF
--- a/example/mnist_with_meterlogger.py
+++ b/example/mnist_with_meterlogger.py
@@ -62,7 +62,7 @@ def main():
 
     engine = Engine()
 
-    mlog = MeterLogger(server='10.10.30.91', port=9917, nclass=10, title="mnist_meterlogger")
+    mlog = MeterLogger(nclass=10, title="mnist_meterlogger")
 
     def h(sample):
         inputs = Variable(sample[0].float() / 255.0)


### PR DESCRIPTION
# Content
I modified mnist_with_meterlogger.py to execute on localhost. 

# Background
According to example/README.md, 
1. start visdom server on local.
2. execute mnist_with_meterlogger.py

However, server setting was '10.10.30.91' on 9917 port. 

it's confusing for beginner. Actually, I also wasted little time 😢 
