### PR TITLE
Fix tests for CI

### DIFF
--- a/tests/loggers/__init__.py
+++ b/tests/loggers/__init__.py
@@ -1,0 +1,5 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.

--- a/tests/runner/__init__.py
+++ b/tests/runner/__init__.py
@@ -1,0 +1,5 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.

--- a/tests/runner/test_app_state_mixin.py
+++ b/tests/runner/test_app_state_mixin.py
@@ -12,7 +12,7 @@ from torch import nn
 from torchtnt.runner.unit import _AppStateMixin
 
 
-class TestUnit(_AppStateMixin):
+class Dummy(_AppStateMixin):
     def __init__(self):
         super().__init__()
         self.module_a = nn.Linear(1, 1)
@@ -29,7 +29,7 @@ class AppStateMixinTest(unittest.TestCase):
         Test setting, getting, and deleting tracked_modules
         """
 
-        my_unit = TestUnit()
+        my_unit = Dummy()
 
         # assert that the attributes are stored in tracked_modules
         self.assertEqual(my_unit.tracked_modules()["module_a"], my_unit.module_a)
@@ -47,7 +47,7 @@ class AppStateMixinTest(unittest.TestCase):
         """
         Test setting, getting, and deleting tracked_optimizers
         """
-        my_unit = TestUnit()
+        my_unit = Dummy()
 
         # assert that the attribute is stored in tracked_optimizers
         self.assertEqual(
@@ -65,7 +65,7 @@ class AppStateMixinTest(unittest.TestCase):
         Test setting, getting, and deleting tracked_lr_schedulers
         """
 
-        my_unit = TestUnit()
+        my_unit = Dummy()
 
         # assert that the attribute is stored in tracked_lr_schedulers
         self.assertEqual(
@@ -83,7 +83,7 @@ class AppStateMixinTest(unittest.TestCase):
         Test the app_state method
         """
 
-        my_unit = TestUnit()
+        my_unit = Dummy()
 
         # the attributes should be in app_state
         for key in ("module_a", "loss_fn_b", "optimizer_c", "lr_scheduler_d"):
@@ -104,7 +104,7 @@ class AppStateMixinTest(unittest.TestCase):
         Test reassigning attributes to a different type
         """
 
-        my_unit = TestUnit()
+        my_unit = Dummy()
 
         # create new objects
         module_e = nn.Linear(1, 1)

--- a/tests/runner/test_evaluate.py
+++ b/tests/runner/test_evaluate.py
@@ -7,9 +7,9 @@
 
 import unittest
 
-from torchtnt.runner.evaluate import evaluate
+from torchtnt.runner._test_utils import DummyEvalUnit, generate_random_dataloader
 
-from torchtnt.tests.runner.utils import DummyEvalUnit, generate_random_dataloader
+from torchtnt.runner.evaluate import evaluate
 
 
 class EvaluateTest(unittest.TestCase):

--- a/tests/runner/test_predict.py
+++ b/tests/runner/test_predict.py
@@ -7,9 +7,9 @@
 
 import unittest
 
-from torchtnt.runner.predict import predict
+from torchtnt.runner._test_utils import DummyPredictUnit, generate_random_dataloader
 
-from torchtnt.tests.runner.utils import DummyPredictUnit, generate_random_dataloader
+from torchtnt.runner.predict import predict
 
 
 class PredictTest(unittest.TestCase):

--- a/tests/utils/__init__.py
+++ b/tests/utils/__init__.py
@@ -1,0 +1,5 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.

--- a/torchtnt/runner/_test_utils.py
+++ b/torchtnt/runner/_test_utils.py
@@ -17,7 +17,7 @@ Batch = Tuple[torch.Tensor, torch.Tensor]
 
 
 class DummyEvalUnit(EvalUnit):
-    def __init__(self, input_dim: int):
+    def __init__(self, input_dim: int) -> None:
         super().__init__()
         # initialize module & loss_fn
         self.module = nn.Linear(input_dim, 2)
@@ -34,7 +34,7 @@ class DummyEvalUnit(EvalUnit):
 
 
 class DummyPredictUnit(PredictUnit):
-    def __init__(self, input_dim: int):
+    def __init__(self, input_dim: int) -> None:
         super().__init__()
         # initialize module
         self.module = nn.Linear(input_dim, 2)


### PR DESCRIPTION
Summary:
Seeing errors like this in CI on trunk:
```
    from torchtnt.tests.runner.utils import DummyPredictUnit, generate_random_dataloader
E   ModuleNotFoundError: No module named 'torchtnt.tests'
```
moving the test utils to resolve it

Differential Revision: D38774677

