### PR TITLE
Fix AverageValueMeter weighted treatment

### DIFF
--- a/test/test_meters.py
+++ b/test/test_meters.py
@@ -47,7 +47,7 @@ class TestMeters(unittest.TestCase):
         """
         m = meter.AverageValueMeter()
         for i in range(1, 11):
-            m.add(i * i, n=i)
+            m.add(i, n=i)
         mean, std = m.value()
         self.assertEqual(mean, 7.0)
         m.reset()


### PR DESCRIPTION
Hi @szagoruyko,

`AverageValueMeter` weighted treatment (i.e. `.add(val, n>1)` call) wasn't behaving as expected out of weighted average/std calculator.   
 Steps to reproduce:
```
arr = []
for i in range(1, 11):
    arr.extend([i]*i)

arr = np.array(arr)
real_mean, real_std = arr.mean(), arr.std()
m = AverageValueMeter()
for i in range(1,11):
    m.add(i, n=i)
m_mean, m_std = m.value()
print(m_mean == real_mean) # False
print(m_std == real_std) # False
```
Fixed as per [here](https://en.wikipedia.org/wiki/Algorithms_for_calculating_variance#Weighted_incremental_algorithm).