### PR TITLE
Update the train() API parameter to take a state

### DIFF
--- a/examples/runner/train_unit_example.py
+++ b/examples/runner/train_unit_example.py
@@ -31,6 +31,7 @@ from torchtnt.runner.callbacks import (
     PyTorchProfiler,
     TensorBoardParameterMonitor,
 )
+from torchtnt.runner.train import init_train_state
 from torchtnt.utils import get_timer_summary, init_from_env, seed
 
 _logger: logging.Logger = logging.getLogger(__name__)
@@ -210,11 +211,15 @@ def main(argv: List[str]) -> None:
         num_samples, args.input_dim, args.batch_size, device
     )
 
-    state = train(
-        my_unit,
-        train_dataloader,
-        callbacks=[lr_monitor, parameter_monitor, profiler],
+    state = init_train_state(
+        dataloader=train_dataloader,
         max_epochs=args.max_epochs,
+    )
+
+    train(
+        state,
+        my_unit,
+        callbacks=[lr_monitor, parameter_monitor, profiler],
     )
     print(get_timer_summary(state.timer))
 

--- a/tests/runner/callbacks/test_garbage_collector.py
+++ b/tests/runner/callbacks/test_garbage_collector.py
@@ -18,7 +18,7 @@ from torchtnt.runner._test_utils import (
 from torchtnt.runner.callbacks.garbage_collector import GarbageCollector
 from torchtnt.runner.evaluate import evaluate
 from torchtnt.runner.predict import predict
-from torchtnt.runner.train import train
+from torchtnt.runner.train import init_train_state, train
 
 
 class GarbageCollectorTest(unittest.TestCase):
@@ -36,8 +36,9 @@ class GarbageCollectorTest(unittest.TestCase):
         gc_callback_mock = MagicMock(spec=GarbageCollector)
 
         dataloader = generate_random_dataloader(dataset_len, input_dim, batch_size)
+        state = init_train_state(dataloader=dataloader, max_epochs=max_epochs)
 
-        train(my_unit, dataloader, callbacks=[gc_callback_mock], max_epochs=max_epochs)
+        train(state, my_unit, callbacks=[gc_callback_mock])
         self.assertEqual(gc_callback_mock.on_train_start.call_count, 1)
         self.assertEqual(
             gc_callback_mock.on_train_step_end.call_count, expected_num_total_steps
@@ -57,9 +58,10 @@ class GarbageCollectorTest(unittest.TestCase):
         gc_callback = GarbageCollector(2)
 
         dataloader = generate_random_dataloader(dataset_len, input_dim, batch_size)
+        state = init_train_state(dataloader=dataloader, max_epochs=max_epochs)
 
         self.assertTrue(gc.isenabled())
-        train(my_unit, dataloader, callbacks=[gc_callback], max_epochs=max_epochs)
+        train(state, my_unit, callbacks=[gc_callback])
         self.assertTrue(gc.isenabled())
 
     def test_garbage_collector_call_count_evaluate(self) -> None:

--- a/tests/runner/callbacks/test_learning_rate_monitor.py
+++ b/tests/runner/callbacks/test_learning_rate_monitor.py
@@ -11,7 +11,7 @@ from unittest.mock import MagicMock
 from torchtnt.loggers.logger import MetricLogger
 from torchtnt.runner._test_utils import DummyTrainUnit, generate_random_dataloader
 from torchtnt.runner.callbacks.learning_rate_monitor import LearningRateMonitor
-from torchtnt.runner.train import train
+from torchtnt.runner.train import init_train_state, train
 
 
 class LearningRateMonitorTest(unittest.TestCase):
@@ -29,8 +29,8 @@ class LearningRateMonitorTest(unittest.TestCase):
         monitor = LearningRateMonitor(loggers=log_writer)
 
         dataloader = generate_random_dataloader(dataset_len, input_dim, batch_size)
-
-        train(my_unit, dataloader, callbacks=[monitor], max_epochs=max_epochs)
+        state = init_train_state(dataloader=dataloader, max_epochs=max_epochs)
+        train(state, my_unit, callbacks=[monitor])
         self.assertEqual(log_writer.log_dict.call_count, 2)
 
     def test_learning_rate_monitor_step(self) -> None:
@@ -49,12 +49,11 @@ class LearningRateMonitorTest(unittest.TestCase):
         dataloader = generate_random_dataloader(dataset_len, input_dim, batch_size)
 
         total_steps = (dataset_len / batch_size) * max_epochs
-
-        train(
-            my_unit,
-            dataloader,
-            callbacks=[monitor],
+        state = init_train_state(
+            dataloader=dataloader,
             max_epochs=max_epochs,
             max_steps=total_steps,
         )
+
+        train(state, my_unit, callbacks=[monitor])
         self.assertEqual(log_writer.log_dict.call_count, total_steps)

--- a/tests/runner/callbacks/test_pytorch_profiler.py
+++ b/tests/runner/callbacks/test_pytorch_profiler.py
@@ -18,7 +18,7 @@ from torchtnt.runner._test_utils import (
 from torchtnt.runner.callbacks.pytorch_profiler import PyTorchProfiler
 from torchtnt.runner.evaluate import evaluate
 from torchtnt.runner.predict import predict
-from torchtnt.runner.train import train
+from torchtnt.runner.train import init_train_state, train
 
 
 class PyTorchProfilerTest(unittest.TestCase):
@@ -38,8 +38,8 @@ class PyTorchProfilerTest(unittest.TestCase):
         profiler = PyTorchProfiler(profiler=profiler_mock)
 
         dataloader = generate_random_dataloader(dataset_len, input_dim, batch_size)
-
-        train(my_unit, dataloader, callbacks=[profiler], max_epochs=max_epochs)
+        state = init_train_state(dataloader=dataloader, max_epochs=max_epochs)
+        train(state, my_unit, callbacks=[profiler])
         self.assertEqual(profiler_mock.start.call_count, 1)
         self.assertEqual(profiler_mock.step.call_count, expected_num_total_steps)
         self.assertEqual(profiler_mock.stop.call_count, 1)

--- a/tests/runner/callbacks/test_tensorboard_parameter_monitor.py
+++ b/tests/runner/callbacks/test_tensorboard_parameter_monitor.py
@@ -13,7 +13,7 @@ from torchtnt.runner._test_utils import DummyTrainUnit, generate_random_dataload
 from torchtnt.runner.callbacks.tensorboard_parameter_monitor import (
     TensorBoardParameterMonitor,
 )
-from torchtnt.runner.train import train
+from torchtnt.runner.train import init_train_state, train
 
 
 class TensorBoardParameterMonitorTest(unittest.TestCase):
@@ -31,6 +31,6 @@ class TensorBoardParameterMonitorTest(unittest.TestCase):
         monitor = TensorBoardParameterMonitor(logger=summary_writer)
 
         dataloader = generate_random_dataloader(dataset_len, input_dim, batch_size)
-
-        train(my_unit, dataloader, callbacks=[monitor], max_epochs=max_epochs)
+        state = init_train_state(dataloader=dataloader, max_epochs=max_epochs)
+        train(state, my_unit, callbacks=[monitor])
         self.assertGreater(summary_writer.add_histogram.call_count, 0)


### PR DESCRIPTION
Summary:
Allow the states to be set up outside of the `train()` function, provides better flexibility. However, the state becomes an opaque object that might be modified accidentally.

Suggest, we should move dataloader out of the state. and make the state immutable.

Reviewed By: ananthsub

Differential Revision: D40233501

