### PR TITLE
enable purely iteration based training

### DIFF
--- a/torchtnt/runner/evaluate.py
+++ b/torchtnt/runner/evaluate.py
@@ -99,7 +99,9 @@ def _evaluate_impl(
 
     while not (
         state.should_stop
-        or _is_epoch_done(eval_state.progress, eval_state.max_steps_per_epoch, None)
+        or _is_epoch_done(
+            eval_state.progress, eval_state.max_steps_per_epoch, eval_state.max_steps
+        )
     ):
         try:
             if not pass_data_iter_to_step:

--- a/torchtnt/runner/fit.py
+++ b/torchtnt/runner/fit.py
@@ -23,6 +23,7 @@ def fit(
     eval_dataloader: Iterable[TEvalData],
     *,
     max_epochs: Optional[int],
+    max_steps: Optional[int] = None,
     max_train_steps_per_epoch: Optional[int] = None,
     max_eval_steps_per_epoch: Optional[int] = None,
     evaluate_every_n_steps: Optional[int] = None,
@@ -37,6 +38,7 @@ def fit(
             progress=Progress(),
             dataloader=train_dataloader,
             max_epochs=max_epochs,
+            max_steps=max_steps,
             max_steps_per_epoch=max_train_steps_per_epoch,
         ),
         eval_state=PhaseState(
@@ -76,12 +78,14 @@ def _fit_impl(
         raise RuntimeError("Expected eval_state to be initialized")
 
     _check_loop_condition("max_epochs", train_state.max_epochs)
+    _check_loop_condition("max_steps", train_state.max_steps)
     _check_loop_condition("max_train_steps_per_epoch", train_state.max_steps_per_epoch)
     _check_loop_condition("max_eval_steps_per_epoch", eval_state.max_steps_per_epoch)
     _check_loop_condition("evaluate_every_n_steps", eval_state.evaluate_every_n_steps)
     _check_loop_condition("evaluate_every_n_epochs", eval_state.evaluate_every_n_epochs)
     logger.info(
         f"Started fit with max_epochs={train_state.max_epochs}"
+        f"max_steps={train_state.max_steps}"
         f"max_train_steps_per_epoch={train_state.max_steps_per_epoch}"
         f"max_eval_steps_per_epoch={eval_state.max_steps_per_epoch}"
         f"evaluate_every_n_steps={eval_state.evaluate_every_n_steps}"
@@ -93,7 +97,7 @@ def _fit_impl(
 
     while not (
         state.should_stop
-        or _is_done(train_state.progress, train_state.max_epochs, None)
+        or _is_done(train_state.progress, train_state.max_epochs, train_state.max_steps)
     ):
         _train_epoch_impl(state, unit, [])
 

--- a/torchtnt/runner/predict.py
+++ b/torchtnt/runner/predict.py
@@ -102,7 +102,9 @@ def _predict_impl(
     while not (
         state.should_stop
         or _is_epoch_done(
-            predict_state.progress, predict_state.max_steps_per_epoch, None
+            predict_state.progress,
+            predict_state.max_steps_per_epoch,
+            predict_state.max_steps,
         )
     ):
         try:

--- a/torchtnt/runner/state.py
+++ b/torchtnt/runner/state.py
@@ -33,6 +33,7 @@ class PhaseState:
     # pyre-ignore: Invalid type variable [34]
     dataloader: Iterable[Any]
     max_epochs: Optional[int] = None  # used only for train
+    max_steps: Optional[int] = None  # used only for train
     max_steps_per_epoch: Optional[int] = None
     evaluate_every_n_steps: Optional[int] = None  # used only for evaluate
     evaluate_every_n_epochs: Optional[int] = None  # used only for evaluate


### PR DESCRIPTION
Summary: Add `max_steps` as an option to `train` and `fit` for users to bound the training loop. this can be used in conjunction with `max_epochs` if desired, or independently.

Differential Revision: D39593500

