### PR TITLE
rename MultiDataloader -> MultiDataLoader

### DIFF
--- a/tests/data/test_multi_dataloader.py
+++ b/tests/data/test_multi_dataloader.py
@@ -22,7 +22,7 @@ from torchtnt.data.iterators import (
     RoundRobin,
     StoppingMechanism,
 )
-from torchtnt.data.multi_dataloader import MultiDataloader
+from torchtnt.data.multi_dataloader import MultiDataLoader
 
 
 class RandomDataset(Dataset[torch.Tensor]):
@@ -71,7 +71,7 @@ class CustomRandomIterator(MultiIterator):
             return self.__next__()
 
 
-class TestMultiDataloader(unittest.TestCase):
+class TestMultiDataLoader(unittest.TestCase):
     def test_round_robin_smallest_dataset_exhausted(self) -> None:
         dataloader_1 = DataLoader(RandomDataset(32, 8), batch_size=8)
         dataloader_2 = DataLoader(RandomDataset(32, 16), batch_size=8)
@@ -82,7 +82,7 @@ class TestMultiDataloader(unittest.TestCase):
             stopping_mechanism=StoppingMechanism.SMALLEST_DATASET_EXHAUSTED
         )
         multi_dataloader = iter(
-            MultiDataloader(
+            MultiDataLoader(
                 individual_dataloaders,
                 round_robin,
             )
@@ -110,7 +110,7 @@ class TestMultiDataloader(unittest.TestCase):
 
         round_robin = RoundRobin(iteration_order=["2", "1"])
         multi_dataloader = iter(
-            MultiDataloader(
+            MultiDataLoader(
                 individual_dataloaders,
                 round_robin,
             )
@@ -138,7 +138,7 @@ class TestMultiDataloader(unittest.TestCase):
         all_dataset_batches = AllDatasetBatches()
 
         multi_dataloader = iter(
-            MultiDataloader(
+            MultiDataLoader(
                 individual_dataloaders,
                 all_dataset_batches,
             )
@@ -169,7 +169,7 @@ class TestMultiDataloader(unittest.TestCase):
         )
 
         multi_dataloader = iter(
-            MultiDataloader(
+            MultiDataLoader(
                 individual_dataloaders,
                 all_dataset_batches,
             )
@@ -199,7 +199,7 @@ class TestMultiDataloader(unittest.TestCase):
             StoppingMechanism.SMALLEST_DATASET_EXHAUSTED
         )
         multi_dataloader = iter(
-            MultiDataloader(
+            MultiDataLoader(
                 individual_dataloaders,
                 all_dataset_batches,
             )
@@ -221,7 +221,7 @@ class TestMultiDataloader(unittest.TestCase):
         individual_dataloaders = {"1": dataloader_1, "2": dataloader_2}
 
         multi_dataloader = iter(
-            MultiDataloader(
+            MultiDataLoader(
                 individual_dataloaders, DataIterationStrategy(), CustomRandomIterator
             )
         )
@@ -242,7 +242,7 @@ class TestMultiDataloader(unittest.TestCase):
         individual_dataloaders = {"1": dataloader_1, "2": dataloader_2}
 
         multi_dataloader = iter(
-            MultiDataloader(
+            MultiDataLoader(
                 individual_dataloaders,
                 RandomizedBatchSampler(
                     weights={"1": 1, "2": 100},
@@ -264,7 +264,7 @@ class TestMultiDataloader(unittest.TestCase):
         individual_dataloaders = {"1": dataloader_1, "2": dataloader_2}
 
         multi_dataloader = iter(
-            MultiDataloader(
+            MultiDataLoader(
                 individual_dataloaders,
                 RandomizedBatchSampler(
                     weights={"1": 1, "2": 100},
@@ -284,7 +284,7 @@ class TestMultiDataloader(unittest.TestCase):
         # Now ensure that, without the `ignore_empty_data` flag, an exception is raised.
         with self.assertRaises(ValueError):
             individual_dataloaders = {"1": dataloader_1, "2": dataloader_2}
-            MultiDataloader(
+            MultiDataLoader(
                 individual_dataloaders,
                 RandomizedBatchSampler(weights={"1": 1, "2": 100}),
             )
@@ -295,7 +295,7 @@ class TestMultiDataloader(unittest.TestCase):
 
         individual_dataloaders = {"1": dataloader_1, "2": dataloader_2}
 
-        multi_dataloader = MultiDataloader(
+        multi_dataloader = MultiDataLoader(
             individual_dataloaders,
             RandomizedBatchSampler(
                 weights={"1": 1, "2": 100},
@@ -321,7 +321,7 @@ class TestMultiDataloader(unittest.TestCase):
 
         individual_dataloaders = {"1": dataloader_1, "2": dataloader_2}
 
-        multi_dataloader = MultiDataloader(
+        multi_dataloader = MultiDataLoader(
             individual_dataloaders,
             RandomizedBatchSampler(
                 weights={"1": 1, "2": 100},
@@ -347,7 +347,7 @@ class TestMultiDataloader(unittest.TestCase):
         individual_dataloaders = {"1": dataloader_1, "2": dataloader_2}
 
         multi_dataloader = iter(
-            MultiDataloader(
+            MultiDataLoader(
                 individual_dataloaders,
                 RandomizedBatchSampler(
                     weights={"1": 100, "2": 1},
@@ -373,7 +373,7 @@ class TestMultiDataloader(unittest.TestCase):
         in_order = InOrder()
 
         multi_dataloader = iter(
-            MultiDataloader(
+            MultiDataLoader(
                 individual_dataloaders,
                 in_order,
             )
@@ -401,7 +401,7 @@ class TestMultiDataloader(unittest.TestCase):
         in_order = InOrder(iteration_order=["2", "1", "2"])
 
         multi_dataloader = iter(
-            MultiDataloader(
+            MultiDataLoader(
                 individual_dataloaders,
                 in_order,
             )

--- a/torchtnt/data/__init__.py
+++ b/torchtnt/data/__init__.py
@@ -14,7 +14,7 @@ from .iterators import (
     RandomizedBatchSamplerIterator,
     RoundRobinIterator,
 )
-from .multi_dataloader import MultiDataloader
+from .multi_dataloader import MultiDataLoader
 
 __all__ = [
     "AllDatasetBatchesIterator",
@@ -22,7 +22,7 @@ __all__ = [
     "DataIterationStrategy",
     "DataIterationStrategyRegistry",
     "InOrderIterator",
-    "MultiDataloader",
+    "MultiDataLoader",
     "MultiIterator",
     "RandomizedBatchSamplerIterator",
     "RoundRobinIterator",

--- a/torchtnt/data/multi_dataloader.py
+++ b/torchtnt/data/multi_dataloader.py
@@ -22,8 +22,8 @@ if TYPE_CHECKING:
 logger: logging.Logger = logging.getLogger(__name__)
 
 
-class MultiDataloader:
-    """MultiDataloader cycles through individual dataloaders passed to it.
+class MultiDataLoader:
+    """MultiDataLoader cycles through individual dataloaders passed to it.
 
     Attributes:
         individual_dataloaders (Dict[str, Union[DataLoader, Iterable]]): A dictionary of DataLoaders or Iterables with dataloader name as key
@@ -73,7 +73,7 @@ class MultiDataloader:
         iterator_cls = self.iterator_cls
         if iterator_cls is None:
             iterator_cls = DataIterationStrategyRegistry.get(self.iteration_strategy)
-        # pyre-fixme[16]: `MultiDataloader` has no attribute `iterator`.
+        # pyre-fixme[16]: `MultiDataLoader` has no attribute `iterator`.
         # pyre-fixme[45]: Cannot instantiate abstract class `MultiIterator`.
         self.iterator = iterator_cls(
             individual_dataloaders=self.individual_dataloaders,


### PR DESCRIPTION
Please read through our [contribution guide](https://github.com/pytorch/tnt/blob/main/CONTRIBUTING.md) prior to creating your pull request.

Summary:

Very small change, rename MultiDataloader to MultiDataLoader to match with PyTorch: https://pytorch.org/docs/stable/data.html#torch.utils.data.DataLoader


Test plan:
<!--  How you tested the change, ideally with a unit test :) -->

Fixes #{issue number}
<!-- Link the issue this pull request fixes -->
