### PR TITLE
Add an in-memory logger

### DIFF
--- a/tests/loggers/test_in_memory.py
+++ b/tests/loggers/test_in_memory.py
@@ -1,0 +1,59 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+import sys
+import unittest
+from collections import OrderedDict
+from contextlib import contextmanager
+from io import StringIO
+
+from torchtnt.loggers.in_memory import InMemoryLogger
+
+
+class InMemoryLoggerTest(unittest.TestCase):
+    def test_in_memory_log(self) -> None:
+        logger = InMemoryLogger()
+        logger.log(name="metric1", data=123.0, step=0)
+        logger.log(name="metric1", data=456.0, step=1)
+        logger.log(name="metric1", data=789.0, step=2)
+        # Test flushing.
+        with captured_output() as (out, err):
+            logger.flush()
+        self.assertTrue(out.getvalue().startswith("OrderedDict(["))
+        self.assertEqual(err.getvalue(), "")
+        logger.log_dict(payload={"metric2": 1.0, "metric3": 2.0}, step=3)
+        # Check the buffer directly.
+        buf = logger.log_buffer
+        self.assertEqual(len(buf), 4)
+        self.assertEqual(buf[0]["metric1"], 123.0)
+        self.assertEqual(buf[0]["step"], 0)
+        self.assertEqual(buf[1]["metric1"], 456.0)
+        self.assertEqual(buf[1]["step"], 1)
+        self.assertEqual(buf[2]["metric1"], 789.0)
+        self.assertEqual(buf[2]["step"], 2)
+        self.assertEqual(buf[3]["metric2"], 1.0)
+        self.assertEqual(buf[3]["metric3"], 2.0)
+        self.assertEqual(buf[3]["step"], 3)
+        # Test flushing.
+        with captured_output() as (out, err):
+            logger.flush()
+        self.assertTrue(out.getvalue().startswith("OrderedDict(["))
+        self.assertEqual(err.getvalue(), "")
+        # Closing the log clears the buffer.
+        logger.close()
+        self.assertEqual(logger.log_buffer, OrderedDict([]))
+
+
+@contextmanager
+def captured_output():
+    new_out, new_err = StringIO(), StringIO()
+    old_out, old_err = sys.stdout, sys.stderr
+    try:
+        sys.stdout, sys.stderr = new_out, new_err
+        yield sys.stdout, sys.stderr
+    finally:
+        sys.stdout, sys.stderr = old_out, old_err

--- a/torchtnt/loggers/__init__.py
+++ b/torchtnt/loggers/__init__.py
@@ -6,6 +6,7 @@
 
 from .csv import CSVLogger
 from .file import FileLogger
+from .in_memory import InMemoryLogger
 from .json import JSONLogger
 from .logger import MetricLogger, Scalar
 from .tensorboard import TensorBoardLogger
@@ -15,6 +16,7 @@ from .utils import scalar_to_float
 __all__ = [
     "CSVLogger",
     "FileLogger",
+    "InMemoryLogger",
     "JSONLogger",
     "MetricLogger",
     "Scalar",

--- a/torchtnt/loggers/in_memory.py
+++ b/torchtnt/loggers/in_memory.py
@@ -1,0 +1,69 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+import atexit
+import logging
+from collections import OrderedDict
+from time import monotonic
+from typing import Dict
+
+from torchtnt.loggers.logger import MetricLogger, Scalar
+from torchtnt.loggers.utils import scalar_to_float
+
+logger: logging.Logger = logging.getLogger(__name__)
+
+
+class InMemoryLogger(MetricLogger):
+    def __init__(self) -> None:
+        """A simple logger that buffers data in-memory.
+
+        Example:
+            from torchtnt.loggers import InMemoryLogger
+            logger = InMemoryLogger()
+            logger.log("accuracy", 23.56, 10)
+            logger.close()
+        """
+
+        self._log_buffer: OrderedDict[int, Dict[str, float]] = OrderedDict()
+        logger.info("Logging metrics in-memory")
+        atexit.register(self.close)
+
+    @property
+    def log_buffer(self) -> Dict[int, Dict[str, float]]:
+        """Directly access the buffer."""
+
+        return self._log_buffer
+
+    def log_dict(self, payload: Dict[str, Scalar], step: int) -> None:
+        """Add multiple scalar values.
+
+        Args:
+            payload (dict): dictionary of tag name and scalar value
+            step (int): step value to record
+        """
+
+        for k, v in payload.items():
+            self.log(k, v, step)
+
+    def log(self, name: str, data: Scalar, step: int) -> None:
+        """Log scalar data to the in-memory buffer.
+
+        Args:
+            name (string): a unique name to group scalars
+            data (float/int/Tensor): scalar data to log
+            step (int): step value to record
+        """
+
+        self._log_buffer.setdefault(step, {})[name] = scalar_to_float(data)
+        self._log_buffer[step]["step"] = step
+        self._log_buffer[step]["time"] = monotonic()
+
+    def flush(self) -> None:
+        print(self._log_buffer)
+
+    def close(self) -> None:
+        self._log_buffer.clear()

--- a/torchtnt/loggers/tensorboard.py
+++ b/torchtnt/loggers/tensorboard.py
@@ -26,7 +26,7 @@ class TensorBoardLogger(MetricLogger):
 
         from torchtnt.loggers import TensorBoardLogger
         logger = TensorBoardLogger()
-        logger.log("accuracy", 23.56)
+        logger.log("accuracy", 23.56, 10)
         logger.close()
     """
 


### PR DESCRIPTION
Summary: Add an in-memory metric logger to `torchtnt/loggers`.

Differential Revision: D38450602

