### PR TITLE
Remove unnecessary self.tb_logger.close() in example

### DIFF
--- a/examples/runner/train_unit_example.py
+++ b/examples/runner/train_unit_example.py
@@ -151,9 +151,6 @@ class MyTrainUnit(TrainUnit[Batch]):
         # step the learning rate scheduler
         self.lr_scheduler.step()
 
-    def on_train_end(self, state: State) -> None:
-        self.tb_logger.close()
-
 
 def main(argv: List[str]) -> None:
     # parse command line arguments


### PR DESCRIPTION
Summary:
this isn't strictly needed due to this:
https://www.internalfb.com/code/fbsource/[c6b7bbf18e27]/fbcode/torchtnt/loggers/tensorboard.py?lines=64

Differential Revision: D40642758

