### PR TITLE
Update assertion in unit test

### DIFF
--- a/tests/loggers/test_tensorboard.py
+++ b/tests/loggers/test_tensorboard.py
@@ -34,8 +34,8 @@ class TensorBoardLoggerTest(unittest.TestCase):
             acc = EventAccumulator(log_dir)
             acc.Reload()
             for i, event in enumerate(acc.Tensors("test_log")):
-                self.assertAlmostEquals(event.tensor_proto.float_val[0], float(i) ** 2)
-                self.assertEquals(event.step, i)
+                self.assertAlmostEqual(event.tensor_proto.float_val[0], float(i) ** 2)
+                self.assertEqual(event.step, i)
 
     def test_log_dict(self) -> None:
         with tempfile.TemporaryDirectory() as log_dir:
@@ -48,16 +48,16 @@ class TensorBoardLoggerTest(unittest.TestCase):
             acc.Reload()
             for i in range(5):
                 tensor_tag = acc.Tensors(f"log_dict_{i}")[0]
-                self.assertAlmostEquals(
+                self.assertAlmostEqual(
                     tensor_tag.tensor_proto.float_val[0], float(i) ** 2
                 )
-                self.assertEquals(tensor_tag.step, 1)
+                self.assertEqual(tensor_tag.step, 1)
 
     def test_log_rank_zero(self) -> None:
         with tempfile.TemporaryDirectory() as log_dir:
             with patch.dict("os.environ", {"RANK": "1"}):
                 logger = TensorBoardLogger(path=log_dir)
-                self.assertEquals(logger.writer, None)
+                self.assertEqual(logger.writer, None)
 
     @staticmethod
     def _setup_worker(rank: int, world_size: int, free_port: int) -> None:

--- a/tests/utils/test_seed.py
+++ b/tests/utils/test_seed.py
@@ -49,7 +49,7 @@ class SeedTest(unittest.TestCase):
                 seed(42, deterministic=deterministic)
                 self.assertFalse(torch.backends.cudnn.deterministic)
                 self.assertTrue(torch.backends.cudnn.benchmark)
-                self.assertEquals(0, torch.get_deterministic_debug_mode())
+                self.assertEqual(0, torch.get_deterministic_debug_mode())
                 self.assertFalse(torch.are_deterministic_algorithms_enabled())
                 self.assertFalse(torch.is_deterministic_algorithms_warn_only_enabled())
 

--- a/tests/utils/test_version.py
+++ b/tests/utils/test_version.py
@@ -29,21 +29,21 @@ class TestVersion(unittest.TestCase):
     @patch("platform.python_version")
     def test_get_python_version(self, mock_python_version: MagicMock) -> None:
         mock_python_version.return_value = "3.8.0"
-        self.assertEquals(version.get_python_version(), Version("3.8.0"))
-        self.assertNotEquals(version.get_python_version(), Version("3.10.5"))
+        self.assertEqual(version.get_python_version(), Version("3.8.0"))
+        self.assertNotEqual(version.get_python_version(), Version("3.10.5"))
 
         mock_python_version.return_value = "3.10.5"
-        self.assertNotEquals(version.get_python_version(), Version("3.8.0"))
-        self.assertEquals(version.get_python_version(), Version("3.10.5"))
+        self.assertNotEqual(version.get_python_version(), Version("3.8.0"))
+        self.assertEqual(version.get_python_version(), Version("3.10.5"))
 
     def test_get_torch_version(self) -> None:
         with patch.object(torch, "__version__", "1.8.3"):
-            self.assertEquals(version.get_torch_version(), Version("1.8.3"))
-            self.assertNotEquals(version.get_torch_version(), Version("1.12.0"))
+            self.assertEqual(version.get_torch_version(), Version("1.8.3"))
+            self.assertNotEqual(version.get_torch_version(), Version("1.12.0"))
 
         with patch.object(torch, "__version__", "1.12.0"):
-            self.assertNotEquals(version.get_torch_version(), Version("1.8.3"))
-            self.assertEquals(version.get_torch_version(), Version("1.12.0"))
+            self.assertNotEqual(version.get_torch_version(), Version("1.8.3"))
+            self.assertEqual(version.get_torch_version(), Version("1.12.0"))
 
     def test_torch_version_comparators(self) -> None:
         with patch.object(torch, "__version__", "1.7.0"):


### PR DESCRIPTION
Summary:
This shows up in the unit test logs
```
  /home/runner/work/tnt/tnt/tests/loggers/test_tensorboard.py:37: DeprecationWarning: Please use assertAlmostEqual instead.
    self.assertAlmostEquals(event.tensor_proto.float_val[0], float(i) ** 2)

  /home/runner/work/tnt/tnt/tests/loggers/test_tensorboard.py:38: DeprecationWarning: Please use assertEqual instead.
    self.assertEquals(event.step, i)

  /home/runner/work/tnt/tnt/tests/utils/test_seed.py:52: DeprecationWarning: Please use assertEqual instead.
    self.assertEquals(0, torch.get_deterministic_debug_mode())

tests/utils/test_version.py::TestVersion::test_get_python_version
  /home/runner/work/tnt/tnt/tests/utils/test_version.py:32: DeprecationWarning: Please use assertEqual instead.
    self.assertEquals(version.get_python_version(), Version("3.8.0"))

tests/utils/test_version.py::TestVersion::test_get_python_version
  /home/runner/work/tnt/tnt/tests/utils/test_version.py:33: DeprecationWarning: Please use assertNotEqual instead.
    self.assertNotEquals(version.get_python_version(), Version("3.10.5"))
```

Differential Revision: D38450333

