### PR TITLE
add versioning to docs build action

### DIFF
--- a/.github/workflows/build_docs.yaml
+++ b/.github/workflows/build_docs.yaml
@@ -10,38 +10,7 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  unit_tests:
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        python-version: [3.7, 3.8, 3.9]
-    steps:
-      - name: Check out repo
-        uses: actions/checkout@v2
-      - name: Setup conda env
-        uses: conda-incubator/setup-miniconda@v2
-        with:
-          miniconda-version: "latest"
-          activate-environment: test
-          python-version: ${{ matrix.python-version }}
-      - name: Install dependencies
-        shell: bash -l {0}
-        run: |
-          set -eux
-          conda activate test
-          conda install pytorch cpuonly -c pytorch-nightly
-          pip install -r requirements.txt
-          pip install -r dev-requirements.txt
-          python setup.py sdist bdist_wheel
-          pip install dist/*.whl
-      - name: Run unit tests
-        shell: bash -l {0}
-        run: |
-          set -eux
-          conda activate test
-          pytest tests -vv
   build_docs:
-    needs: unit_tests
     runs-on: ubuntu-latest
     steps:
       - name: Check out repo
@@ -72,8 +41,8 @@ jobs:
           touch build/html/.nojekyll
           cd ..
       - name: Deploy docs to Github pages
-        uses: JamesIves/github-pages-deploy-action@releases/v3
+        uses: JamesIves/github-pages-deploy-action@v4.4.1
         with:
-            ACCESS_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-            BRANCH: gh-pages # The branch the action should deploy to.
-            FOLDER: docs/build/html # The folder the action should deploy.
+            branch: gh-pages # The branch the action should deploy to.
+            folder: docs/build/html # The folder the action should deploy.
+            target-folder: master

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -35,8 +35,12 @@ copyright = "2022, Meta"
 author = "Meta"
 
 # The full version, including alpha/beta/rc tags
-release = __version__
-
+if os.environ.get("RELEASE_BUILD", None):
+    version = __version__
+    release = __version__
+else:
+    version = "master (unstable)"
+    release = "master"
 
 # -- General configuration ---------------------------------------------------
 
@@ -66,6 +70,9 @@ html_theme_path = [pytorch_sphinx_theme.get_html_theme_path()]
 # relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".
 html_static_path = ["_static"]
+html_theme_options = {
+    "display_version": True,
+}
 
 # where to find external docs
 intersphinx_mapping = {


### PR DESCRIPTION
Please read through our [contribution guide](https://github.com/pytorch/tnt/blob/main/CONTRIBUTING.md) prior to creating your pull request.

Summary:

- removes unit tests from doc build (tests still run on PR and commit in the unit_test action)
- instead of the files being stored directly, move to master directory. when tnt gets a full release, a stable symlink can point to the directory of the latest version (e.g. 0.0.3/).


Test plan:

https://github.com/edward-io/tnt/tree/gh-pages

Fixes #{issue number}
<!-- Link the issue this pull request fixes -->
