### PR TITLE
Add runner example

### DIFF
--- a/tests/runner/test_fit.py
+++ b/tests/runner/test_fit.py
@@ -1,0 +1,123 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+import unittest
+
+from torchtnt.runner._test_utils import DummyFitUnit, generate_random_dataloader
+from torchtnt.runner.fit import fit
+
+
+class FitTest(unittest.TestCase):
+    def test_fit_evaluate_every_n_epochs(self) -> None:
+        """
+        Test fit entry point with evaluate_every_n_epochs=1
+        """
+        input_dim = 2
+        train_dataset_len = 8
+        eval_dataset_len = 4
+        batch_size = 2
+        max_epochs = 3
+        evaluate_every_n_epochs = 1
+        expected_train_steps_per_epoch = train_dataset_len / batch_size
+        expected_eval_steps_per_epoch = eval_dataset_len / batch_size
+        expected_num_evaluate_calls = max_epochs / evaluate_every_n_epochs
+
+        my_unit = DummyFitUnit(input_dim=input_dim)
+
+        train_dataloader = generate_random_dataloader(
+            train_dataset_len, input_dim, batch_size
+        )
+        eval_dataloader = generate_random_dataloader(
+            eval_dataset_len, input_dim, batch_size
+        )
+
+        state = fit(
+            my_unit,
+            train_dataloader,
+            eval_dataloader,
+            max_epochs=max_epochs,
+            evaluate_every_n_epochs=evaluate_every_n_epochs,
+        )
+
+        self.assertEqual(state.train_state.progress.num_epochs_completed, max_epochs)
+        self.assertEqual(state.train_state.progress.num_steps_completed_in_epoch, 0)
+        self.assertEqual(
+            state.train_state.progress.num_steps_completed,
+            max_epochs * expected_train_steps_per_epoch,
+        )
+
+        self.assertEqual(
+            state.eval_state.progress.num_epochs_completed,
+            expected_num_evaluate_calls,
+        )
+        self.assertEqual(state.eval_state.progress.num_steps_completed_in_epoch, 0)
+        self.assertEqual(
+            state.eval_state.progress.num_steps_completed,
+            max_epochs * expected_eval_steps_per_epoch,
+        )
+
+        # step_output should be reset to None
+        self.assertEqual(state.eval_state.step_output, None)
+        self.assertEqual(state.train_state.step_output, None)
+
+    def test_fit_evaluate_every_n_steps(self) -> None:
+        """
+        Test fit entry point with evaluate_every_n_steps=2
+        """
+        input_dim = 2
+        train_dataset_len = 16
+        eval_dataset_len = 4
+        batch_size = 2
+        max_epochs = 3
+        evaluate_every_n_steps = 2
+        expected_train_steps_per_epoch = train_dataset_len / batch_size
+        expected_eval_steps_per_epoch = eval_dataset_len / batch_size
+        expected_num_evaluate_calls_per_train_epoch = (
+            expected_train_steps_per_epoch / evaluate_every_n_steps
+        )
+        expected_num_evaluate_calls = (
+            expected_num_evaluate_calls_per_train_epoch * max_epochs
+        )
+
+        my_unit = DummyFitUnit(input_dim=input_dim)
+
+        train_dataloader = generate_random_dataloader(
+            train_dataset_len, input_dim, batch_size
+        )
+        eval_dataloader = generate_random_dataloader(
+            eval_dataset_len, input_dim, batch_size
+        )
+
+        state = fit(
+            my_unit,
+            train_dataloader,
+            eval_dataloader,
+            max_epochs=max_epochs,
+            evaluate_every_n_epochs=None,
+            evaluate_every_n_steps=evaluate_every_n_steps,
+        )
+
+        self.assertEqual(state.train_state.progress.num_epochs_completed, max_epochs)
+        self.assertEqual(state.train_state.progress.num_steps_completed_in_epoch, 0)
+        self.assertEqual(
+            state.train_state.progress.num_steps_completed,
+            max_epochs * expected_train_steps_per_epoch,
+        )
+
+        self.assertEqual(
+            state.eval_state.progress.num_epochs_completed,
+            expected_num_evaluate_calls,
+        )
+        self.assertEqual(state.eval_state.progress.num_steps_completed_in_epoch, 0)
+        self.assertEqual(
+            state.eval_state.progress.num_steps_completed,
+            expected_num_evaluate_calls * expected_eval_steps_per_epoch,
+        )
+
+        # step_output should be reset to None
+        self.assertEqual(state.eval_state.step_output, None)
+        self.assertEqual(state.train_state.step_output, None)

