### PR TITLE
enable purely iteration based training

### DIFF
--- a/torchtnt/runner/evaluate.py
+++ b/torchtnt/runner/evaluate.py
@@ -99,7 +99,7 @@ def _evaluate_impl(
 
     while not (
         state.should_stop
-        or _is_epoch_done(eval_state.progress, eval_state.max_steps_per_epoch)
+        or _is_epoch_done(eval_state.progress, eval_state.max_steps_per_epoch, None)
     ):
         try:
             if not pass_data_iter_to_step:

--- a/torchtnt/runner/fit.py
+++ b/torchtnt/runner/fit.py
@@ -91,7 +91,7 @@ def _fit_impl(
     with state.timer.time(f"train.{unit.__class__.__name__}.on_train_start"):
         unit.on_train_start(state)
 
-    while not _is_done(train_state.progress, train_state.max_epochs):
+    while not _is_done(train_state.progress, train_state.max_epochs, None):
         _train_epoch_impl(state, unit, [])
 
     with state.timer.time(f"train.{unit.__class__.__name__}.on_train_end"):

--- a/torchtnt/runner/predict.py
+++ b/torchtnt/runner/predict.py
@@ -101,7 +101,9 @@ def _predict_impl(
 
     while not (
         state.should_stop
-        or _is_epoch_done(predict_state.progress, predict_state.max_steps_per_epoch)
+        or _is_epoch_done(
+            predict_state.progress, predict_state.max_steps_per_epoch, None
+        )
     ):
         try:
             if not pass_data_iter_to_step:

--- a/torchtnt/runner/train.py
+++ b/torchtnt/runner/train.py
@@ -89,7 +89,8 @@ def _train_impl(
     _run_callback_fn(callbacks, "on_train_start", state, train_unit)
 
     while not (
-        state.should_stop or _is_done(train_state.progress, train_state.max_epochs)
+        state.should_stop
+        or _is_done(train_state.progress, train_state.max_epochs, None)
     ):
         _train_epoch_impl(state, train_unit, callbacks)
 
@@ -184,7 +185,7 @@ def _train_epoch_impl(
 
     while not (
         state.should_stop
-        or _is_epoch_done(train_state.progress, train_state.max_steps_per_epoch)
+        or _is_epoch_done(train_state.progress, train_state.max_steps_per_epoch, None)
     ):
         try:
             if not pass_data_iter_to_step:

--- a/torchtnt/runner/utils.py
+++ b/torchtnt/runner/utils.py
@@ -31,18 +31,21 @@ def _check_loop_condition(name: str, val: Optional[int]) -> None:
         )
 
 
-def _is_done(progress: Progress, max_epochs: Optional[int]) -> bool:
-    if max_epochs is None:
-        # infinite training
-        return False
-    return progress.num_epochs_completed >= max_epochs
+def _is_done(
+    progress: Progress, max_epochs: Optional[int], max_steps: Optional[int]
+) -> bool:
+    return (max_steps is not None and progress.num_steps_completed >= max_steps) or (
+        max_epochs is not None and progress.num_epochs_completed >= max_epochs
+    )
 
 
-def _is_epoch_done(progress: Progress, max_steps_per_epoch: Optional[int]) -> bool:
-    # No limit specified, so continue until the data iterator is exhausted
-    if max_steps_per_epoch is None:
-        return False
-    return progress.num_steps_completed_in_epoch >= max_steps_per_epoch
+def _is_epoch_done(
+    progress: Progress, max_steps_per_epoch: Optional[int], max_steps: Optional[int]
+) -> bool:
+    return (max_steps is not None and progress.num_steps_completed >= max_steps) or (
+        max_steps_per_epoch is not None
+        and progress.num_steps_completed_in_epoch >= max_steps_per_epoch
+    )
 
 
 def _set_module_training_mode(


### PR DESCRIPTION
Summary: Prepare for `max_steps` as an option to `train` and `fit` for users to bound the training loop. this can be used in conjunction with `max_epochs` if desired, or independently.

Reviewed By: daniellepintz

Differential Revision: D39567903

