### PR TITLE
Refactor callback interfaces

### DIFF
--- a/tests/runner/test_utils.py
+++ b/tests/runner/test_utils.py
@@ -10,7 +10,7 @@ from typing import Iterator, Union
 from unittest.mock import MagicMock
 
 from torch import nn
-from torchtnt.runner.callback import TrainCallback
+from torchtnt.runner.callback import Callback
 from torchtnt.runner.progress import Progress
 from torchtnt.runner.state import EntryPoint, State
 from torchtnt.runner.unit import (
@@ -83,9 +83,9 @@ class UtilsTest(unittest.TestCase):
 
     def test_run_callback_fn_hooks(self) -> None:
         """
-        Test _run_callback_fn with all of the hooks on TrainCallback
+        Test _run_callback_fn with all of the hooks on Callback
         """
-        callback = DummyTrainCallback("train")
+        callback = DummyCallback("train")
         train_unit = MagicMock()
         timer = Timer()
         dummy_train_state = State(
@@ -104,15 +104,13 @@ class UtilsTest(unittest.TestCase):
         )
         self.assertEqual(callback.dummy_data, "on_exception")
         self.assertTrue(
-            "callback.DummyTrainCallback.on_exception"
-            in timer.recorded_durations.keys()
+            "callback.DummyCallback.on_exception" in timer.recorded_durations.keys()
         )
 
         _run_callback_fn([callback], "on_train_start", dummy_train_state, train_unit)
         self.assertEqual(callback.dummy_data, "on_train_start")
         self.assertTrue(
-            "callback.DummyTrainCallback.on_train_start"
-            in timer.recorded_durations.keys()
+            "callback.DummyCallback.on_train_start" in timer.recorded_durations.keys()
         )
 
         _run_callback_fn(
@@ -120,7 +118,7 @@ class UtilsTest(unittest.TestCase):
         )
         self.assertEqual(callback.dummy_data, "on_train_epoch_start")
         self.assertTrue(
-            "callback.DummyTrainCallback.on_train_epoch_start"
+            "callback.DummyCallback.on_train_epoch_start"
             in timer.recorded_durations.keys()
         )
 
@@ -129,14 +127,14 @@ class UtilsTest(unittest.TestCase):
         )
         self.assertEqual(callback.dummy_data, "on_train_step_start")
         self.assertTrue(
-            "callback.DummyTrainCallback.on_train_step_start"
+            "callback.DummyCallback.on_train_step_start"
             in timer.recorded_durations.keys()
         )
 
         _run_callback_fn([callback], "on_train_step_end", dummy_train_state, train_unit)
         self.assertEqual(callback.dummy_data, "on_train_step_end")
         self.assertTrue(
-            "callback.DummyTrainCallback.on_train_step_end"
+            "callback.DummyCallback.on_train_step_end"
             in timer.recorded_durations.keys()
         )
 
@@ -145,22 +143,21 @@ class UtilsTest(unittest.TestCase):
         )
         self.assertEqual(callback.dummy_data, "on_train_epoch_end")
         self.assertTrue(
-            "callback.DummyTrainCallback.on_train_epoch_end"
+            "callback.DummyCallback.on_train_epoch_end"
             in timer.recorded_durations.keys()
         )
 
         _run_callback_fn([callback], "on_train_end", dummy_train_state, train_unit)
         self.assertEqual(callback.dummy_data, "on_train_end")
         self.assertTrue(
-            "callback.DummyTrainCallback.on_train_end"
-            in timer.recorded_durations.keys()
+            "callback.DummyCallback.on_train_end" in timer.recorded_durations.keys()
         )
 
     def test_run_callback_fn_exception(self) -> None:
         """
         Test _run_callback_fn exception handling
         """
-        callback = DummyTrainCallback("train")
+        callback = DummyCallback("train")
         train_unit = MagicMock()
         dummy_train_state = MagicMock()
 
@@ -228,7 +225,7 @@ class UtilsTest(unittest.TestCase):
         self.assertFalse(_is_epoch_done(p, max_steps_per_epoch=None, max_steps=None))
 
 
-class DummyTrainCallback(TrainCallback):
+class DummyCallback(Callback):
     def __init__(self, dummy_data: str) -> None:
         self.dummy_data = dummy_data
         self.dummy_attr = 1

--- a/torchtnt/runner/callback.py
+++ b/torchtnt/runner/callback.py
@@ -39,7 +39,7 @@ class _NameMixin:
         return self.__class__.__qualname__
 
 
