### PR TITLE
Add support for external stopping in loops

### DIFF
--- a/tests/runner/test_evaluate.py
+++ b/tests/runner/test_evaluate.py
@@ -6,10 +6,14 @@
 # LICENSE file in the root directory of this source tree.
 
 import unittest
+from typing import Tuple
 
+import torch
+from torch import nn
 from torchtnt.runner._test_utils import DummyEvalUnit, generate_random_dataloader
-
 from torchtnt.runner.evaluate import evaluate
+from torchtnt.runner.state import State
+from torchtnt.runner.unit import EvalUnit
 
 
 class EvaluateTest(unittest.TestCase):
@@ -64,3 +68,55 @@ class EvaluateTest(unittest.TestCase):
         self.assertEqual(state.eval_state.step_output, None)
 
         self.assertEqual(my_unit.module.training, initial_training_mode)
+
+    def test_evaluate_stop(self) -> None:
+        """
+        Test evaluate entry point with setting state's `stop()` flag
+        """
+        input_dim = 2
+        dataset_len = 10
+        batch_size = 2
+        max_steps_per_epoch = 4
+        steps_before_stopping = 2
+
+        my_unit = StopEvalUnit(
+            input_dim=input_dim, steps_before_stopping=steps_before_stopping
+        )
+        dataloader = generate_random_dataloader(dataset_len, input_dim, batch_size)
+        state = evaluate(my_unit, dataloader, max_steps_per_epoch=max_steps_per_epoch)
+
+        self.assertEqual(state.eval_state.progress.num_epochs_completed, 1)
+        self.assertEqual(state.eval_state.progress.num_steps_completed_in_epoch, 0)
+        self.assertEqual(
+            my_unit.steps_processed, state.eval_state.progress.num_steps_completed
+        )
+        self.assertEqual(my_unit.steps_processed, steps_before_stopping)
+
+
+class StopEvalUnit(EvalUnit[Tuple[torch.Tensor, torch.Tensor]]):
+    def __init__(self, input_dim: int, steps_before_stopping: int) -> None:
+        super().__init__()
+        # initialize module & loss_fn
+        self.module = nn.Linear(input_dim, 2)
+        self.loss_fn = nn.CrossEntropyLoss()
+        self.steps_processed = 0
+        self.steps_before_stopping = steps_before_stopping
+
+    def eval_step(
+        self, state: State, data: Tuple[torch.Tensor, torch.Tensor]
+    ) -> Tuple[torch.Tensor, torch.Tensor]:
+
+        inputs, targets = data
+
+        outputs = self.module(inputs)
+        loss = self.loss_fn(outputs, targets)
+
+        assert state.eval_state
+        if (
+            state.eval_state.progress.num_steps_completed_in_epoch + 1
+            == self.steps_before_stopping
+        ):
+            state.stop()
+
+        self.steps_processed += 1
+        return loss, outputs

--- a/tests/runner/test_predict.py
+++ b/tests/runner/test_predict.py
@@ -6,10 +6,16 @@
 # LICENSE file in the root directory of this source tree.
 
 import unittest
+from typing import Tuple
+
+import torch
+from torch import nn
 
 from torchtnt.runner._test_utils import DummyPredictUnit, generate_random_dataloader
 
 from torchtnt.runner.predict import predict
+from torchtnt.runner.state import State
+from torchtnt.runner.unit import PredictUnit
 
 
 class PredictTest(unittest.TestCase):
@@ -66,3 +72,51 @@ class PredictTest(unittest.TestCase):
         self.assertEqual(state.predict_state.step_output, None)
 
         self.assertEqual(my_unit.module.training, initial_training_mode)
+
+    def test_predict_stop(self) -> None:
+        """
+        Test predict entry point with setting state's `stop()` flag
+        """
+        input_dim = 2
+        dataset_len = 10
+        batch_size = 2
+        max_steps_per_epoch = 4
+        steps_before_stopping = 2
+
+        my_unit = StopPredictUnit(
+            input_dim=input_dim, steps_before_stopping=steps_before_stopping
+        )
+        dataloader = generate_random_dataloader(dataset_len, input_dim, batch_size)
+        state = predict(my_unit, dataloader, max_steps_per_epoch=max_steps_per_epoch)
+
+        self.assertEqual(state.predict_state.progress.num_epochs_completed, 1)
+        self.assertEqual(state.predict_state.progress.num_steps_completed_in_epoch, 0)
+        self.assertEqual(
+            my_unit.steps_processed, state.predict_state.progress.num_steps_completed
+        )
+        self.assertEqual(my_unit.steps_processed, steps_before_stopping)
+
+
+class StopPredictUnit(PredictUnit[Tuple[torch.Tensor, torch.Tensor]]):
+    def __init__(self, input_dim: int, steps_before_stopping: int) -> None:
+        super().__init__()
+        # initialize module
+        self.module = nn.Linear(input_dim, 2)
+        self.steps_processed = 0
+        self.steps_before_stopping = steps_before_stopping
+
+    def predict_step(
+        self, state: State, data: Tuple[torch.Tensor, torch.Tensor]
+    ) -> torch.Tensor:
+        inputs, targets = data
+
+        outputs = self.module(inputs)
+        assert state.predict_state
+        if (
+            state.predict_state.progress.num_steps_completed_in_epoch + 1
+            == self.steps_before_stopping
+        ):
+            state.stop()
+
+        self.steps_processed += 1
+        return outputs

