### PR TITLE
Allow users to override tracked_modules/optimizers/lr schedulers/misc and take effect in app state

### DIFF
--- a/tests/runner/test_app_state_mixin.py
+++ b/tests/runner/test_app_state_mixin.py
@@ -89,6 +89,12 @@ class AppStateMixinTest(unittest.TestCase):
         # assert that the grad scaler is stored in the app_state
         self.assertEqual(my_unit.app_state()["grad_scaler_e"], my_unit.grad_scaler_e)
 
+        # delete the attribute
+        my_unit.grad_scaler_e = None
+
+        # the attribute should be removed from tracked_misc_statefuls
+        self.assertFalse("grad_scaler_e" in my_unit.tracked_misc_statefuls())
+
     def test_app_state(self) -> None:
         """
         Test the app_state method
@@ -155,3 +161,8 @@ class AppStateMixinTest(unittest.TestCase):
         my_unit.lr_scheduler_d = loss_fn_f
         self.assertTrue("lr_scheduler_d" not in my_unit.tracked_lr_schedulers())
         self.assertTrue("lr_scheduler_d" in my_unit.tracked_modules())
+
+        self.assertTrue("grad_scaler_e" in my_unit.tracked_misc_statefuls())
+        my_unit.grad_scaler_e = loss_fn_f
+        self.assertTrue("grad_scaler_e" not in my_unit.tracked_misc_statefuls())
+        self.assertTrue("grad_scaler_e" in my_unit.tracked_modules())

--- a/torchtnt/runner/unit.py
+++ b/torchtnt/runner/unit.py
@@ -36,7 +36,7 @@ def _remove_from_dicts(name_to_remove: str, *dicts: Dict[str, Any]) -> None:
             del d[name_to_remove]
 
 
-class _AppStateMixin:
+class AppStateMixin:
     """
     A mixin to track modules, optimizers, and LR schedulers to simplify checkpointing object states.
     This can be easily extended to cover types that conform to the Stateful protocol.
@@ -58,10 +58,10 @@ class _AppStateMixin:
         # in order to let users customize the saving & loading paths independently?
         # or should we assume this is done outside of the loop framework entirely?
         app_state = {
-            **self._modules,
-            **self._optimizers,
-            **self._lr_schedulers,
-            **self._misc_statefuls,
+            **self.tracked_modules(),
+            **self.tracked_optimizers(),
+            **self.tracked_lr_schedulers(),
+            **self.tracked_misc_statefuls(),
         }
         return app_state
 
@@ -171,7 +171,7 @@ TEvalData = TypeVar("TEvalData")
 TPredictData = TypeVar("TPredictData")
 
 
-class TrainUnit(_AppStateMixin, _OnExceptionMixin, Generic[TTrainData], ABC):
+class TrainUnit(AppStateMixin, _OnExceptionMixin, Generic[TTrainData], ABC):
     """
     Base interface for training.
     """
@@ -193,7 +193,7 @@ class TrainUnit(_AppStateMixin, _OnExceptionMixin, Generic[TTrainData], ABC):
         pass
 
 
-class EvalUnit(_AppStateMixin, _OnExceptionMixin, Generic[TEvalData], ABC):
+class EvalUnit(AppStateMixin, _OnExceptionMixin, Generic[TEvalData], ABC):
     def on_eval_start(self, state: State) -> None:
         pass
 
@@ -214,7 +214,7 @@ class EvalUnit(_AppStateMixin, _OnExceptionMixin, Generic[TEvalData], ABC):
         pass
 
 
-class PredictUnit(_AppStateMixin, _OnExceptionMixin, Generic[TPredictData], ABC):
+class PredictUnit(AppStateMixin, _OnExceptionMixin, Generic[TPredictData], ABC):
     def on_predict_start(self, state: State) -> None:
         pass
 

--- a/torchtnt/runner/unit.py
+++ b/torchtnt/runner/unit.py
@@ -76,6 +76,9 @@ class _AppStateMixin:
     ) -> Dict[str, torch.optim.lr_scheduler._LRScheduler]:
         return self._lr_schedulers
 
+    def tracked_misc_statefuls(self) -> Dict[str, Any]:
+        return self._misc_statefuls
+
     def __getattr__(self, name: str) -> Any:
         if "_modules" in self.__dict__:
             _modules = self.__dict__["_modules"]
@@ -112,6 +115,7 @@ class _AppStateMixin:
             self._modules,
             self._optimizers,
             self._lr_schedulers,
+            self._misc_statefuls,
         )
         tracked_objects[name] = value
 
@@ -151,6 +155,8 @@ class _AppStateMixin:
             del self._optimizers[name]
         elif name in self._lr_schedulers:
             del self._lr_schedulers[name]
+        elif name in self._misc_statefuls:
+            del self._misc_statefuls[name]
         else:
             super().__delattr__(name)
 


### PR DESCRIPTION
Summary:
pointed out by daniellepintz - previously the app state relied on the private attributes vs the methods that can be overridden by subclasses

this change also makes the AppStateMixin public since its APIs are already public on the unit classes.

Differential Revision: D40318005

