### PR TITLE
remove torch.inference_mode from predict/eval units

### DIFF
--- a/torchtnt/runner/evaluate.py
+++ b/torchtnt/runner/evaluate.py
@@ -55,7 +55,7 @@ def evaluate(
         raise e
 
 
-@torch.inference_mode()
+@torch.no_grad()
 def _evaluate_impl(
     state: State,
     eval_unit: EvalUnit[TEvalData],

--- a/torchtnt/runner/predict.py
+++ b/torchtnt/runner/predict.py
@@ -55,7 +55,7 @@ def predict(
         raise e
 
 
-@torch.inference_mode()
+@torch.no_grad()
 def _predict_impl(
     state: State,
     predict_unit: PredictUnit[TPredictData],

--- a/torchtnt/runner/unit.py
+++ b/torchtnt/runner/unit.py
@@ -4,7 +4,9 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
+# Disable `Any` type errors
 # pyre-ignore-all-errors[2]
+# pyre-ignore-all-errors[3]
 
 from abc import ABC, abstractmethod
 from typing import Any, Dict, Generic, TypeVar
@@ -74,7 +76,6 @@ class _AppStateMixin:
     ) -> Dict[str, torch.optim.lr_scheduler._LRScheduler]:
         return self._lr_schedulers
 
-    # pyre-ignore: Missing return annotation [3]
     def __getattr__(self, name: str) -> Any:
         if "_modules" in self.__dict__:
             _modules = self.__dict__["_modules"]
@@ -176,7 +177,6 @@ class TrainUnit(_AppStateMixin, _OnExceptionMixin, Generic[TTrainData], ABC):
         pass
 
     @abstractmethod
-    # pyre-ignore: Missing return annotation [3]
     def train_step(self, state: State, data: TTrainData) -> Any:
         ...
 
@@ -195,8 +195,10 @@ class EvalUnit(_AppStateMixin, _OnExceptionMixin, Generic[TEvalData], ABC):
         pass
 
     @abstractmethod
-    # pyre-ignore: Missing return annotation [3]
     def eval_step(self, state: State, data: TEvalData) -> Any:
+        """
+        Optionally can be decorated with ``@torch.inference_mode()`` for improved peformance.
+        """
         ...
 
     def on_eval_epoch_end(self, state: State) -> None:
@@ -214,8 +216,10 @@ class PredictUnit(_AppStateMixin, _OnExceptionMixin, Generic[TPredictData], ABC)
         pass
 
     @abstractmethod
-    # pyre-ignore: Missing return annotation [3]
     def predict_step(self, state: State, data: TPredictData) -> Any:
+        """
+        Optionally can be decorated with ``@torch.inference_mode()`` for improved peformance.
+        """
         ...
 
     def on_predict_epoch_end(self, state: State) -> None:


### PR DESCRIPTION
Please read through our [contribution guide](https://github.com/pytorch/tnt/blob/main/CONTRIBUTING.md) prior to creating your pull request.

Summary:

`torch.inference_mode()` has some problems with distributed collectives, and users may want gradients during eval.  Using `torch.no_grad()` instead and add docs so users can add decorate their step with `inference_mode` if they prefer.

Downside: the tensors returned from dataloader are not covered under `eval_step`

Test plan:
<!--  How you tested the change, ideally with a unit test :) -->

Fixes #{issue number}
<!-- Link the issue this pull request fixes -->