--- a/torchtnt/runner/evaluate.py
+++ b/torchtnt/runner/evaluate.py
@@ -84,7 +84,10 @@ def _evaluate_impl(
 
     data_iter = iter(eval_state.dataloader)
 
-    while not _is_epoch_done(eval_state.progress, eval_state.max_steps_per_epoch):
+    while not (
+        state.should_stop
+        or _is_epoch_done(eval_state.progress, eval_state.max_steps_per_epoch)
+    ):
         try:
             # TODO: conditionally expose data iterator for use cases that require access during the step
             with state.timer.time("eval.data_iter_next"):

--- a/torchtnt/runner/predict.py
+++ b/torchtnt/runner/predict.py
@@ -86,7 +86,10 @@ def _predict_impl(
 
     data_iter = iter(predict_state.dataloader)
 
-    while not _is_epoch_done(predict_state.progress, predict_state.max_steps_per_epoch):
+    while not (
+        state.should_stop
+        or _is_epoch_done(predict_state.progress, predict_state.max_steps_per_epoch)
+    ):
         try:
             # TODO: conditionally expose data iterator for use cases that require access during the step
             with state.timer.time("predict.data_iter_next"):

--- a/torchtnt/runner/state.py
+++ b/torchtnt/runner/state.py
@@ -5,12 +5,15 @@
 # LICENSE file in the root directory of this source tree.
 
 
+import logging
 from dataclasses import dataclass
 from enum import auto, Enum
 from typing import Any, Iterable, Optional
 
 from torchtnt.runner.progress import Progress
 from torchtnt.utils.timer import Timer
+
+_logger: logging.Logger = logging.getLogger(__name__)
 
 
 class EntryPoint(Enum):
@@ -52,3 +55,15 @@ class State:
     train_state: Optional[PhaseState] = None
     eval_state: Optional[PhaseState] = None
     predict_state: Optional[PhaseState] = None
+
+    _should_stop: bool = False
+
+    def stop(self) -> None:
+        """Signal to the loop to end after the current step completes."""
+        _logger.warn("Received signal to stop")
+        self._should_stop = True
+
+    @property
+    def should_stop(self) -> bool:
+        """Read-only property for whether to terminate the loop after the current step completes."""
+        return self._should_stop

--- a/torchtnt/runner/train.py
+++ b/torchtnt/runner/train.py
@@ -85,7 +85,9 @@ def _train_impl(
     with state.timer.time(f"train.{train_unit.__class__.__name__}.on_train_start"):
         train_unit.on_train_start(state)
 
-    while not _is_done(train_state.progress, train_state.max_epochs):
+    while not (
+        state.should_stop or _is_done(train_state.progress, train_state.max_epochs)
+    ):
         _train_epoch_impl(state, train_unit)
 
     with state.timer.time(f"train.{train_unit.__class__.__name__}.on_train_end"):
@@ -163,7 +165,10 @@ def _train_epoch_impl(state: State, train_unit: TrainUnit[TTrainData]) -> None:
 
     data_iter = iter(train_state.dataloader)
 
-    while not _is_epoch_done(train_state.progress, train_state.max_steps_per_epoch):
+    while not (
+        state.should_stop
+        or _is_epoch_done(train_state.progress, train_state.max_steps_per_epoch)
+    ):
         try:
             # TODO: conditionally expose data iterator for use cases that require access during the step
             with state.timer.time("train.data_iter_next"):


### PR DESCRIPTION
Summary:
Currently the loops only stop based on the progress information. This can be limiting in case users want to stop at arbitrary points during the step functions. a common use case is early stopping based on a monitored metric.

This adds a method to the State object to indicate the loops should stop. In distributed training, it's contingent on users to synchronize the decision of whether to call `stop()`.

To help with this, under torchtnt/utils we offer this helper function that can meet this need: https://github.com/pytorch/tnt/blob/0feb0c1a50297dab99729410ec332f964143e1e5/torchtnt/utils/distributed.py#L289-L292

Differential Revision: D39529183

