### PR TITLE
[ez] fix default `__getattr__` behavior in _AppStateMixin

### DIFF
--- a/torchtnt/runner/unit.py
+++ b/torchtnt/runner/unit.py
@@ -72,8 +72,9 @@ class _AppStateMixin:
             _lr_schedulers = self.__dict__["_lr_schedulers"]
             if name in _lr_schedulers:
                 return _lr_schedulers[name]
-        # pyre-ignore: Undefined attribute [16]
-        return super().__getattr__(name)
+
+        return self.__getattribute__(name)
+
 
     def _update_attr(
         self,


### PR DESCRIPTION
Please read through our [contribution guide](https://github.com/pytorch/tnt/blob/main/CONTRIBUTING.md) prior to creating your pull request.

Summary:

previously, calling `super().__getattr__` resulted in error:

```
trainer/0 [0]:  File "/tmp/jetter.akkix4bz/scripts/hack/vise/train.py", line 68, in main
trainer/0 [0]:    fit(
trainer/0 [0]:  File "/tmp/jetter.akkix4bz/torchtnt/runner/fit.py", line 61, in fit
trainer/0 [0]:    raise e
trainer/0 [0]:  File "/tmp/jetter.akkix4bz/torchtnt/runner/fit.py", line 53, in fit
trainer/0 [0]:    _fit_impl(state, unit, callbacks)
trainer/0 [0]:  File "/tmp/jetter.akkix4bz/torchtnt/runner/fit.py", line 99, in _fit_impl
trainer/0 [0]:    _train_epoch_impl(state, unit, callbacks)
trainer/0 [0]:  File "/tmp/jetter.akkix4bz/torchtnt/runner/train.py", line 199, in _train_epoch_impl
trainer/0 [0]:    train_state.step_output = train_unit.train_step(state, step_input)
trainer/0 [0]:  File "/tmp/jetter.akkix4bz/scripts/hack/vise/clip_unit.py", line 93, in train_step
trainer/0 [0]:    if self.lr_schedule:
trainer/0 [0]:  File "/tmp/jetter.akkix4bz/torchtnt/runner/unit.py", line 76, in __getattr__
trainer/0 [0]:    return super().__getattr__(name)
trainer/0 [0]:AttributeError: 'super' object has no attribute '__getattr__
```

See https://stackoverflow.com/questions/2405590/how-do-i-override-getattr-without-breaking-the-default-behavior for related discussion

Test plan:
<!--  How you tested the change, ideally with a unit test :) -->

Fixes #{issue number}
<!-- Link the issue this pull request fixes -->
