### PR TITLE
Implemented MultiLabelConfusionMeter class

### DIFF
--- a/test/test_meters.py
+++ b/test/test_meters.py
@@ -174,6 +174,68 @@ class TestMeters(unittest.TestCase):
             self.assertEqual(row.sum(), 1,
                              "Row no " + str(i) + " fails to sum to one in normalized mode")
 
+    def testMultiLabelConfusionMeter(self):
+        output = torch.Tensor([[1, 1, 0], [0, 1, 0], [1, 0, 1], [1, 1, 1]])
+        target = torch.Tensor([[0, 1, 0], [0, 0, 1], [1, 0, 1], [1, 0, 1]])
+
+        mtr = meter.MultiLabelConfusionMeter(k=3, normalized=False)
+        mtr.add(output, target)
+
+        conf_mtrx = mtr.value()
+        correct_conf_mtrx = np.array([[[1, 1],
+                                       [0, 2]],
+
+                                      [[1, 2],
+                                       [0, 1]],
+
+                                      [[1, 0],
+                                       [1, 2]]])
+
+        self.assertEqual(conf_mtrx[0, 0, 0], correct_conf_mtrx[0, 0, 0], 'incorrect true negatives for class 0')
+        self.assertEqual(conf_mtrx[1, 0, 0], correct_conf_mtrx[1, 0, 0], 'incorrect true negatives for class 1')
+        self.assertEqual(conf_mtrx[2, 0, 0], correct_conf_mtrx[2, 0, 0], 'incorrect true negatives for class 2')
+
+        self.assertEqual(conf_mtrx[0, 0, 1], correct_conf_mtrx[0, 0, 1], 'incorrect false positives for class 0')
+        self.assertEqual(conf_mtrx[1, 0, 1], correct_conf_mtrx[1, 0, 1], 'incorrect false positives for class 1')
+        self.assertEqual(conf_mtrx[2, 0, 1], correct_conf_mtrx[2, 0, 1], 'incorrect false positives for class 2')
+
+        self.assertEqual(conf_mtrx[0, 1, 0], correct_conf_mtrx[0, 1, 0], 'incorrect false negatives for class 0')
+        self.assertEqual(conf_mtrx[1, 1, 0], correct_conf_mtrx[1, 1, 0], 'incorrect false negatives for class 1')
+        self.assertEqual(conf_mtrx[2, 1, 0], correct_conf_mtrx[2, 1, 0], 'incorrect false negatives for class 2')
+
+        self.assertEqual(conf_mtrx[0, 1, 1], correct_conf_mtrx[0, 1, 1], 'incorrect true positives for class 0')
+        self.assertEqual(conf_mtrx[1, 1, 1], correct_conf_mtrx[1, 1, 1], 'incorrect true positives for class 1')
+        self.assertEqual(conf_mtrx[2, 1, 1], correct_conf_mtrx[2, 1, 1], 'incorrect true positives for class 2')
+
+        mtr = meter.MultiLabelConfusionMeter(k=3, normalized=True)
+        mtr.add(output, target)
+
+        conf_mtrx_normalized = mtr.value()
+        correct_conf_mtrx_normalized = np.array([[[0.25, 0.25],
+                                                  [0,    0.5]],
+
+                                                 [[0.25, 0.5],
+                                                  [0,    0.25]],
+
+                                                 [[0.25, 0],
+                                                  [0.25, 0.5]]])
+
+        self.assertAlmostEqual(conf_mtrx_normalized[0, 0, 0], correct_conf_mtrx_normalized[0, 0, 0], 'incorrect normalized true negatives for class 0')
+        self.assertAlmostEqual(conf_mtrx_normalized[1, 0, 0], correct_conf_mtrx_normalized[1, 0, 0], 'incorrect normalized true negatives for class 1')
+        self.assertAlmostEqual(conf_mtrx_normalized[2, 0, 0], correct_conf_mtrx_normalized[2, 0, 0], 'incorrect normalized true negatives for class 2')
+
+        self.assertAlmostEqual(conf_mtrx_normalized[0, 0, 1], correct_conf_mtrx_normalized[0, 0, 1], 'incorrect normalized false positives for class 0')
+        self.assertAlmostEqual(conf_mtrx_normalized[1, 0, 1], correct_conf_mtrx_normalized[1, 0, 1], 'incorrect normalized false positives for class 1')
+        self.assertAlmostEqual(conf_mtrx_normalized[2, 0, 1], correct_conf_mtrx_normalized[2, 0, 1], 'incorrect normalized false positives for class 2')
+
+        self.assertAlmostEqual(conf_mtrx_normalized[0, 1, 0], correct_conf_mtrx_normalized[0, 1, 0], 'incorrect normalized false negatives for class 0')
+        self.assertAlmostEqual(conf_mtrx_normalized[1, 1, 0], correct_conf_mtrx_normalized[1, 1, 0], 'incorrect normalized false negatives for class 1')
+        self.assertAlmostEqual(conf_mtrx_normalized[2, 1, 0], correct_conf_mtrx_normalized[2, 1, 0], 'incorrect normalized false negatives for class 2')
+
+        self.assertAlmostEqual(conf_mtrx_normalized[0, 1, 1], correct_conf_mtrx_normalized[0, 1, 1], 'incorrect normalized true positives for class 0')
+        self.assertAlmostEqual(conf_mtrx_normalized[1, 1, 1], correct_conf_mtrx_normalized[1, 1, 1], 'incorrect normalized true positives for class 1')
+        self.assertAlmostEqual(conf_mtrx_normalized[2, 1, 1], correct_conf_mtrx_normalized[2, 1, 1], 'incorrect normalized true positives for class 2')
+
     def testMSEMeter(self):
         a = torch.ones(7)
         b = torch.zeros(7)

