### PR TITLE
Warn if no steps run during epoch

### DIFF
--- a/torchtnt/runner/evaluate.py
+++ b/torchtnt/runner/evaluate.py
@@ -96,6 +96,7 @@ def _evaluate_impl(
 
     # pyre-ignore[6]: Incompatible parameter type
     pass_data_iter_to_step = _step_requires_iterator(eval_unit.eval_step)
+    prev_steps_in_epoch = eval_state.progress.num_steps_completed_in_epoch
 
     while not (
         state.should_stop
@@ -118,6 +119,14 @@ def _evaluate_impl(
             eval_state.progress.num_steps_completed += 1
         except StopIteration:
             break
+
+    # Possibly warn about an empty dataloader
+    any_steps_completed = (
+        abs(eval_state.progress.num_steps_completed_in_epoch - prev_steps_in_epoch) == 0
+    )
+    if not any_steps_completed:
+        logger.warning("No steps completed during evaluate epoch!")
+
     with state.timer.time(f"eval.{eval_unit.__class__.__name__}.on_eval_epoch_end"):
         eval_unit.on_eval_epoch_end(state)
     _run_callback_fn(callbacks, "on_eval_epoch_end", state, eval_unit)

--- a/torchtnt/runner/train.py
+++ b/torchtnt/runner/train.py
@@ -188,6 +188,7 @@ def _train_epoch_impl(
 
     # pyre-ignore[6]: Incompatible parameter type
     pass_data_iter_to_step = _step_requires_iterator(train_unit.train_step)
+    prev_steps_in_epoch = train_state.progress.num_steps_completed_in_epoch
 
     while not (
         state.should_stop
@@ -227,6 +228,15 @@ def _train_epoch_impl(
 
         except StopIteration:
             break
+
+    # Possibly warn about an empty dataloader
+    any_steps_completed = (
+        abs(train_state.progress.num_steps_completed_in_epoch - prev_steps_in_epoch)
+        == 0
+    )
+    if not any_steps_completed:
+        logger.warning("No steps completed during train epoch!")
+
     with state.timer.time(f"train.{train_unit.__class__.__name__}.on_train_epoch_end"):
         train_unit.on_train_epoch_end(state)
     _run_callback_fn(callbacks, "on_train_epoch_end", state, train_unit)


### PR DESCRIPTION
Summary:
This adds a warning if no steps were completed during the epoch. This is to help users in case.

This may happen if users pass in an empty dataloader, or if a user unknowingly restores their dataloader state from a previously exhausted dataloader.

Since there isn't one way of pre-determining the dataloader's length without iterating over all the elements, we add a warning to the logs to make debugging this case a little bit easier.

Reviewed By: daniellepintz

Differential Revision: D39913910

