### PR TITLE
Explicit none checks for progress bar callback

### DIFF
--- a/tests/runner/callbacks/test_tqdm_progress_bar.py
+++ b/tests/runner/callbacks/test_tqdm_progress_bar.py
@@ -19,6 +19,7 @@ from torchtnt.runner.callbacks.tqdm_progress_bar import (
     TQDMProgressBar,
 )
 from torchtnt.runner.state import EntryPoint, PhaseState, State
+from torchtnt.runner.train import init_train_state, train
 
 
 class TQDMProgressBarTest(unittest.TestCase):
@@ -45,6 +46,22 @@ class TQDMProgressBarTest(unittest.TestCase):
         progress_bar = TQDMProgressBar()
         progress_bar.on_train_epoch_start(state, my_unit)
         self.assertEqual(progress_bar._train_progress_bar.total, expected_total)
+
+    def test_progress_bar_train_integration(self) -> None:
+        """
+        Test TQDMProgressBar callback with train entry point
+        """
+        input_dim = 2
+        dataset_len = 10
+        batch_size = 2
+        max_epochs = 1
+
+        dataloader = generate_random_dataloader(dataset_len, input_dim, batch_size)
+        state = init_train_state(dataloader=dataloader, max_epochs=max_epochs)
+
+        my_unit = MagicMock(spec=DummyTrainUnit)
+        progress_bar = TQDMProgressBar()
+        train(state, my_unit, callbacks=[progress_bar])
 
     def test_progress_bar_evaluate(self) -> None:
         """

--- a/torchtnt/runner/callbacks/tqdm_progress_bar.py
+++ b/torchtnt/runner/callbacks/tqdm_progress_bar.py
@@ -42,7 +42,7 @@ class TQDMProgressBar(Callback):
             )
 
     def on_train_step_end(self, state: State, unit: TTrainUnit) -> None:
-        if self._train_progress_bar and state.train_state:
+        if self._train_progress_bar is not None and state.train_state:
             _update_progress_bar(
                 self._train_progress_bar,
                 state.train_state.progress.num_steps_completed,
@@ -50,7 +50,7 @@ class TQDMProgressBar(Callback):
             )
 
     def on_train_epoch_end(self, state: State, unit: TTrainUnit) -> None:
-        if self._train_progress_bar and state.train_state:
+        if self._train_progress_bar is not None and state.train_state:
             _close_progress_bar(
                 self._train_progress_bar,
                 state.train_state.progress.num_steps_completed,
@@ -69,7 +69,7 @@ class TQDMProgressBar(Callback):
             )
 
     def on_eval_step_end(self, state: State, unit: TEvalUnit) -> None:
-        if self._eval_progress_bar and state.eval_state:
+        if self._eval_progress_bar is not None and state.eval_state:
             _update_progress_bar(
                 self._eval_progress_bar,
                 state.eval_state.progress.num_steps_completed,
@@ -77,7 +77,7 @@ class TQDMProgressBar(Callback):
             )
 
     def on_eval_epoch_end(self, state: State, unit: TEvalUnit) -> None:
-        if self._eval_progress_bar and state.eval_state:
+        if self._eval_progress_bar is not None and state.eval_state:
             _close_progress_bar(
                 self._eval_progress_bar,
                 state.eval_state.progress.num_steps_completed,
@@ -96,7 +96,7 @@ class TQDMProgressBar(Callback):
             )
 
     def on_predict_step_end(self, state: State, unit: TPredictUnit) -> None:
-        if self._predict_progress_bar and state.predict_state:
+        if self._predict_progress_bar is not None and state.predict_state:
             _update_progress_bar(
                 self._predict_progress_bar,
                 state.predict_state.progress.num_steps_completed,
@@ -104,7 +104,7 @@ class TQDMProgressBar(Callback):
             )
 
     def on_predict_epoch_end(self, state: State, unit: TPredictUnit) -> None:
-        if self._predict_progress_bar and state.predict_state:
+        if self._predict_progress_bar is not None and state.predict_state:
             _close_progress_bar(
                 self._predict_progress_bar,
                 state.predict_state.progress.num_steps_completed,


### PR DESCRIPTION
Summary:
Follow up to comment on https://github.com/pytorch/tnt/pull/223
Stack trace when run with `max_steps` and `max_steps_per_epoch` both set to None

```
torchtnt/runner/callbacks/tqdm_progress_bar.py in on_train_step_end(self, state, unit)
     43
     44     def on_train_step_end(self, state: State, unit: TTrainUnit) -> None:
---> 45         if self._train_progress_bar and state.train_state:
     46             _update_progress_bar(
     47                 self._train_progress_bar,
tqdm/std.py in __bool__(self)
   1118             return self.total > 0
   1119         if self.iterable is None:
-> 1120             raise TypeError('bool() undefined when iterable == total == None')
   1121         return bool(self.iterable)
   1122
TypeError: bool() undefined when iterable == total == None
```

Differential Revision: D40643481