--- a/tests/runner/test_train.py
+++ b/tests/runner/test_train.py
@@ -1,0 +1,104 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+import unittest
+
+from torchtnt.runner._test_utils import DummyTrainUnit, generate_random_dataloader
+from torchtnt.runner.train import train, train_epoch
+
+
+class TrainTest(unittest.TestCase):
+    def test_train(self) -> None:
+        """
+        Test train entry point
+        """
+        input_dim = 2
+        dataset_len = 8
+        batch_size = 2
+        max_epochs = 3
+        expected_steps_per_epoch = dataset_len / batch_size
+
+        my_unit = DummyTrainUnit(input_dim=input_dim)
+        initial_training_mode = my_unit.module.training
+
+        dataloader = generate_random_dataloader(dataset_len, input_dim, batch_size)
+
+        state = train(my_unit, dataloader, max_epochs=max_epochs)
+
+        self.assertEqual(state.train_state.progress.num_epochs_completed, max_epochs)
+        self.assertEqual(state.train_state.progress.num_steps_completed_in_epoch, 0)
+        self.assertEqual(
+            state.train_state.progress.num_steps_completed,
+            max_epochs * expected_steps_per_epoch,
+        )
+
+        # step_output should be reset to None
+        self.assertEqual(state.train_state.step_output, None)
+
+        self.assertEqual(my_unit.module.training, initial_training_mode)
+
+    def test_train_max_steps_per_epoch(self) -> None:
+        """
+        Test train entry point with max_steps_per_epoch
+        """
+        input_dim = 2
+        dataset_len = 8
+        batch_size = 2
+        max_epochs = 3
+        max_steps_per_epoch = 2
+
+        my_unit = DummyTrainUnit(input_dim=input_dim)
+        initial_training_mode = my_unit.module.training
+
+        dataloader = generate_random_dataloader(dataset_len, input_dim, batch_size)
+
+        state = train(
+            my_unit,
+            dataloader,
+            max_epochs=max_epochs,
+            max_steps_per_epoch=max_steps_per_epoch,
+        )
+
+        self.assertEqual(state.train_state.progress.num_epochs_completed, max_epochs)
+        self.assertEqual(state.train_state.progress.num_steps_completed_in_epoch, 0)
+        self.assertEqual(
+            state.train_state.progress.num_steps_completed,
+            max_epochs * max_steps_per_epoch,
+        )
+
+        # step_output should be reset to None
+        self.assertEqual(state.train_state.step_output, None)
+
+        self.assertEqual(my_unit.module.training, initial_training_mode)
+
+    def test_train_epoch(self) -> None:
+        """
+        Test train_epoch entry point
+        """
+        input_dim = 2
+        dataset_len = 8
+        batch_size = 2
+        expected_steps_per_epoch = dataset_len / batch_size
+
+        my_unit = DummyTrainUnit(input_dim=input_dim)
+        initial_training_mode = my_unit.module.training
+
+        dataloader = generate_random_dataloader(dataset_len, input_dim, batch_size)
+
+        state = train_epoch(my_unit, dataloader)
+
+        self.assertEqual(state.train_state.progress.num_epochs_completed, 1)
+        self.assertEqual(state.train_state.progress.num_steps_completed_in_epoch, 0)
+        self.assertEqual(
+            state.train_state.progress.num_steps_completed,
+            expected_steps_per_epoch,
+        )
+
+        # step_output should be reset to None
+        self.assertEqual(state.train_state.step_output, None)
+
+        self.assertEqual(my_unit.module.training, initial_training_mode)

