### PR TITLE
Add important classes/APIs to init

### DIFF
--- a/examples/runner/train_unit_example.py
+++ b/examples/runner/train_unit_example.py
@@ -25,10 +25,8 @@ from torch.utils.data.dataset import Dataset, TensorDataset
 from torcheval.metrics import BinaryAccuracy
 from torchtnt.data import CudaDataPrefetcher
 from torchtnt.loggers import TensorBoardLogger
+from torchtnt.runner import State, train, TrainUnit
 from torchtnt.runner.callbacks import PyTorchProfiler, TensorBoardParameterMonitor
-from torchtnt.runner.state import State
-from torchtnt.runner.train import train
-from torchtnt.runner.unit import TrainUnit
 from torchtnt.utils import get_timer_summary, init_from_env, seed
 
 _logger: logging.Logger = logging.getLogger(__name__)

--- a/torchtnt/runner/__init__.py
+++ b/torchtnt/runner/__init__.py
@@ -4,14 +4,24 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
+from .callback import Callback
+from .evaluate import evaluate
+from .fit import fit
+from .predict import predict
 from .progress import Progress
 from .state import PhaseState, State
+from .train import train
 from .unit import EvalUnit, PredictUnit, TrainUnit
 
 __all__ = [
+    "Callback",
+    "evaluate",
+    "fit",
+    "predict",
     "Progress",
     "PhaseState",
     "State",
+    "train",
     "EvalUnit",
     "PredictUnit",
     "TrainUnit",


### PR DESCRIPTION
Summary:
This will make all of these automatically appear in the docs: https://pytorch.org/tnt/torchtnt.runner.html
Also, users should be able to import these directly from `torchtnt.runner`

Differential Revision: D40081623

