### PR TITLE
Make progress properties read-only

### DIFF
--- a/torchtnt/runner/evaluate.py
+++ b/torchtnt/runner/evaluate.py
@@ -115,8 +115,7 @@ def _evaluate_impl(
             _run_callback_fn(callbacks, "on_eval_step_end", state, eval_unit)
             # clear step_output to avoid retaining extra memory
             eval_state.step_output = None
-            eval_state.progress.num_steps_completed_in_epoch += 1
-            eval_state.progress.num_steps_completed += 1
+            eval_state.progress.increment_step()
         except StopIteration:
             break
 
@@ -132,8 +131,7 @@ def _evaluate_impl(
     _run_callback_fn(callbacks, "on_eval_epoch_end", state, eval_unit)
 
     # set progress counters for the next epoch
-    eval_state.progress.num_epochs_completed += 1
-    eval_state.progress.num_steps_completed_in_epoch = 0
+    eval_state.progress.increment_epoch()
 
     with state.timer.time(f"eval.{eval_unit.__class__.__name__}.on_eval_end"):
         eval_unit.on_eval_end(state)

--- a/torchtnt/runner/predict.py
+++ b/torchtnt/runner/predict.py
@@ -123,8 +123,7 @@ def _predict_impl(
 
             # clear step_output to avoid retaining extra memory
             predict_state.step_output = None
-            predict_state.progress.num_steps_completed_in_epoch += 1
-            predict_state.progress.num_steps_completed += 1
+            predict_state.progress.increment_step()
         except StopIteration:
             break
 
@@ -143,8 +142,7 @@ def _predict_impl(
     _run_callback_fn(callbacks, "on_predict_epoch_end", state, predict_unit)
 
     # set progress counters for the next epoch
-    predict_state.progress.num_epochs_completed += 1
-    predict_state.progress.num_steps_completed_in_epoch = 0
+    predict_state.progress.increment_epoch()
 
     with state.timer.time(f"predict.{predict_unit.__class__.__name__}.on_predict_end"):
         predict_unit.on_predict_end(state)

--- a/torchtnt/runner/progress.py
+++ b/torchtnt/runner/progress.py
@@ -4,20 +4,50 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
-from dataclasses import asdict, dataclass
 from typing import Any, Dict
 
 
-@dataclass
 class Progress:
-    """Use a dataclass for typed access to fields and to add state_dict/load_state_dict for convenience for checkpointing."""
+    """Class to track progress during the loop. Includes state_dict/load_state_dict for convenience for checkpointing."""
 
-    num_epochs_completed: int = 0
-    num_steps_completed: int = 0
-    num_steps_completed_in_epoch: int = 0
+    def __init__(
+        self,
+        num_epochs_completed: int = 0,
+        num_steps_completed: int = 0,
+        num_steps_completed_in_epoch: int = 0,
+    ) -> None:
+        self._num_epochs_completed: int = num_epochs_completed
+        self._num_steps_completed: int = num_steps_completed
+        self._num_steps_completed_in_epoch: int = num_steps_completed_in_epoch
+
+    @property
+    def num_epochs_completed(self) -> int:
+        return self._num_epochs_completed
+
+    @property
+    def num_steps_completed(self) -> int:
+        return self._num_steps_completed
+
+    @property
+    def num_steps_completed_in_epoch(self) -> int:
+        return self._num_steps_completed_in_epoch
+
+    def increment_step(self) -> None:
+        self._num_steps_completed += 1
+        self._num_steps_completed_in_epoch += 1
+
+    def increment_epoch(self) -> None:
+        self._num_epochs_completed += 1
+        self._num_steps_completed_in_epoch = 0
 
     def state_dict(self) -> Dict[str, Any]:
-        return asdict(self)
+        return {
+            "num_epochs_completed": self._num_epochs_completed,
+            "num_steps_completed": self._num_steps_completed,
+            "num_steps_completed_in_epoch": self._num_steps_completed_in_epoch,
+        }
 
     def load_state_dict(self, state_dict: Dict[str, Any]) -> None:
-        self.__dict__.update(state_dict)
+        self._num_epochs_completed = state_dict["num_epochs_completed"]
+        self._num_steps_completed = state_dict["num_steps_completed"]
+        self._num_steps_completed_in_epoch = state_dict["num_steps_completed_in_epoch"]

--- a/torchtnt/runner/train.py
+++ b/torchtnt/runner/train.py
@@ -209,8 +209,7 @@ def _train_epoch_impl(
 
             # clear step_output to avoid retaining extra memory
             train_state.step_output = None
-            train_state.progress.num_steps_completed_in_epoch += 1
-            train_state.progress.num_steps_completed += 1
+            train_state.progress.increment_step()
 
             if (
                 evaluate_every_n_steps
@@ -241,8 +240,7 @@ def _train_epoch_impl(
     _run_callback_fn(callbacks, "on_train_epoch_end", state, train_unit)
 
     # set progress counters for the next epoch
-    train_state.progress.num_epochs_completed += 1
-    train_state.progress.num_steps_completed_in_epoch = 0
+    train_state.progress.increment_epoch()
 
     if (
         evaluate_every_n_epochs


### PR DESCRIPTION
Summary: Since the progress is available as part of the State, which is available to callers, we want to provide read-only access to these fields to make it clear that only the loop is expected to update these values

Differential Revision: D39981965

