### PR TITLE
Fix installation dependencies specification

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,4 @@
 numpy
 visdom
+torch
+six

--- a/setup.py
+++ b/setup.py
@@ -8,6 +8,9 @@ VERSION = '0.0.5'
 
 long_description = "Simple tools for logging and visualizing, loading and training"
 
+with open('requirements.txt','r') as req_file:
+    install_reqs = [line.strip() for line in req_file.readlines()]
+
 setup_info = dict(
     # Metadata
     name='torchnet',
@@ -24,11 +27,7 @@ setup_info = dict(
 
     zip_safe=True,
 
-    install_requires=[
-        'torch',
-        'six',
-        'visdom'
-    ]
+    install_requires=install_reqs
 )
 
 setup(**setup_info)

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ VERSION = '0.0.5'
 
 long_description = "Simple tools for logging and visualizing, loading and training"
 
-with open('requirements.txt','r') as req_file:
+with open('requirements.txt', 'r') as req_file:
     install_reqs = [line.strip() for line in req_file.readlines()]
 
 setup_info = dict(


### PR DESCRIPTION
The package dependencies of torchnet are specified in
requirements.txt and setup.py and this duplication led
to two divergent versions of the depdendencies specification.

The fix: have setup.py parse and use requirements.txt.
I also merged the list of packages from requirements.txt and
setup.py.