### PR TITLE
Make AutoUnit extend EvalUnit and PredictUnit

### DIFF
--- a/examples/runner/auto_unit_example.py
+++ b/examples/runner/auto_unit_example.py
@@ -18,7 +18,7 @@ import torch.nn as nn
 from torch.utils.data.dataset import Dataset, TensorDataset
 from torcheval.metrics import BinaryAccuracy
 from torchtnt.loggers import TensorBoardLogger
-from torchtnt.runner import AutoTrainUnit, init_train_state, State, train
+from torchtnt.runner import AutoUnit, fit, init_fit_state, State
 from torchtnt.utils import get_timer_summary, init_from_env, seed
 from typing_extensions import Literal
 
@@ -36,7 +36,7 @@ def _generate_dataset(num_samples: int, input_dim: int) -> Dataset[Batch]:
     return TensorDataset(data, labels)
 
 
-class MyTrainUnit(AutoTrainUnit[Batch]):
+class MyUnit(AutoUnit[Batch]):
     def __init__(
         self,
         *,
@@ -129,7 +129,7 @@ def main(argv: List[str]) -> None:
     lr_scheduler = torch.optim.lr_scheduler.ExponentialLR(optimizer, gamma=0.9)
     train_accuracy = BinaryAccuracy(device=device)
 
-    my_unit = MyTrainUnit(
+    my_unit = MyUnit(
         module=module,
         optimizer=optimizer,
         lr_scheduler=lr_scheduler,
@@ -143,19 +143,25 @@ def main(argv: List[str]) -> None:
         clip_grad_norm=1.0,
     )
 
-    num_samples = 10240
-    dataset = _generate_dataset(num_samples, args.input_dim)
     train_dataloader = torch.utils.data.DataLoader(
-        dataset,
+        dataset=_generate_dataset(num_samples=10240, input_dim=args.input_dim),
         batch_size=args.batch_size,
         pin_memory=(device.type == "cuda"),
     )
-    state = init_train_state(
-        dataloader=train_dataloader,
+
+    eval_dataloader = torch.utils.data.DataLoader(
+        dataset=_generate_dataset(num_samples=1024, input_dim=args.input_dim),
+        batch_size=args.batch_size,
+        pin_memory=(device.type == "cuda"),
+    )
+
+    state = init_fit_state(
+        train_dataloader=train_dataloader,
+        eval_dataloader=eval_dataloader,
         max_epochs=args.max_epochs,
     )
 
-    train(state, my_unit)
+    fit(state, my_unit)
 
     print(get_timer_summary(state.timer))
 

--- a/tests/runner/test_train.py
+++ b/tests/runner/test_train.py
@@ -45,6 +45,8 @@ class TrainTest(unittest.TestCase):
 
         # step_output should be reset to None
         self.assertEqual(state.train_state.step_output, None)
+        # is_last_batch should be set to True
+        self.assertEqual(state.train_state.is_last_batch, True)
 
         self.assertEqual(my_unit.module.training, initial_training_mode)
         self.assertEqual(state.entry_point, EntryPoint.TRAIN)

--- a/tests/runner/test_utils.py
+++ b/tests/runner/test_utils.py
@@ -24,6 +24,7 @@ from torchtnt.runner.unit import TEvalUnit, TPredictUnit, TTrainUnit
 from torchtnt.runner.utils import (
     _is_done,
     _is_epoch_done,
+    _is_last_batch_in_epoch,
     _maybe_set_distributed_sampler_epoch,
     _reset_module_training_mode,
     _run_callback_fn,
@@ -251,6 +252,39 @@ class UtilsTest(unittest.TestCase):
         self.assertFalse(_is_epoch_done(p, max_steps_per_epoch=None, max_steps=200))
         self.assertFalse(_is_epoch_done(p, max_steps_per_epoch=6, max_steps=None))
         self.assertFalse(_is_epoch_done(p, max_steps_per_epoch=None, max_steps=None))
+
+    def test_is_last_batch_in_epoch(self) -> None:
+        p = Progress(
+            num_epochs_completed=2,
+            num_steps_completed=99,
+            num_steps_completed_in_epoch=9,
+        )
+
+        self.assertTrue(
+            _is_last_batch_in_epoch(p, max_steps_per_epoch=10, max_steps=200)
+        )
+        self.assertTrue(
+            _is_last_batch_in_epoch(p, max_steps_per_epoch=10, max_steps=None)
+        )
+        self.assertTrue(
+            _is_last_batch_in_epoch(p, max_steps_per_epoch=100, max_steps=100)
+        )
+        self.assertTrue(
+            _is_last_batch_in_epoch(p, max_steps_per_epoch=None, max_steps=100)
+        )
+
+        self.assertFalse(
+            _is_last_batch_in_epoch(p, max_steps_per_epoch=11, max_steps=200)
+        )
+        self.assertFalse(
+            _is_last_batch_in_epoch(p, max_steps_per_epoch=None, max_steps=200)
+        )
+        self.assertFalse(
+            _is_last_batch_in_epoch(p, max_steps_per_epoch=11, max_steps=None)
+        )
+        self.assertFalse(
+            _is_last_batch_in_epoch(p, max_steps_per_epoch=None, max_steps=None)
+        )
 
 
 class DummyCallback(Callback):

--- a/torchtnt/runner/__init__.py
+++ b/torchtnt/runner/__init__.py
@@ -4,7 +4,7 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
-from .auto_unit import AutoTrainUnit
+from .auto_unit import AutoUnit
 from .callback import Callback
 from .evaluate import evaluate, init_eval_state
 from .fit import fit, init_fit_state
@@ -15,7 +15,7 @@ from .train import init_train_state, train
 from .unit import EvalUnit, PredictUnit, TrainUnit
 
 __all__ = [
-    "AutoTrainUnit",
+    "AutoUnit",
     "Callback",
     "evaluate",
     "init_eval_state",

--- a/torchtnt/runner/_test_utils.py
+++ b/torchtnt/runner/_test_utils.py
@@ -5,11 +5,11 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
-from typing import Tuple
+from typing import Iterator, Tuple
 
 import torch
-from torch import nn
-from torch.utils.data import DataLoader, Dataset, TensorDataset
+from torch import nn, Tensor
+from torch.utils.data import DataLoader, Dataset, IterableDataset, TensorDataset
 from torchtnt.runner.state import State
 from torchtnt.runner.unit import EvalUnit, PredictUnit, TrainUnit
 
@@ -109,5 +109,24 @@ def generate_random_dataloader(
 ) -> DataLoader:
     return DataLoader(
         generate_random_dataset(num_samples, input_dim),
+        batch_size=batch_size,
+    )
+
+
+class RandomIterableDataset(IterableDataset):
+    def __init__(self, size: int, count: int) -> None:
+        self.count: int = count
+        self.size: int = size
+
+    def __iter__(self) -> Iterator[Tensor]:
+        for _ in range(self.count):
+            yield torch.randn(self.size)
+
+
+def generate_random_predict_dataloader(
+    num_samples: int, input_dim: int, batch_size: int
+) -> DataLoader:
+    return DataLoader(
+        dataset=RandomIterableDataset(input_dim, num_samples),
         batch_size=batch_size,
     )

--- a/torchtnt/runner/state.py
+++ b/torchtnt/runner/state.py
@@ -87,7 +87,9 @@ class PhaseState:
         self._max_steps_per_epoch = max_steps_per_epoch
         self._evaluate_every_n_steps = evaluate_every_n_steps
         self._evaluate_every_n_epochs = evaluate_every_n_epochs
+
         self._step_output: Any = None
+        self._is_last_batch: bool = False  # only used for train
 
     @property
     def dataloader(self) -> Iterable[Any]:
@@ -120,6 +122,10 @@ class PhaseState:
     @property
     def step_output(self) -> Any:
         return self._step_output
+
+    @property
+    def is_last_batch(self) -> bool:
+        return self._is_last_batch
 
 
 class State:

--- a/torchtnt/runner/train.py
+++ b/torchtnt/runner/train.py
@@ -14,7 +14,7 @@ from torchtnt.runner.state import ActivePhase, EntryPoint, PhaseState, State
 from torchtnt.runner.unit import TTrainData, TTrainUnit
 from torchtnt.runner.utils import (
     _is_done,
-    _is_epoch_done,
+    _is_last_batch_in_epoch,
     _maybe_set_distributed_sampler_epoch,
     _reset_module_training_mode,
     _run_callback_fn,
@@ -216,42 +216,62 @@ def _train_epoch_impl(
     pass_data_iter_to_step = _step_requires_iterator(train_unit.train_step)
     prev_steps_in_epoch = train_state.progress.num_steps_completed_in_epoch
 
-    while not (
-        state.should_stop
-        or _is_epoch_done(
-            train_state.progress, train_state.max_steps_per_epoch, train_state.max_steps
-        )
-    ):
+    try:
+        # get the first batch from the data iterator
+        if not pass_data_iter_to_step:
+            step_input = next(data_iter)
+    except StopIteration:
+        raise RuntimeError("Dataloader is empty")
+
+    # set is_last_batch to False before starting the loop. it will only be modified inside the loop
+    train_state._is_last_batch = False
+
+    while not state.should_stop and not train_state._is_last_batch:
         try:
+            # get the next batch from the data iterator
             if not pass_data_iter_to_step:
-                # get the next batch from the data iterator
-                with state.timer.time("train.data_iter_next"):
-                    step_input = next(data_iter)
+                next_step_input = next(data_iter)
 
-            _run_callback_fn(callbacks, "on_train_step_start", state, train_unit)
-            with state.timer.time(f"train.{train_unit.__class__.__name__}.train_step"):
-                train_state._step_output = train_unit.train_step(state, step_input)
-            train_state.progress.increment_step()
-            _run_callback_fn(callbacks, "on_train_step_end", state, train_unit)
-
-            # clear step_output to avoid retaining extra memory
-            train_state._step_output = None
-
-            if (
-                evaluate_every_n_steps
-                and train_state.progress.num_steps_completed_in_epoch
-                % evaluate_every_n_steps
-                == 0
+            if _is_last_batch_in_epoch(
+                train_state.progress,
+                train_state.max_steps_per_epoch,
+                train_state.max_steps,
             ):
-                _evaluate_impl(
-                    state,
-                    # pyre-ignore: Incompatible parameter type [6]
-                    train_unit,
-                    callbacks,
-                )
+                train_state._is_last_batch = True
 
         except StopIteration:
-            break
+            train_state._is_last_batch = True
+
+        _run_callback_fn(callbacks, "on_train_step_start", state, train_unit)
+        with state.timer.time(f"train.{train_unit.__class__.__name__}.train_step"):
+            try:
+                train_state._step_output = train_unit.train_step(state, step_input)
+            except StopIteration:
+                # catch a StopIteration for the case where the train_step takes in an iterator
+                break
+
+        train_state.progress.increment_step()
+        _run_callback_fn(callbacks, "on_train_step_end", state, train_unit)
+
+        # clear step_output to avoid retaining extra memory
+        train_state._step_output = None
+
+        if (
+            evaluate_every_n_steps
+            and train_state.progress.num_steps_completed_in_epoch
+            % evaluate_every_n_steps
+            == 0
+        ):
+            _evaluate_impl(
+                state,
+                # pyre-ignore: Incompatible parameter type [6]
+                train_unit,
+                callbacks,
+            )
+
+        if not pass_data_iter_to_step:
+            # pyre-ignore
+            step_input = next_step_input
 
     # Possibly warn about an empty dataloader
     any_steps_completed = (

--- a/torchtnt/runner/utils.py
+++ b/torchtnt/runner/utils.py
@@ -38,6 +38,17 @@ def _is_epoch_done(
     )
 
 
+def _is_last_batch_in_epoch(
+    progress: Progress, max_steps_per_epoch: Optional[int], max_steps: Optional[int]
+) -> bool:
+    return (
+        max_steps is not None and progress.num_steps_completed >= max_steps - 1
+    ) or (
+        max_steps_per_epoch is not None
+        and progress.num_steps_completed_in_epoch >= max_steps_per_epoch - 1
+    )
+
+
 def _maybe_set_distributed_sampler_epoch(
     # pyre-ignore: Missing parameter annotation [2]
     dataloader: Iterable[Any],


### PR DESCRIPTION
Summary: This will allow the AutoUnit to be used with the `evaluate`, `predict`, and `fit` entry points as well.

Differential Revision: D40649415

