### PR TITLE
Support passing the data iterator directly to the step function

### DIFF
--- a/tests/runner/test_utils.py
+++ b/tests/runner/test_utils.py
@@ -6,10 +6,15 @@
 # LICENSE file in the root directory of this source tree.
 
 import unittest
+from typing import Iterator
 
 from torch import nn
 
-from torchtnt.runner.utils import _reset_module_training_mode, _set_module_training_mode
+from torchtnt.runner.utils import (
+    _reset_module_training_mode,
+    _set_module_training_mode,
+    _step_requires_iterator,
+)
 
 
 class UtilsTest(unittest.TestCase):
@@ -60,3 +65,20 @@ class UtilsTest(unittest.TestCase):
 
         self.assertTrue(module.training)
         self.assertTrue(loss_fn.training)
+
+    def test_step_func_requires_iterator(self) -> None:
+        class Foo:
+            def bar(self) -> None:
+                pass
+
+            def baz(self, data: Iterator[int], b: int, c: str) -> int:
+                return b
+
+        def dummy(a: int, b: str, data: Iterator[str]) -> None:
+            pass
+
+        foo = Foo()
+
+        self.assertFalse(_step_requires_iterator(foo.bar))
+        self.assertTrue(_step_requires_iterator(foo.baz))
+        self.assertTrue(_step_requires_iterator(dummy))


### PR DESCRIPTION
Summary:
Looking for comments. This feels hacky since it checks the signature of the step function to determine what inputs to pass in. The type is a requirement of the unit interface: https://github.com/pytorch/tnt/blob/e03a107ed68691833bd0c123b7606a483edc4bcc/torchtnt/runner/unit.py#L140-L182

This uses https://docs.python.org/3/library/typing.html#typing.get_origin to resolve subscripted types with generics, which is why we compare against `collections.abc.Iterator` vs `typing.Iterator` (suggested by https://stackoverflow.com/questions/53854463/python-3-7-check-if-type-annotation-is-subclass-of-generic)

Reviewed By: daniellepintz

Differential Revision: D39567423

