### PR TITLE
Use is_last_batch in AutoUnit to update weights for last batch with gradient accumulation

### DIFF
--- a/tests/runner/test_train.py
+++ b/tests/runner/test_train.py
@@ -45,6 +45,8 @@ class TrainTest(unittest.TestCase):
 
         # step_output should be reset to None
         self.assertEqual(state.train_state.step_output, None)
+        # is_last_batch should be set to True
+        self.assertEqual(state.train_state.is_last_batch, True)
 
         self.assertEqual(my_unit.module.training, initial_training_mode)
         self.assertEqual(state.entry_point, EntryPoint.TRAIN)

--- a/tests/runner/test_utils.py
+++ b/tests/runner/test_utils.py
@@ -24,6 +24,7 @@ from torchtnt.runner.unit import TEvalUnit, TPredictUnit, TTrainUnit
 from torchtnt.runner.utils import (
     _is_done,
     _is_epoch_done,
+    _is_last_batch_in_epoch,
     _maybe_set_distributed_sampler_epoch,
     _reset_module_training_mode,
     _run_callback_fn,
@@ -251,6 +252,39 @@ class UtilsTest(unittest.TestCase):
         self.assertFalse(_is_epoch_done(p, max_steps_per_epoch=None, max_steps=200))
         self.assertFalse(_is_epoch_done(p, max_steps_per_epoch=6, max_steps=None))
         self.assertFalse(_is_epoch_done(p, max_steps_per_epoch=None, max_steps=None))
+
+    def test_is_last_batch_in_epoch(self) -> None:
+        p = Progress(
+            num_epochs_completed=2,
+            num_steps_completed=99,
+            num_steps_completed_in_epoch=9,
+        )
+
+        self.assertTrue(
+            _is_last_batch_in_epoch(p, max_steps_per_epoch=10, max_steps=200)
+        )
+        self.assertTrue(
+            _is_last_batch_in_epoch(p, max_steps_per_epoch=10, max_steps=None)
+        )
+        self.assertTrue(
+            _is_last_batch_in_epoch(p, max_steps_per_epoch=100, max_steps=100)
+        )
+        self.assertTrue(
+            _is_last_batch_in_epoch(p, max_steps_per_epoch=None, max_steps=100)
+        )
+
+        self.assertFalse(
+            _is_last_batch_in_epoch(p, max_steps_per_epoch=11, max_steps=200)
+        )
+        self.assertFalse(
+            _is_last_batch_in_epoch(p, max_steps_per_epoch=None, max_steps=200)
+        )
+        self.assertFalse(
+            _is_last_batch_in_epoch(p, max_steps_per_epoch=11, max_steps=None)
+        )
+        self.assertFalse(
+            _is_last_batch_in_epoch(p, max_steps_per_epoch=None, max_steps=None)
+        )
 
 
 class DummyCallback(Callback):

--- a/torchtnt/runner/state.py
+++ b/torchtnt/runner/state.py
@@ -87,7 +87,9 @@ class PhaseState:
         self._max_steps_per_epoch = max_steps_per_epoch
         self._evaluate_every_n_steps = evaluate_every_n_steps
         self._evaluate_every_n_epochs = evaluate_every_n_epochs
+
         self._step_output: Any = None
+        self._is_last_batch: bool = False  # only used for train
 
     @property
     def dataloader(self) -> Iterable[Any]:
@@ -120,6 +122,10 @@ class PhaseState:
     @property
     def step_output(self) -> Any:
         return self._step_output
+
+    @property
+    def is_last_batch(self) -> bool:
+        return self._is_last_batch
 
 
 class State:

--- a/torchtnt/runner/train.py
+++ b/torchtnt/runner/train.py
@@ -14,7 +14,7 @@ from torchtnt.runner.state import ActivePhase, EntryPoint, PhaseState, State
 from torchtnt.runner.unit import TTrainData, TTrainUnit
 from torchtnt.runner.utils import (
     _is_done,
-    _is_epoch_done,
+    _is_last_batch_in_epoch,
     _maybe_set_distributed_sampler_epoch,
     _reset_module_training_mode,
     _run_callback_fn,
@@ -216,42 +216,62 @@ def _train_epoch_impl(
     pass_data_iter_to_step = _step_requires_iterator(train_unit.train_step)
     prev_steps_in_epoch = train_state.progress.num_steps_completed_in_epoch
 
-    while not (
-        state.should_stop
-        or _is_epoch_done(
-            train_state.progress, train_state.max_steps_per_epoch, train_state.max_steps
-        )
-    ):
+    try:
+        # get the first batch from the data iterator
+        if not pass_data_iter_to_step:
+            step_input = next(data_iter)
+    except StopIteration:
+        raise RuntimeError("Dataloader is empty")
+
+    # set is_last_batch to False before starting the loop. it will only be modified inside the loop
+    train_state._is_last_batch = False
+
+    while not state.should_stop and not train_state._is_last_batch:
         try:
+            # get the next batch from the data iterator
             if not pass_data_iter_to_step:
-                # get the next batch from the data iterator
-                with state.timer.time("train.data_iter_next"):
-                    step_input = next(data_iter)
+                next_step_input = next(data_iter)
 
-            _run_callback_fn(callbacks, "on_train_step_start", state, train_unit)
-            with state.timer.time(f"train.{train_unit.__class__.__name__}.train_step"):
-                train_state._step_output = train_unit.train_step(state, step_input)
-            train_state.progress.increment_step()
-            _run_callback_fn(callbacks, "on_train_step_end", state, train_unit)
-
-            # clear step_output to avoid retaining extra memory
-            train_state._step_output = None
-
-            if (
-                evaluate_every_n_steps
-                and train_state.progress.num_steps_completed_in_epoch
-                % evaluate_every_n_steps
-                == 0
+            if _is_last_batch_in_epoch(
+                train_state.progress,
+                train_state.max_steps_per_epoch,
+                train_state.max_steps,
             ):
-                _evaluate_impl(
-                    state,
-                    # pyre-ignore: Incompatible parameter type [6]
-                    train_unit,
-                    callbacks,
-                )
+                train_state._is_last_batch = True
 
         except StopIteration:
-            break
+            train_state._is_last_batch = True
+
+        _run_callback_fn(callbacks, "on_train_step_start", state, train_unit)
+        with state.timer.time(f"train.{train_unit.__class__.__name__}.train_step"):
+            try:
+                train_state._step_output = train_unit.train_step(state, step_input)
+            except StopIteration:
+                # catch a StopIteration for the case where the train_step takes in an iterator
+                break
+
+        train_state.progress.increment_step()
+        _run_callback_fn(callbacks, "on_train_step_end", state, train_unit)
+
+        # clear step_output to avoid retaining extra memory
+        train_state._step_output = None
+
+        if (
+            evaluate_every_n_steps
+            and train_state.progress.num_steps_completed_in_epoch
+            % evaluate_every_n_steps
+            == 0
+        ):
+            _evaluate_impl(
+                state,
+                # pyre-ignore: Incompatible parameter type [6]
+                train_unit,
+                callbacks,
+            )
+
+        if not pass_data_iter_to_step:
+            # pyre-ignore
+            step_input = next_step_input
 
     # Possibly warn about an empty dataloader
     any_steps_completed = (

--- a/torchtnt/runner/utils.py
+++ b/torchtnt/runner/utils.py
@@ -38,6 +38,17 @@ def _is_epoch_done(
     )
 
 
+def _is_last_batch_in_epoch(
+    progress: Progress, max_steps_per_epoch: Optional[int], max_steps: Optional[int]
+) -> bool:
+    return (
+        max_steps is not None and progress.num_steps_completed >= max_steps - 1
+    ) or (
+        max_steps_per_epoch is not None
+        and progress.num_steps_completed_in_epoch >= max_steps_per_epoch - 1
+    )
+
+
 def _maybe_set_distributed_sampler_epoch(
     # pyre-ignore: Missing parameter annotation [2]
     dataloader: Iterable[Any],


### PR DESCRIPTION
Summary: Now that we have the `is_last_batch` flag in the PhaseState, we can use this to know if a given train_step is the last batch, instead of relying on `on_train_epoch_end` to run the last optimizer step (in the case of grad accumulation).

Differential Revision: D40854929