--- a/torchtnt/examples/runner/train_example.py
+++ b/torchtnt/examples/runner/train_example.py
@@ -1,0 +1,236 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-strict
+
+import argparse
+import logging
+import os
+import sys
+import tempfile
+from argparse import Namespace
+from typing import List, Optional, Tuple, Union
+
+import torch
+import torch.nn as nn
+from torch.distributed.fsdp import (
+    CPUOffload,
+    FullyShardedDataParallel as FSDP,
+    MixedPrecision,
+)
+from torch.nn.parallel import DistributedDataParallel as DDP
+from torch.utils.data.dataset import Dataset, TensorDataset
+from torcheval.metrics import BinaryAccuracy
+from torchtnt.loggers.tensorboard import TensorBoardLogger
+from torchtnt.runner.state import State
+from torchtnt.runner.train import train
+from torchtnt.runner.unit import TrainUnit
+from torchtnt.utils import CudaDataPrefetcher, init_from_env, seed, Timer
+
+_logger: logging.Logger = logging.getLogger(__name__)
+logging.basicConfig(level=logging.INFO)
+
+Batch = Tuple[torch.Tensor, torch.Tensor]
+
+
+def prepare_module(
+    input_dim: int,
+    device: torch.device,
+    strategy: Optional[str],
+    precision: Optional[torch.dtype],
+) -> nn.Module:
+    """
+    Instantiate a nn.Module which will define the architecture of your model. If using a data parallel technique, wrap the module in DDP or FSDP.
+    See https://pytorch.org/docs/stable/generated/torch.nn.Module.html for docs.
+    """
+    module = nn.Linear(input_dim, 2)
+    # move module to device
+    module = module.to(device)
+
+    if strategy == "ddp":
+        # wrap module in DDP
+        device_ids = None
+        if device.type == "cuda":
+            device_ids = [device.index]
+        return DDP(module, device_ids=device_ids)
+    elif strategy == "fsdp":
+        # wrap module in FSDP
+        return FSDP(
+            module,
+            cpu_offload=CPUOffload(offload_params=True),
+            mixed_precision=MixedPrecision(
+                param_dtype=precision,
+                reduce_dtype=precision,
+                buffer_dtype=precision,
+            ),
+        )
+    else:
+        return module
+
+
+def _generate_dataset(num_samples: int, input_dim: int) -> Dataset[Batch]:
+    """Returns a dataset of random inputs and labels for binary classification."""
+    # TODO: use datapipes/dataloaderV2
+    data = torch.randn(num_samples, input_dim)
+    labels = torch.randint(low=0, high=2, size=(num_samples,))
+    return TensorDataset(data, labels)
+
+
+def prepare_dataloader(
+    num_samples: int, input_dim: int, batch_size: int, device: torch.device
+) -> Union[CudaDataPrefetcher, torch.utils.data.DataLoader]:
+    """Instantiate DataLoader and CudaDataPrefetcher"""
+    # pin_memory enables faster host to GPU copies
+    on_cuda = device.type == "cuda"
+    dataloader = torch.utils.data.DataLoader(
+        _generate_dataset(num_samples, input_dim),
+        batch_size=batch_size,
+        pin_memory=on_cuda,
+    )
+    if on_cuda:
+        dataloader = CudaDataPrefetcher(dataloader, device)
+    return dataloader
+
+
+class MyTrainUnit(TrainUnit[Batch]):
+    def __init__(
+        self,
+        input_dim: int,
+        device: torch.device,
+        strategy: str,
+        precision: Optional[torch.dtype],
+        lr: float,
+        log_frequency_steps: int,
+    ):
+        super().__init__()
+        # initialize module & optimizer
+        self.module = prepare_module(input_dim, device, strategy, precision)
+        self.optimizer = torch.optim.SGD(self.module.parameters(), lr=lr)
+        self.lr_scheduler = torch.optim.lr_scheduler.ExponentialLR(
+            self.optimizer, gamma=0.9
+        )
+        self.loss_fn = torch.nn.BCEWithLogitsLoss()
+
+        # create an accuracy Metric to compute the accuracy of training
+        self.train_accuracy = BinaryAccuracy(device=device)
+        self.log_frequency_steps = log_frequency_steps
+
+        path = tempfile.mkdtemp()
+        self.tb_logger = TensorBoardLogger(path)
+
+    def train_step(self, state: State, data: Batch) -> None:
+        inputs, targets = data
+        outputs = self.module(inputs)
+        loss = torch.nn.functional.binary_cross_entropy_with_logits(outputs, targets)
+        loss.backward()
+
+        self.optimizer.step()
+        self.optimizer.zero_grad()
+
+        # update metrics & logs
+        self.train_accuracy.update(outputs, targets)
+        progress = state.train_state.progress
+        if (progress.num_steps_completed + 1) % self.log_frequency_steps == 0:
+            acc = self.metric.compute()
+            self.tb_logger.log("loss", loss, progress.num_steps_completed)
+            self.tb_logger.log("accuracy", acc, progress.num_steps_completed)
+
+    def on_train_epoch_end(self, state: State) -> None:
+        # reset the metric every epoch
+        self.train_accuracy.reset()
+
+        # step the learning rate scheduler
+        self.lr_scheduler.step()
+
+    def on_train_end(self, state: State) -> None:
+        self.tb_logger.close()
+
+
+def main(argv: List[str]) -> None:
+    # parse command line arguments
+    args = get_args(argv)
+
+    precision = None
+    if args.precision == "fp16":
+        precision = torch.float16
+    elif args.precision == "bf16":
+        precision = torch.bfloat16
+
+    # seed the RNG for better reproducibility. see docs https://pytorch.org/docs/stable/notes/randomness.html
+    seed(args.seed)
+
+    # device and process group initialization
+    device = init_from_env()
+
+    _logger.info(
+        f"LOCAL_RANK: {os.environ.get('LOCAL_RANK', '0')}\n"
+        f"RANK: {os.environ.get('RANK', '0')}\n"
+        f"GROUP_RANK: {os.environ.get('GROUP_RANK', '0')}\n"
+        f"WORLD_SIZE: {os.environ.get('WORLD_SIZE', '0')}"
+    )
+
+    my_unit = MyTrainUnit(
+        args.input_dim,
+        device,
+        args.strategy,
+        precision,
+        args.lr,
+        args.log_frequency_steps,
+    )
+
+    num_samples = 10240
+    train_dataloader = prepare_dataloader(
+        num_samples, args.input_dim, args.batch_size, device
+    )
+
+    t = Timer()
+    t.start()
+
+    train(my_unit, train_dataloader, max_epochs=args.max_epochs)
+
+    t.stop()
+    print(f"Total time for training {args.max_epochs} epochs: {t.total_time_seconds}")
+
+
+class ValidateAccumGradBatchesAction(argparse.Action):
+    # Validate input to accum_grad_batches
+    def __call__(self, parser, namespace, values, option_string=None):  # pyre-ignore
+        if values < 1:
+            raise ValueError(f"`accum_grad_batches` must be an int >= 1. Got {values}.")
+        setattr(namespace, self.dest, values)
+
+
+def get_args(argv: List[str]) -> Namespace:
+    """Parse command line arguments"""
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--seed", type=int, default=0, help="random seed")
+    parser.add_argument("--input-dim", type=int, default=32, help="input dimension")
+    parser.add_argument("--max-epochs", type=int, default=2, help="training epochs")
+    parser.add_argument("--batch-size", type=int, default=32, help="batch size")
+    parser.add_argument("--lr", type=float, default=0.1, help="learning rate")
+    parser.add_argument(
+        "--log-frequency-steps", type=int, default=10, help="log every n steps"
+    )
+    parser.add_argument(
+        "--precision",
+        type=str,
+        default=None,
+        help="fp16 or bf16",
+        choices=["fp16", "bf16"],
+    )
+    parser.add_argument(
+        "--strategy",
+        type=str,
+        default=None,
+        help="define the training strategy (ddp or fsdp)",
+        choices=["ddp", "fsdp"],
+    )
+    return parser.parse_args(argv)
+
+
+if __name__ == "__main__":
+    main(sys.argv[1:])

