### PR TITLE
Add copy_data_to_device overridable method to AutoUnit

### DIFF
--- a/tests/runner/test_auto_unit.py
+++ b/tests/runner/test_auto_unit.py
@@ -21,6 +21,7 @@ from torchtnt.runner.auto_unit import AutoTrainUnit
 from torchtnt.runner.state import State
 from torchtnt.runner.train import init_train_state, train
 from torchtnt.utils import init_from_env
+from torchtnt.utils.device import copy_data_to_device
 from torchtnt.utils.test_utils import get_pet_launch_config
 
 
@@ -368,11 +369,35 @@ class TestAutoUnit(unittest.TestCase):
                 precision="fp16",
             )
 
+    def test_move_data_to_device(self) -> None:
+        """
+        Test that move_data_to_device is called
+        """
+        device = init_from_env()
+        my_module = torch.nn.Linear(2, 2).to(device)
+        my_optimizer = torch.optim.SGD(my_module.parameters(), lr=0.01)
 
-class DummyAutoTrainUnit(AutoTrainUnit[Tuple[torch.tensor, torch.tensor]]):
-    def compute_loss(
-        self, state: State, data: Tuple[torch.tensor, torch.tensor]
-    ) -> Tuple[torch.Tensor, Any]:
+        auto_train_unit = DummyAutoTrainUnit(
+            module=my_module,
+            optimizer=my_optimizer,
+        )
+
+        dummy_data = (torch.ones(2, 2), torch.ones(2, 2))
+
+        with patch.object(
+            DummyAutoTrainUnit, "move_data_to_device"
+        ) as move_data_to_device_mock:
+            dummy_data = copy_data_to_device(dummy_data, device)
+            move_data_to_device_mock.return_value = dummy_data
+            auto_train_unit.train_step(state=MagicMock(), data=dummy_data)
+            move_data_to_device_mock.assert_called_once()
+
+
+Batch = Tuple[torch.tensor, torch.tensor]
+
+
+class DummyAutoTrainUnit(AutoTrainUnit[Batch]):
+    def compute_loss(self, state: State, data: Batch) -> Tuple[torch.Tensor, Any]:
         inputs, targets = data
         outputs = self.module(inputs)
         loss = torch.nn.functional.cross_entropy(outputs, targets)

--- a/torchtnt/runner/auto_unit.py
+++ b/torchtnt/runner/auto_unit.py
@@ -159,8 +159,22 @@ class AutoTrainUnit(TrainUnit[TTrainData], ABC):
         """
         pass
 
+    def move_data_to_device(self, state: State, data: TTrainData) -> TTrainData:
+        """
+        The user can override this method with custom code to copy data to device. This will be called at the start of every ``train_step``.
+        By default this uses the utility function :py:func:`~torchtnt.utils.copy_data_to_device`.
+
+        Args:
+            state: a State object which is passed from the ``train_step``
+            data: a batch of data which is passed from the ``train_step``
+
+        Returns:
+            A batch of data which is on the device
+        """
+        return copy_data_to_device(data, self.device)
+
     def train_step(self, state: State, data: TTrainData) -> Tuple[torch.Tensor, Any]:
-        data = copy_data_to_device(data, self.device)
+        data = self.move_data_to_device(state, data)
         assert state.train_state
 
         should_update_weights = (


### PR DESCRIPTION
Summary:
Make copy_data_to_device an overridable method on the AutoUnit so that users can implement custom data transforms / moving data to device

Requested by user [in this post](https://fb.workplace.com/groups/1323951304836028/permalink/1343979336166558/)

Differential Revision: D41044574

