### PR TITLE
Add no_sync context when using DDP/FSDP and gradient accumulation

### DIFF
--- a/tests/runner/test_auto_unit.py
+++ b/tests/runner/test_auto_unit.py
@@ -225,6 +225,26 @@ class TestAutoUnit(unittest.TestCase):
             auto_train_unit.num_optimizer_steps_completed, expected_opt_steps_per_epoch
         )
 
+    def test_log_frequency_steps_exception(self) -> None:
+        """
+        Test that an exception is raised when log_frequency_steps is < 1
+        """
+        device = init_from_env()
+        my_module = torch.nn.Linear(2, 2).to(device)
+        my_optimizer = torch.optim.SGD(my_module.parameters(), lr=0.01)
+        my_lr_scheduler = torch.optim.lr_scheduler.ExponentialLR(
+            my_optimizer, gamma=0.9
+        )
+        with self.assertRaisesRegex(
+            ValueError, "log_frequency_steps must be > 0. Got 0"
+        ):
+            _ = DummyAutoTrainUnit(
+                module=my_module,
+                optimizer=my_optimizer,
+                lr_scheduler=my_lr_scheduler,
+                log_frequency_steps=0,
+            )
+
 
 class DummyAutoTrainUnit(AutoTrainUnit[Tuple[torch.tensor, torch.tensor]]):
     def compute_loss(

--- a/torchtnt/runner/auto_unit.py
+++ b/torchtnt/runner/auto_unit.py
@@ -74,6 +74,10 @@ class AutoTrainUnit(TrainUnit[TTrainData], ABC):
         self.lr_scheduler = lr_scheduler
         self.step_lr_interval = step_lr_interval
         self.device: torch.device = device or get_device_from_env()
+        if not log_frequency_steps > 0:
+            raise ValueError(
+                f"log_frequency_steps must be > 0. Got {log_frequency_steps}"
+            )
         self.log_frequency_steps: int = log_frequency_steps
 
         if not precision:


### PR DESCRIPTION
Summary:
if using gradient accumulation and DDP/FSDP, when in a step where we will not update the weights, run forward and backward in no_sync context
https://pytorch.org/docs/stable/_modules/torch/nn/parallel/distributed.html#DistributedDataParallel.no_sync
https://pytorch.org/docs/stable/fsdp.html#torch.distributed.fsdp.FullyShardedDataParallel.no_sync

Reviewed By: ananthsub

Differential Revision: D40231819

