### PR TITLE
Use warning instead of warn

### DIFF
--- a/torchtnt/runner/state.py
+++ b/torchtnt/runner/state.py
@@ -60,7 +60,7 @@ class State:
 
     def stop(self) -> None:
         """Signal to the loop to end after the current step completes."""
-        _logger.warn("Received signal to stop")
+        _logger.warning("Received signal to stop")
         self._should_stop = True
 
     @property


### PR DESCRIPTION
Summary: `warn` is deprecated in favor of `warning`

Differential Revision: D39585793