-class TrainCallback(_OnExceptionMixin, _NameMixin):
+class _TrainCallback:
     def on_train_start(self, state: State, unit: TrainUnit[TTrainData]) -> None:
         pass
 
@@ -59,7 +59,7 @@ class TrainCallback(_OnExceptionMixin, _NameMixin):
         pass
 
 
-class EvalCallback(_OnExceptionMixin, _NameMixin):
+class _EvalCallback:
     def on_eval_start(self, state: State, unit: EvalUnit[TEvalData]) -> None:
         pass
 
@@ -79,7 +79,7 @@ class EvalCallback(_OnExceptionMixin, _NameMixin):
         pass
 
 
-class PredictCallback(_OnExceptionMixin, _NameMixin):
+class _PredictCallback:
     def on_predict_start(self, state: State, unit: PredictUnit[TPredictData]) -> None:
         pass
 
@@ -107,5 +107,7 @@ class PredictCallback(_OnExceptionMixin, _NameMixin):
         pass
 
 
-class Callback(TrainCallback, EvalCallback, PredictCallback):
+class Callback(
+    _TrainCallback, _EvalCallback, _PredictCallback, _OnExceptionMixin, _NameMixin
+):
     pass

--- a/torchtnt/runner/evaluate.py
+++ b/torchtnt/runner/evaluate.py
@@ -8,7 +8,7 @@ import logging
 from typing import Iterable, List, Optional
 
 import torch
-from torchtnt.runner.callback import EvalCallback
+from torchtnt.runner.callback import Callback
 
 from torchtnt.runner.progress import Progress
 from torchtnt.runner.state import EntryPoint, PhaseState, State
@@ -30,7 +30,7 @@ logger: logging.Logger = logging.getLogger(__name__)
 def evaluate(
     eval_unit: EvalUnit[TEvalData],
     dataloader: Iterable[TEvalData],
-    callbacks: Optional[List[EvalCallback]] = None,
+    callbacks: Optional[List[Callback]] = None,
     *,
     max_steps_per_epoch: Optional[int] = None,
 ) -> State:
@@ -63,7 +63,7 @@ def evaluate(
 def _evaluate_impl(
     state: State,
     eval_unit: EvalUnit[TEvalData],
-    callbacks: List[EvalCallback],
+    callbacks: List[Callback],
 ) -> None:
     # input validation
     eval_state = state.eval_state

--- a/torchtnt/runner/predict.py
+++ b/torchtnt/runner/predict.py
@@ -8,7 +8,7 @@ import logging
 from typing import Iterable, List, Optional
 
 import torch
-from torchtnt.runner.callback import PredictCallback
+from torchtnt.runner.callback import Callback
 
 from torchtnt.runner.progress import Progress
 from torchtnt.runner.state import EntryPoint, PhaseState, State
@@ -30,7 +30,7 @@ logger: logging.Logger = logging.getLogger(__name__)
 def predict(
     predict_unit: PredictUnit[TPredictData],
     dataloader: Iterable[TPredictData],
-    callbacks: Optional[List[PredictCallback]] = None,
+    callbacks: Optional[List[Callback]] = None,
     *,
     max_steps_per_epoch: Optional[int] = None,
 ) -> State:
@@ -63,7 +63,7 @@ def predict(
 def _predict_impl(
     state: State,
     predict_unit: PredictUnit[TPredictData],
-    callbacks: List[PredictCallback],
+    callbacks: List[Callback],
 ) -> None:
     # input validation
     predict_state = state.predict_state

--- a/torchtnt/runner/train.py
+++ b/torchtnt/runner/train.py
@@ -8,7 +8,7 @@ import logging
 from typing import Iterable, List, Optional
 
 import torch
-from torchtnt.runner.callback import TrainCallback
+from torchtnt.runner.callback import Callback
 from torchtnt.runner.evaluate import _evaluate_impl
 from torchtnt.runner.progress import Progress
 from torchtnt.runner.state import EntryPoint, PhaseState, State
@@ -32,7 +32,7 @@ logger: logging.Logger = logging.getLogger(__name__)
 def train(
     train_unit: TrainUnit[TTrainData],
     dataloader: Iterable[TTrainData],
-    callbacks: Optional[List[TrainCallback]] = None,
+    callbacks: Optional[List[Callback]] = None,
     *,
     max_epochs: Optional[int],
     max_steps: Optional[int] = None,
@@ -67,7 +67,7 @@ def train(
 def _train_impl(
     state: State,
     train_unit: TrainUnit[TTrainData],
-    callbacks: List[TrainCallback],
+    callbacks: List[Callback],
 ) -> None:
     train_state = state.train_state
     if not train_state:
@@ -113,7 +113,7 @@ def _train_impl(
 def train_epoch(
     train_unit: TrainUnit[TTrainData],
     dataloader: Iterable[TTrainData],
-    callbacks: Optional[List[TrainCallback]] = None,
+    callbacks: Optional[List[Callback]] = None,
     *,
     max_steps_per_epoch: Optional[int] = None,
 ) -> State:
@@ -154,7 +154,7 @@ def train_epoch(
 def _train_epoch_impl(
     state: State,
     train_unit: TrainUnit[TTrainData],
-    callbacks: List[TrainCallback],
+    callbacks: List[Callback],
 ) -> None:
     logger.info("Started train epoch")
 
@@ -221,7 +221,6 @@ def _train_epoch_impl(
                     state,
                     # pyre-ignore: Incompatible parameter type [6]
                     train_unit,
-                    # pyre-ignore: Incompatible parameter type [6]
                     callbacks,
                 )
 
@@ -243,7 +242,6 @@ def _train_epoch_impl(
             state,
             # pyre-ignore: Incompatible parameter type [6]
             train_unit,
-            # pyre-ignore: Incompatible parameter type [6]
             callbacks,
         )
 

--- a/torchtnt/runner/utils.py
+++ b/torchtnt/runner/utils.py
@@ -7,19 +7,13 @@
 import collections
 import inspect
 import logging
-import typing
-from typing import Any, Callable, Dict, List, Optional, Union
+from typing import Any, Callable, Dict, List, Optional
 
 import torch
 import torch.nn as nn
 import typing_extensions
 
-from torchtnt.runner.callback import (
-    Callback,
-    EvalCallback,
-    PredictCallback,
-    TrainCallback,
-)
+from torchtnt.runner.callback import Callback
 from torchtnt.runner.progress import Progress
 from torchtnt.runner.state import State
 
@@ -75,57 +69,8 @@ def _reset_module_training_mode(
             module.train(prior_modes[name])
 
 
-@typing.overload
-def _run_callback_fn(
-    callbacks: List[TrainCallback],
-    fn_name: str,
-    state: State,
-    *args: Any,
-    **kwargs: Any,
-) -> None:
-    ...
-
-
-@typing.overload
-def _run_callback_fn(
-    callbacks: List[EvalCallback],
-    fn_name: str,
-    state: State,
-    *args: Any,
-    **kwargs: Any,
-) -> None:
-    ...
-
-
-@typing.overload
-def _run_callback_fn(
-    callbacks: List[PredictCallback],
-    fn_name: str,
-    state: State,
-    *args: Any,
-    **kwargs: Any,
-) -> None:
-    ...
-
-
-@typing.overload
 def _run_callback_fn(
     callbacks: List[Callback],
-    fn_name: str,
-    state: State,
-    *args: Any,
-    **kwargs: Any,
-) -> None:
-    ...
-
-
-def _run_callback_fn(
-    callbacks: Union[
-        List[TrainCallback],
-        List[EvalCallback],
-        List[PredictCallback],
-        List[Callback],
-    ],
     fn_name: str,
     state: State,
     *args: Any,


### PR DESCRIPTION
Summary:
Supporting `fit` is at odds with the splitting up of callbacks by train/eval/predict. in the current codebase, users might implement a TrainCallback, which works fine with `train`, but they would see a typing error trying to use that same class with `fit` . making this usable with `fit` as-is would require changes like the following:
```
def fit(unit, train_callbacks: List[TrainCallback], eval_callbacks: List[EvalCallback], ...)
```
as an example, if one wanted to use the pytorch profiler in this case:
```
fit(unit, train_callbacks=[PyTorchProfiler(...)], eval_callbacks=[PyTorchProfiler(...)], ...)
```
which is not user friendly

as a result, we prefer collapsing down to a single Callback class extension point, so users can simply do this everywhere without worrying about types/what to extend or implement
```
callbacks = [...]
train(train_unit, callbacks=callbacks)
evaluate(eval_unit, callbacks=callbacks)
predict(eval, unit, callbacks=callbacks)
fit(eval, unit, callbacks=callbacks)
```

Reviewed By: daniellepintz

Differential Revision: D39978073