--- a/torchtnt/runner/_test_utils.py
+++ b/torchtnt/runner/_test_utils.py
@@ -67,6 +67,36 @@ class DummyTrainUnit(TrainUnit[Batch]):
         return loss, outputs
 
 
+class DummyFitUnit(TrainUnit[Batch], EvalUnit[Batch]):
+    def __init__(self, input_dim: int) -> None:
+        super().__init__()
+        # initialize module, loss_fn, & optimizer
+        self.module = nn.Linear(input_dim, 2)
+        self.loss_fn = nn.CrossEntropyLoss()
+        self.optimizer = torch.optim.SGD(self.module.parameters(), lr=0.01)
+
+    def train_step(
+        self, state: State, data: Batch
+    ) -> Tuple[torch.Tensor, torch.Tensor]:
+        inputs, targets = data
+
+        outputs = self.module(inputs)
+        loss = self.loss_fn(outputs, targets)
+        loss.backward()
+
+        self.optimizer.step()
+        self.optimizer.zero_grad()
+
+        return loss, outputs
+
+    def eval_step(self, state: State, data: Batch) -> Tuple[torch.Tensor, torch.Tensor]:
+        inputs, targets = data
+
+        outputs = self.module(inputs)
+        loss = self.loss_fn(outputs, targets)
+        return loss, outputs
+
+
 def generate_random_dataset(num_samples: int, input_dim: int) -> Dataset[Batch]:
     """Returns a dataset of random inputs and labels for binary classification."""
     data = torch.randn(num_samples, input_dim)

