### PR TITLE
Delete stub file to enable mypy check (#799)

### DIFF
--- a/torchtnt/runner/auto_unit.py
+++ b/torchtnt/runner/auto_unit.py
@@ -191,7 +191,7 @@ class AutoTrainUnit(TrainUnit[TTrainData], ABC):
         # https://pytorch.org/docs/stable/_modules/torch/nn/parallel/distributed.html#DistributedDataParallel.no_sync
         # https://pytorch.org/docs/stable/fsdp.html#torch.distributed.fsdp.FullyShardedDataParallel.no_sync
         maybe_no_sync = (
-            self.module.no_sync()  # pyre-ignore
+            self.module.no_sync()
             if not should_update_weights and isinstance(self.module, (DDP, FSDP))
             else contextlib.nullcontext()
         )


### PR DESCRIPTION
Summary:
X-link: https://github.com/pytorch/torchrec/pull/799

X-link: https://github.com/facebookresearch/detectron2/pull/4649

Context in https://fburl.com/4irjskbe

This change deletes distributed.pyi, so that lintrunner will run mypy on distributed.py for typing check.

Differential Revision: D41028360