--- a/torchnet/meter/__init__.py
+++ b/torchnet/meter/__init__.py
@@ -1,6 +1,7 @@
 from .averagevaluemeter import AverageValueMeter
 from .classerrormeter import ClassErrorMeter
 from .confusionmeter import ConfusionMeter
+from .multilabelconfusionmeter import MultiLabelConfusionMeter
 from .timemeter import TimeMeter
 from .msemeter import MSEMeter
 from .movingaveragevaluemeter import MovingAverageValueMeter

--- a/torchnet/meter/multilabelconfusionmeter.py
+++ b/torchnet/meter/multilabelconfusionmeter.py
@@ -1,0 +1,91 @@
+from . import meter
+import numpy as np
+
+
+class MultiLabelConfusionMeter(meter.Meter):
+    """
+    The MultiLabelConfusionMeter constructs a confusion matrix for a multi-class multi-label
+    classification problem. For single labeled classification problem, please use ConfusionMeter.
+
+    Args:
+        k (int): number of classes in the classification problem
+        normalized (boolean): Determines whether or not the confusion matrix
+            is normalized or not
+
+    """
+
+    def __init__(self, k, normalized=False):
+        super(MultiLabelConfusionMeter, self).__init__()
+        self.conf = np.ndarray((k, 2, 2), dtype=np.int32)
+        self.normalized = normalized
+        self.k = k
+        self.reset()
+
+    def reset(self):
+        self.conf.fill(0)
+
+    def add(self, predicted, target):
+        """Computes the confusion matrix of shape K x 2 x 2 where K is the number of classes
+
+        Args:
+            predicted (tensor): Must be an N x K tensor of predicted classes obtained from
+                the model for N examples and K classes. The values must be 0/1. 
+                The i'th row and j'th column represents a j'th label prediction for sample i
+                if its value is 1 else if the value is 0 then the j'th label is not predicted. 
+            target (tensor): Must be an N x K tensor of classes which represents the ground truth. 
+                The values must be 0/1. The i'th row and j'th column represents a j'th label ground truth 
+                for sample i if its value is 1 else if the value is 0 then the j'th label is not a ground truth.
+
+        """
+
+        predicted = predicted.cpu().numpy()
+        target = target.cpu().numpy()
+
+        assert predicted.shape[0] == target.shape[0], \
+            'number of targets and predicted outputs do not match'
+
+        assert np.ndim(predicted) == 2, \
+            'predicted tensor must be of dimension 2'
+
+        assert np.ndim(target) == 2, \
+            'target tensor must be of dimension 2'
+
+        assert predicted.shape[1] == self.k, \
+            'number of prediction classes does not match the original number of classes'
+
+        assert target.shape[1] == self.k, \
+            'number of target classes does not match the original number of classes'
+
+        num_samples = predicted.shape[0]
+
+        assert int(self.k * num_samples) == ((predicted.astype(np.int32) == 0).sum() + (predicted.astype(np.int32) == 1).sum()), \
+            'predicted array must be binary'
+
+        assert int(self.k * num_samples) == ((target.astype(np.int32) == 0).sum() + (target.astype(np.int32) == 1).sum()), \
+            'target array must be binary'
+
+        target_total = np.count_nonzero(target, axis=0)
+        predictions_total = np.count_nonzero(predicted, axis=0)
+        tp = np.count_nonzero(np.multiply(target, predicted), axis=0)
+        fp = predictions_total - tp
+        fn = target_total - tp
+        tn = target.shape[0] - tp - fp - fn
+
+        self.conf += np.array([tn, fp, fn, tp]).T.reshape(-1, 2, 2)
+
+
+    def value(self):
+        """
+        Returns:
+            Confusion matrix M of shape K x 2 x 2, where 
+            M[i, 0, 0] corresponds to count/rate of true negatives of class i,
+            M[i, 0, 1] corresponds to count/rate of false positives of class i,
+            M[i, 1, 0] corresponds to count/rate of false negatives of class i,
+            M[i, 1, 1] corresponds to count/rate of true positives of class i.
+        """
+        if self.normalized:
+            conf = self.conf.astype(np.float64)
+            sums = conf.sum(axis=2).sum(axis=1)
+            return (conf.reshape(conf.shape[0], 4) / sums[:, None]).reshape(conf.shape)
+        else:
+            return self.conf


