### PR TITLE
Exclude get_pet_launch_config from torchtnt.utils

### DIFF
--- a/tests/utils/test_env.py
+++ b/tests/utils/test_env.py
@@ -9,12 +9,9 @@ import unittest
 
 import torch
 import torch.distributed.launcher as pet
-from torchtnt.utils import (
-    get_device_from_env,
-    get_pet_launch_config,
-    get_process_group_backend_from_device,
-)
+from torchtnt.utils import get_device_from_env, get_process_group_backend_from_device
 from torchtnt.utils.env import init_from_env
+from torchtnt.utils.test_utils import get_pet_launch_config
 
 
 class EnvTest(unittest.TestCase):

--- a/torchtnt/utils/__init__.py
+++ b/torchtnt/utils/__init__.py
@@ -34,7 +34,6 @@ from .rank_zero_log import (
     rank_zero_warn,
 )
 from .seed import seed
-from .test_utils import get_pet_launch_config
 from .timer import FullSyncPeriodicTimer, get_timer_summary, Timer
 from .version import (
     get_python_version,
@@ -76,7 +75,6 @@ __all__ = [
     "rank_zero_print",
     "rank_zero_warn",
     "seed",
-    "get_pet_launch_config",
     "FullSyncPeriodicTimer",
     "get_timer_summary",
     "Timer",


### PR DESCRIPTION
Summary:
Importing torchtnt.utils pulls torchtnt.test_utils which pulls torch.distributed.launcher that takes 3.5s to import.

torchtnt.test_utils is used only in tests

Before:
https://pxl.cl/2jnVc

After:
https://pxl.cl/2jnVf

Reviewed By: daniellepintz

Differential Revision: D40866222

