### PR TITLE
move validation for loop arguments into state

### DIFF
--- a/tests/runner/test_state.py
+++ b/tests/runner/test_state.py
@@ -1,0 +1,40 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+import unittest
+
+from torchtnt.runner.progress import Progress
+from torchtnt.runner.state import _check_loop_condition, PhaseState
+
+
+class StateTest(unittest.TestCase):
+    def test_check_loop_condition(self) -> None:
+        var = "foo"
+        _check_loop_condition(var, None)
+        _check_loop_condition(var, 100)
+        with self.assertRaisesRegex(ValueError, f"Invalid value provided for {var}"):
+            _check_loop_condition(var, -1)
+
+    def test_phase_state_validation(self) -> None:
+        with self.assertRaisesRegex(
+            ValueError, "Invalid value provided for max_epochs"
+        ):
+            PhaseState(progress=Progress(), dataloader=[], max_epochs=-2)
+        with self.assertRaisesRegex(ValueError, "Invalid value provided for max_steps"):
+            PhaseState(progress=Progress(), dataloader=[], max_steps=-2)
+        with self.assertRaisesRegex(
+            ValueError, "Invalid value provided for max_steps_per_epoch"
+        ):
+            PhaseState(progress=Progress(), dataloader=[], max_steps_per_epoch=-2)
+        with self.assertRaisesRegex(
+            ValueError, "Invalid value provided for evaluate_every_n_steps"
+        ):
+            PhaseState(progress=Progress(), dataloader=[], evaluate_every_n_steps=-2)
+        with self.assertRaisesRegex(
+            ValueError, "Invalid value provided for evaluate_every_n_epochs"
+        ):
+            PhaseState(progress=Progress(), dataloader=[], evaluate_every_n_epochs=-2)