### PR DESCRIPTION
This PR is a follow-up on this [issue](https://github.com/pytorch/tnt/issues/70) where it was requested to add the ```MultiLabelConfusionMeter``` class for generating confusion matrix for multi-label, multi-class classification problems. I have added some tests but let me know if more is needed. I would be happy to add documentation once this class is approved.

An example is given below:
```python
import torch
import torchnet.meter as meter

'''
Both inputs below must be a tensor of shape N x K, where N is the number of samples 
and K is the number of classes. The values of the tensors must be binary where a 
1 in the i'th row and j'th column marks the j'th label for the i'th sample.
'''

predicted = torch.Tensor([[1, 1, 0], [0, 1, 0], [1, 0, 1], [1, 1, 1]])
ground_truth = torch.Tensor([[0, 1, 0], [0, 0, 1], [1, 0, 1], [1, 0, 1]])
mtr = meter.MultiLabelConfusionMeter(k=3, normalized=False)
mtr.add(predicted, ground_truth)
conf_matrix = mtr.value() # Generates a K x 2 x 2 confusion matrix

'''
conf_matrix[i, 0, 0] corresponds to count/rate of true negatives of class i,
conf_matrix[i, 0, 1] corresponds to count/rate of false positives of class i,
conf_matrix[i, 1, 0] corresponds to count/rate of false negatives of class i,
conf_matrix[i, 1, 1] corresponds to count/rate of true positives of class i.

With normalization : meter.MultiLabelConfusionMeter(k=3, normalized=True), for all i:
conf_matrix[i, 0, 0] + conf_matrix[i, 0, 1] + conf_matrix[i, 1, 0] + conf_matrix[i, 1, 1] = 1
'''

```