### PR TITLE
Add Callback class and support in `predict` entry point

### DIFF
--- a/torchtnt/runner/callback.py
+++ b/torchtnt/runner/callback.py
@@ -1,0 +1,111 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+import logging
+from typing import Union
+
+from torchtnt.runner.state import State
+from torchtnt.runner.unit import (
+    EvalUnit,
+    PredictUnit,
+    TEvalData,
+    TPredictData,
+    TrainUnit,
+    TTrainData,
+)
+
+logger: logging.Logger = logging.getLogger(__name__)
+
+
+class _OnExceptionMixin:
+    def on_exception(
+        self,
+        state: State,
+        unit: Union[
+            TrainUnit[TTrainData], EvalUnit[TEvalData], PredictUnit[TPredictData]
+        ],
+        exc: BaseException,
+    ) -> None:
+        pass
+
+
+class _NameMixin:
+    @property
+    def name(self) -> str:
+        """Should be a distinct name per instance. This is useful for debugging, profiling, and checkpointing purposes."""
+        return self.__class__.__qualname__
+
+
+class TrainCallback(_OnExceptionMixin, _NameMixin):
+    def on_train_start(self, state: State, unit: TrainUnit[TTrainData]) -> None:
+        pass
+
+    def on_train_epoch_start(self, state: State, unit: TrainUnit[TTrainData]) -> None:
+        pass
+
+    def on_train_step_start(self, state: State, unit: TrainUnit[TTrainData]) -> None:
+        pass
+
+    def on_train_step_end(self, state: State, unit: TrainUnit[TTrainData]) -> None:
+        pass
+
+    def on_train_epoch_end(self, state: State, unit: TrainUnit[TTrainData]) -> None:
+        pass
+
+    def on_train_end(self, state: State, unit: TrainUnit[TTrainData]) -> None:
+        pass
+
+
+class EvalCallback(_OnExceptionMixin, _NameMixin):
+    def on_eval_start(self, state: State, unit: EvalUnit[TEvalData]) -> None:
+        pass
+
+    def on_eval_epoch_start(self, state: State, unit: EvalUnit[TEvalData]) -> None:
+        pass
+
+    def on_eval_step_start(self, state: State, unit: EvalUnit[TEvalData]) -> None:
+        pass
+
+    def on_eval_step_end(self, state: State, unit: EvalUnit[TEvalData]) -> None:
+        pass
+
+    def on_eval_epoch_end(self, state: State, unit: EvalUnit[TEvalData]) -> None:
+        pass
+
+    def on_eval_end(self, state: State, unit: EvalUnit[TEvalData]) -> None:
+        pass
+
+
+class PredictCallback(_OnExceptionMixin, _NameMixin):
+    def on_predict_start(self, state: State, unit: PredictUnit[TPredictData]) -> None:
+        pass
+
+    def on_predict_epoch_start(
+        self, state: State, unit: PredictUnit[TPredictData]
+    ) -> None:
+        pass
+
+    def on_predict_step_start(
+        self, state: State, unit: PredictUnit[TPredictData]
+    ) -> None:
+        pass
+
+    def on_predict_step_end(
+        self, state: State, unit: PredictUnit[TPredictData]
+    ) -> None:
+        pass
+
+    def on_predict_epoch_end(
+        self, state: State, unit: PredictUnit[TPredictData]
+    ) -> None:
+        pass
+
+    def on_predict_end(self, state: State, unit: PredictUnit[TPredictData]) -> None:
+        pass
+
+
+class Callback(TrainCallback, EvalCallback, PredictCallback):
+    pass

--- a/torchtnt/runner/utils.py
+++ b/torchtnt/runner/utils.py
@@ -4,13 +4,15 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
-from typing import Dict, Optional
+import typing
+from typing import Any, Dict, List, Optional, Union
 
 import torch
-
 import torch.nn as nn
 
+from torchtnt.runner.callback import EvalCallback, PredictCallback, TrainCallback
 from torchtnt.runner.progress import Progress
+from torchtnt.runner.state import State
 
 # Helper functions common across the loops
 
@@ -56,6 +58,60 @@ def _reset_module_training_mode(
     for name, module in modules.items():
         if name in prior_modes:
             module.train(prior_modes[name])
+
+
+@typing.overload
+def _run_callback_fn(
+    callbacks: Optional[List[PredictCallback]],
+    fn_name: str,
+    state: State,
+    *args: Any,
+    **kwargs: Any,
+) -> None:
+    ...
+
+
+@typing.overload
+def _run_callback_fn(
+    callbacks: Optional[List[EvalCallback]],
+    fn_name: str,
+    state: State,
+    *args: Any,
+    **kwargs: Any,
+) -> None:
+    ...
+
+
+@typing.overload
+def _run_callback_fn(
+    callbacks: Optional[List[TrainCallback]],
+    fn_name: str,
+    state: State,
+    *args: Any,
+    **kwargs: Any,
+) -> None:
+    ...
+
+
+def _run_callback_fn(
+    callbacks: Union[
+        Optional[List[PredictCallback]],
+        Optional[List[EvalCallback]],
+        Optional[List[TrainCallback]],
+    ],
+    fn_name: str,
+    state: State,
+    *args: Any,
+    **kwargs: Any,
+) -> None:
+    if not callbacks:
+        return
+    for cb in callbacks:
+        fn = getattr(cb, fn_name)
+        if not callable(fn):
+            raise ValueError(f"Invalid callback method name provided: {fn_name}")
+        with state.timer.time(f"callback.{cb.name}.{fn_name}"):
+            fn(state, *args, **kwargs)
 
 
 def log_api_usage(entry_point: str) -> None:


### PR DESCRIPTION
Summary: Add Callback class and integrate it into the `predict` entry point.

Differential Revision: D39532948