--- a/torchtnt/runner/evaluate.py
+++ b/torchtnt/runner/evaluate.py
@@ -14,7 +14,6 @@ from torchtnt.runner.progress import Progress
 from torchtnt.runner.state import EntryPoint, PhaseState, State
 from torchtnt.runner.unit import EvalUnit, TEvalData
 from torchtnt.runner.utils import (
-    _check_loop_condition,
     _is_epoch_done,
     _reset_module_training_mode,
     _run_callback_fn,
@@ -69,9 +68,9 @@ def _evaluate_impl(
     eval_state = state.eval_state
     if not eval_state:
         raise RuntimeError("Expected eval_state to be initialized!")
-    max_steps_per_epoch = eval_state.max_steps_per_epoch
-    _check_loop_condition("max_steps_per_epoch", max_steps_per_epoch)
-    logger.info(f"Started evaluate with max_steps_per_epoch={max_steps_per_epoch}")
+    logger.info(
+        f"Started evaluate with max_steps_per_epoch={eval_state.max_steps_per_epoch}"
+    )
 
     # Set all modules to eval mode
     # access modules made available through _AppStateMixin

--- a/torchtnt/runner/fit.py
+++ b/torchtnt/runner/fit.py
@@ -13,12 +13,7 @@ from torchtnt.runner.progress import Progress
 from torchtnt.runner.state import EntryPoint, PhaseState, State
 from torchtnt.runner.train import _train_epoch_impl
 from torchtnt.runner.unit import EvalUnit, TEvalData, TrainUnit, TTrainData
-from torchtnt.runner.utils import (
-    _check_loop_condition,
-    _is_done,
-    _run_callback_fn,
-    log_api_usage,
-)
+from torchtnt.runner.utils import _is_done, _run_callback_fn, log_api_usage
 from torchtnt.utils.timer import get_timer_summary, Timer
 
 logger: logging.Logger = logging.getLogger(__name__)
@@ -88,12 +83,6 @@ def _fit_impl(
     if not eval_state:
         raise RuntimeError("Expected eval_state to be initialized")
 
-    _check_loop_condition("max_epochs", train_state.max_epochs)
-    _check_loop_condition("max_steps", train_state.max_steps)
-    _check_loop_condition("max_train_steps_per_epoch", train_state.max_steps_per_epoch)
-    _check_loop_condition("max_eval_steps_per_epoch", eval_state.max_steps_per_epoch)
-    _check_loop_condition("evaluate_every_n_steps", eval_state.evaluate_every_n_steps)
-    _check_loop_condition("evaluate_every_n_epochs", eval_state.evaluate_every_n_epochs)
     logger.info(
         f"Started fit with max_epochs={train_state.max_epochs}"
         f"max_steps={train_state.max_steps}"

--- a/torchtnt/runner/predict.py
+++ b/torchtnt/runner/predict.py
@@ -14,7 +14,6 @@ from torchtnt.runner.progress import Progress
 from torchtnt.runner.state import EntryPoint, PhaseState, State
 from torchtnt.runner.unit import PredictUnit, TPredictData
 from torchtnt.runner.utils import (
-    _check_loop_condition,
     _is_epoch_done,
     _reset_module_training_mode,
     _run_callback_fn,
@@ -69,9 +68,9 @@ def _predict_impl(
     predict_state = state.predict_state
     if not predict_state:
         raise RuntimeError("Expected predict_state to be initialized!")
-    max_steps_per_epoch = predict_state.max_steps_per_epoch
-    _check_loop_condition("max_steps_per_epoch", max_steps_per_epoch)
-    logger.info(f"Started predict with max_steps_per_epoch={max_steps_per_epoch}")
+    logger.info(
+        f"Started predict with max_steps_per_epoch={predict_state.max_steps_per_epoch}"
+    )
 
     # Set all modules to eval mode
     # access modules made available through _AppStateMixin

--- a/torchtnt/runner/state.py
+++ b/torchtnt/runner/state.py
@@ -16,6 +16,13 @@ from torchtnt.utils.timer import Timer
 _logger: logging.Logger = logging.getLogger(__name__)
 
 
+def _check_loop_condition(name: str, val: Optional[int]) -> None:
+    if val is not None and val < 0:
+        raise ValueError(
+            f"Invalid value provided for {name}. Expected a non-negative integer or None, but received {val}."
+        )
+
+
 class EntryPoint(Enum):
     FIT = auto()
     TRAIN = auto()
@@ -29,18 +36,27 @@ class PhaseState:
 
     progress: Progress
 
-    # input arguments
     # pyre-ignore: Invalid type variable [34]
     dataloader: Iterable[Any]
+
+    # Stopping conditions
     max_epochs: Optional[int] = None  # used only for train
     max_steps: Optional[int] = None  # used only for train
     max_steps_per_epoch: Optional[int] = None
+
     evaluate_every_n_steps: Optional[int] = None  # used only for evaluate
     evaluate_every_n_epochs: Optional[int] = None  # used only for evaluate
 
     # contains the output from the last call to the user's `*_step` method
     # pyre-ignore: Invalid type variable [34]
     step_output: Any = None
+
+    def __post_init__(self) -> None:
+        _check_loop_condition("max_epochs", self.max_epochs)
+        _check_loop_condition("max_steps", self.max_steps)
+        _check_loop_condition("max_steps_per_epoch", self.max_steps_per_epoch)
+        _check_loop_condition("evaluate_every_n_steps", self.evaluate_every_n_steps)
+        _check_loop_condition("evaluate_every_n_epochs", self.evaluate_every_n_epochs)
 
 
 @dataclass

--- a/torchtnt/runner/train.py
+++ b/torchtnt/runner/train.py
@@ -14,7 +14,6 @@ from torchtnt.runner.progress import Progress
 from torchtnt.runner.state import EntryPoint, PhaseState, State
 from torchtnt.runner.unit import TrainUnit, TTrainData
 from torchtnt.runner.utils import (
-    _check_loop_condition,
     _is_done,
     _is_epoch_done,
     _maybe_set_distributed_sampler_epoch,
@@ -74,15 +73,8 @@ def _train_impl(
     if not train_state:
         raise RuntimeError("Expected train_state to be initialized!")
 
-    max_steps_per_epoch = train_state.max_steps_per_epoch
-    _check_loop_condition("max_steps_per_epoch", train_state.max_steps_per_epoch)
-    max_epochs = train_state.max_epochs
-    _check_loop_condition("max_epochs", train_state.max_epochs)
-    max_steps = train_state.max_steps
-    _check_loop_condition("max_steps", train_state.max_steps)
-
     logger.info(
-        f"Started train with max_epochs={max_epochs}, max_steps={max_steps}, max_steps_per_epoch={max_steps_per_epoch}"
+        f"Started train with max_epochs={train_state.max_epochs}, max_steps={train_state.max_steps}, max_steps_per_epoch={train_state.max_steps_per_epoch}"
     )
 
     # Set all modules to train() mode
@@ -132,7 +124,6 @@ def train_epoch(
     )
 
     try:
-        _check_loop_condition("max_steps_per_epoch", max_steps_per_epoch)
         logger.info(
             f"Started train_epoch with max_steps_per_epoch={max_steps_per_epoch}"
         )

--- a/torchtnt/runner/utils.py
+++ b/torchtnt/runner/utils.py
@@ -21,15 +21,6 @@ _logger: logging.Logger = logging.getLogger(__name__)
 
 
 # Helper functions common across the loops
-
-
-def _check_loop_condition(name: str, val: Optional[int]) -> None:
-    if val is not None and val < 0:
-        raise ValueError(
-            f"Invalid value provided for {name}. Expected a non-negative integer or None, but received {val}."
-        )
-
-
 def _is_done(
     progress: Progress, max_epochs: Optional[int], max_steps: Optional[int]
 ) -> bool:


### PR DESCRIPTION
Summary: This validation logic was called across every entry point, so it made sense for the validation to sit as part of the state initialization

Reviewed By: daniellepintz

Differential Revision: D40130262

