### PR TITLE
add release build github action

### DIFF
--- a/.github/workflows/release_build.yaml
+++ b/.github/workflows/release_build.yaml
@@ -1,0 +1,69 @@
+name: Push Release to PyPi
+
+on:
+  workflow_dispatch:
+
+jobs:
+  unit_tests:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: [3.7, 3.8, 3.9]
+    steps:
+      - name: Check out repo
+        uses: actions/checkout@v2
+      - name: Setup conda env
+        uses: conda-incubator/setup-miniconda@v2
+        with:
+          miniconda-version: "latest"
+          activate-environment: test
+          python-version: ${{ matrix.python-version }}
+      - name: Install dependencies
+        shell: bash -l {0}
+        run: |
+          set -eux
+          conda activate test
+          conda install pytorch cpuonly -c pytorch-nightly
+          pip install -r requirements.txt
+          pip install -r dev-requirements.txt
+          python setup.py sdist bdist_wheel
+          pip install dist/*.whl
+      - name: Run unit tests
+        shell: bash -l {0}
+        run: |
+          set -eux
+          conda activate test
+          pytest tests -vv
+  # TODO figure out how to deduplicate steps
+  upload_to_pypi:
+    needs: unit_tests
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repo
+        uses: actions/checkout@v2
+      - name: Setup conda env
+        uses: conda-incubator/setup-miniconda@v2
+        with:
+          miniconda-version: "latest"
+          activate-environment: test
+          python-version: 3.7
+      - name: Install dependencies
+        shell: bash -l {0}
+        run: |
+          set -eux
+          conda activate test
+          conda install pytorch cpuonly -c pytorch-nightly
+          pip install -r requirements.txt
+          pip install -r dev-requirements.txt
+          pip install -e ".[dev]"
+      - name: Upload to PyPI
+        shell: bash -l {0}
+        env:
+          PYPI_USER: ${{ secrets.PYPI_USER }}
+          PYPI_TOKEN: ${{ secrets.PYPI_TOKEN }}
+        run: |
+          set -eux
+          conda activate test
+          pip install twine
+          python setup.py sdist bdist_wheel
+          twine upload --username "$PYPI_USER" --password "$PYPI_TOKEN" dist/* --verbose


### PR DESCRIPTION
Please read through our [contribution guide](https://github.com/pytorch/tnt/blob/main/CONTRIBUTING.md) prior to creating your pull request.

Summary:

action automatically runs tests and pushes to pypi.

one click push, assuming the version has been bumped in `torchtnt/__init__.py`.

<img width="1321" alt="image" src="https://user-images.githubusercontent.com/53842584/183227418-0294f8c7-2e28-4d4b-9b1f-33724f2f59a4.png">


Test plan:

https://github.com/edward-io/tnt/actions/runs/2807063637

(failed because we already have a 0.0.1 on pypi)