--- a/torchtnt/runner/fit.py
+++ b/torchtnt/runner/fit.py
@@ -1,0 +1,95 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+import logging
+from typing import Iterable, Optional
+
+from torchtnt.runner.progress import Progress
+from torchtnt.runner.state import EntryPoint, PhaseState, State
+from torchtnt.runner.train import _train_epoch_impl
+from torchtnt.runner.unit import EvalUnit, TEvalData, TrainUnit, TTrainData
+from torchtnt.runner.utils import _check_loop_condition, _is_done
+
+logger: logging.Logger = logging.getLogger(__name__)
+
+
+def fit(
+    unit: TrainUnit[TTrainData],
+    train_dataloader: Iterable[TTrainData],
+    eval_dataloader: Iterable[TEvalData],
+    *,
+    max_epochs: Optional[int],
+    max_train_steps_per_epoch: Optional[int] = None,
+    max_eval_steps_per_epoch: Optional[int] = None,
+    evaluate_every_n_steps: Optional[int] = None,
+    evaluate_every_n_epochs: Optional[int] = 1,
+) -> State:
+    """Function that interleaves training & evaluation."""
+    state = State(
+        entry_point=EntryPoint.FIT,
+        train_state=PhaseState(
+            progress=Progress(),
+            dataloader=train_dataloader,
+            max_epochs=max_epochs,
+            max_steps_per_epoch=max_train_steps_per_epoch,
+        ),
+        eval_state=PhaseState(
+            progress=Progress(),
+            dataloader=eval_dataloader,
+            max_steps_per_epoch=max_eval_steps_per_epoch,
+            evaluate_every_n_steps=evaluate_every_n_steps,
+            evaluate_every_n_epochs=evaluate_every_n_epochs,
+        ),
+    )
+    try:
+        _fit_impl(state, unit)
+        return state
+    except Exception as e:
+        # TODO: log for diagnostics
+        logger.info(e)
+        unit.on_exception(state, e)
+        raise e
+
+
+def _fit_impl(
+    state: State,
+    unit: TrainUnit[TTrainData],
+) -> None:
+    # input validation
+    if not isinstance(unit, TrainUnit):
+        raise TypeError("Expected module to implement TrainUnit interface.")
+    if not isinstance(unit, EvalUnit):
+        raise TypeError("Expected module to implement EvalUnit interface.")
+
+    train_state = state.train_state
+    if not train_state:
+        raise RuntimeError("Expected train_state to be initialized")
+    eval_state = state.eval_state
+    if not eval_state:
+        raise RuntimeError("Expected eval_state to be initialized")
+
+    _check_loop_condition("max_epochs", train_state.max_epochs)
+    _check_loop_condition("max_train_steps_per_epoch", train_state.max_steps_per_epoch)
+    _check_loop_condition("max_eval_steps_per_epoch", eval_state.max_steps_per_epoch)
+    _check_loop_condition("evaluate_every_n_steps", eval_state.evaluate_every_n_steps)
+    _check_loop_condition("evaluate_every_n_epochs", eval_state.evaluate_every_n_epochs)
+    logger.info(
+        f"Started fit with max_epochs={train_state.max_epochs}"
+        f"max_train_steps_per_epoch={train_state.max_steps_per_epoch}"
+        f"max_eval_steps_per_epoch={eval_state.max_steps_per_epoch}"
+        f"evaluate_every_n_steps={eval_state.evaluate_every_n_steps}"
+        f"evaluate_every_n_epochs={eval_state.evaluate_every_n_epochs}"
+    )
+
+    unit.on_train_start(state)
+
+    train_state = state.train_state
+    assert train_state is not None
+
+    while not _is_done(train_state.progress, train_state.max_epochs):
+        _train_epoch_impl(state, unit)
+
+    unit.on_train_end(state)

