### PR TITLE
Fix TimeMeter to track a counter value and return time per unit count.

### DIFF
--- a/torchnet/meter/timemeter.py
+++ b/torchnet/meter/timemeter.py
@@ -31,7 +31,9 @@ class TimeMeter(meter.Meter):
         self.time = time.time()
 
     def value(self):
-        if self.unit:
+        if self.unit and self.n == 0:
+            raise ValueError("Trying to divide by zero in TimeMeter")
+        elif self.unit:
             return (time.time() - self.time) / self.n
         else:
             return time.time() - self.time

--- a/torchnet/meter/timemeter.py
+++ b/torchnet/meter/timemeter.py
@@ -23,9 +23,15 @@ class TimeMeter(meter.Meter):
         self.unit = unit
         self.reset()
 
+    def add(self, n=1):
+        self.n += n
+        
     def reset(self):
         self.n = 0
         self.time = time.time()
 
     def value(self):
-        return time.time() - self.time
+        if self.unit:
+            return (time.time() - self.time) / self.n
+        else:
+            return time.time() - self.time

--- a/torchnet/meter/timemeter.py
+++ b/torchnet/meter/timemeter.py
@@ -25,7 +25,7 @@ class TimeMeter(meter.Meter):
 
     def add(self, n=1):
         self.n += n
-        
+
     def reset(self):
         self.n = 0
         self.time = time.time()


### PR DESCRIPTION
Even though the documentation states that TimeMeter returns the time passed since the last `reset()` divided by the counter value when `unit=True`, this was not actually the case. This fix updates the code to do what's described in the documentation.

Note that this can cause a `ZeroDivisionError`, I'm open to suggestions for how to better deal with that.