### PR TITLE
Use boolean indexing in apmeter

### DIFF
--- a/torchnet/meter/apmeter.py
+++ b/torchnet/meter/apmeter.py
@@ -138,5 +138,5 @@ class APMeter(meter.Meter):
             precision = tp.div(rg)
 
             # compute average precision
-            ap[k] = precision[truth.byte()].sum() / max(float(truth.sum()), 1)
+            ap[k] = precision[truth.bool()].sum() / max(float(truth.sum()), 1)
         return ap


### PR DESCRIPTION
Newer PyTorch versions throw a UserWarning each time indexing with dtype torch.uint8 occurs, i.e.:
```
/pytorch/aten/src/ATen/native/IndexingUtils.h:20: UserWarning: indexing with dtype torch.uint8 is now deprecated, please use a dtype torch.bool instead.
```
This PR makes sure the apmeter uses dtype torch.bool when indexing.