### PR TITLE
Type logger's log_dict as read-only

### DIFF
--- a/torchtnt/loggers/file.py
+++ b/torchtnt/loggers/file.py
@@ -10,7 +10,7 @@ import logging
 from abc import ABC, abstractmethod
 from collections import OrderedDict
 from time import monotonic
-from typing import Dict
+from typing import Dict, Mapping
 
 from torchtnt.loggers.logger import Scalar
 from torchtnt.loggers.utils import scalar_to_float
@@ -53,7 +53,7 @@ class FileLogger(ABC):
     def path(self) -> str:
         return self._path
 
-    def log_dict(self, payload: Dict[str, Scalar], step: int) -> None:
+    def log_dict(self, payload: Mapping[str, Scalar], step: int) -> None:
         """Add multiple scalar values.
 
         Args:

--- a/torchtnt/loggers/in_memory.py
+++ b/torchtnt/loggers/in_memory.py
@@ -9,7 +9,7 @@ import atexit
 import logging
 from collections import OrderedDict
 from time import monotonic
-from typing import Dict
+from typing import Dict, Mapping
 
 from torchtnt.loggers.logger import MetricLogger, Scalar
 from torchtnt.loggers.utils import scalar_to_float
@@ -38,7 +38,7 @@ class InMemoryLogger(MetricLogger):
 
         return self._log_buffer
 
-    def log_dict(self, payload: Dict[str, Scalar], step: int) -> None:
+    def log_dict(self, payload: Mapping[str, Scalar], step: int) -> None:
         """Add multiple scalar values.
 
         Args:

--- a/torchtnt/loggers/logger.py
+++ b/torchtnt/loggers/logger.py
@@ -5,7 +5,7 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
-from typing import Dict, Union
+from typing import Mapping, Union
 
 from numpy import ndarray
 from torch import Tensor
@@ -30,7 +30,7 @@ class MetricLogger(Protocol):
         """
         pass
 
-    def log_dict(self, payload: Dict[str, Scalar], step: int) -> None:
+    def log_dict(self, payload: Mapping[str, Scalar], step: int) -> None:
         """Log multiple scalar values.
 
         Args:

--- a/torchtnt/loggers/tensorboard.py
+++ b/torchtnt/loggers/tensorboard.py
@@ -7,7 +7,7 @@
 
 import atexit
 import logging
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Mapping, Optional
 
 import torch.distributed as dist
 
@@ -89,7 +89,7 @@ class TensorBoardLogger(MetricLogger):
     def path(self) -> str:
         return self._path
 
-    def log_dict(self, payload: Dict[str, Scalar], step: int) -> None:
+    def log_dict(self, payload: Mapping[str, Scalar], step: int) -> None:
         """Add multiple scalar values to TensorBoard.
 
         Args:


### PR DESCRIPTION
Summary: Using `Mapping` vs `Dict` to indicate that the logger protocol should not mutate the input collection.

Differential Revision: D40370788