--- a/torchtnt/runner/train.py
+++ b/torchtnt/runner/train.py
@@ -1,0 +1,168 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+import logging
+from typing import Iterable, Optional
+
+import torch
+
+from torchtnt.runner.progress import Progress
+from torchtnt.runner.state import EntryPoint, PhaseState, State
+from torchtnt.runner.unit import TrainUnit, TTrainData
+from torchtnt.runner.utils import (
+    _check_loop_condition,
+    _is_done,
+    _is_epoch_done,
+    _reset_module_training_mode,
+    _set_module_training_mode,
+)
+
+logger: logging.Logger = logging.getLogger(__name__)
+
+# Define training procedures: train() and train_epoch() are exposed as top-level, user-facing functions
+
+
+@torch.enable_grad()
+def train(
+    train_unit: TrainUnit[TTrainData],
+    dataloader: Iterable[TTrainData],
+    *,
+    max_epochs: Optional[int],
+    max_steps_per_epoch: Optional[int] = None,
+) -> State:
+    state = State(
+        entry_point=EntryPoint.TRAIN,
+        train_state=PhaseState(
+            dataloader=dataloader,
+            max_epochs=max_epochs,
+            max_steps_per_epoch=max_steps_per_epoch,
+            progress=Progress(),
+        ),
+    )
+    try:
+        _train_impl(state, train_unit)
+        logger.info("Finished train")
+        return state
+    except Exception as e:
+        # TODO: log for diagnostics
+        logger.info(f"Exception during train\n: {e}")
+        train_unit.on_exception(state, e)
+        raise e
+
+
+def _train_impl(
+    state: State,
+    train_unit: TrainUnit[TTrainData],
+) -> None:
+    train_state = state.train_state
+    if not train_state:
+        raise RuntimeError("Expected train_state to be initialized!")
+
+    max_steps_per_epoch = train_state.max_steps_per_epoch
+    _check_loop_condition("max_steps_per_epoch", train_state.max_steps_per_epoch)
+    max_epochs = train_state.max_epochs
+    _check_loop_condition("max_epochs", train_state.max_epochs)
+    logger.info(
+        f"Started train with max_epochs={max_epochs} and max_steps_per_epoch={max_steps_per_epoch}"
+    )
+
+    # TODO: add profiling & timing
+
+    # Set all modules to train() mode
+    # access modules made available through _AppStateMixin
+    tracked_modules = train_unit.tracked_modules()
+    prior_module_train_states = _set_module_training_mode(tracked_modules, True)
+
+    train_unit.on_train_start(state)
+    while not _is_done(train_state.progress, train_state.max_epochs):
+        _train_epoch_impl(state, train_unit)
+
+    train_unit.on_train_end(state)
+
+    # Reset training mode for modules at the end of the epoch
+    # This ensures that side-effects made by the loop are reset before
+    # returning back to the user
+    _reset_module_training_mode(tracked_modules, prior_module_train_states)
+
+
+@torch.enable_grad()
+def train_epoch(
+    train_unit: TrainUnit[TTrainData],
+    dataloader: Iterable[TTrainData],
+    *,
+    max_steps_per_epoch: Optional[int] = None,
+) -> State:
+    state = State(
+        entry_point=EntryPoint.TRAIN,
+        train_state=PhaseState(
+            dataloader=dataloader,
+            max_epochs=1,
+            max_steps_per_epoch=max_steps_per_epoch,
+            progress=Progress(),
+        ),
+    )
+
+    try:
+        _check_loop_condition("max_steps_per_epoch", max_steps_per_epoch)
+        logger.info(
+            f"Started train_epoch with max_steps_per_epoch={max_steps_per_epoch}"
+        )
+        _train_epoch_impl(
+            state,
+            train_unit,
+        )
+        logger.info("Finished train")
+        return state
+    except Exception as e:
+        # TODO: log for diagnostics
+        logger.info(f"Exception during train_epoch\n: {e}")
+        train_unit.on_exception(state, e)
+        raise e
+
+
+def _train_epoch_impl(state: State, train_unit: TrainUnit[TTrainData]) -> None:
+    logger.info("Started train epoch")
+
+    # Set all modules to train() mode
+    # access modules made available through _AppStateMixin
+    tracked_modules = train_unit.tracked_modules()
+    prior_module_train_states = _set_module_training_mode(tracked_modules, True)
+
+    train_state = state.train_state
+    assert train_state is not None
+
+    # Check the progress to conditionally run this
+    # to avoid running this multiple times
+    # in the case of resuming from a checkpoint mid-epoch
+    if train_state.progress.num_steps_completed_in_epoch == 0:
+        train_unit.on_train_epoch_start(state)
+
+    data_iter = iter(train_state.dataloader)
+
+    while not _is_epoch_done(train_state.progress, train_state.max_steps_per_epoch):
+        try:
+            # TODO: conditionally expose data iterator for use cases that require access during the step
+            batch = next(data_iter)
+            train_state.step_output = train_unit.train_step(state, batch)
+            # clear step_output to avoid retaining extra memory
+            train_state.step_output = None
+            train_state.progress.num_steps_completed_in_epoch += 1
+            train_state.progress.num_steps_completed += 1
+
+        except StopIteration:
+            break
+    train_unit.on_train_epoch_end(state)
+
+    # set progress counters for the next epoch
+    train_state.progress.num_epochs_completed += 1
+    train_state.progress.num_steps_completed_in_epoch = 0
+
+    # Reset training mode for modules at the end of the epoch
+    # This ensures that side-effects made by the loop are reset before
+    # returning back to the user
+    _reset_module_training_mode(tracked_modules, prior_module_train_states)
+
+    logger.info("Ended train epoch")


### PR DESCRIPTION
Summary: Adding an end-to-end example using `TrainUnit`, and the `train` entry point.

Reviewed By: edward-io

Differential Revision: D38608581

