### PR TITLE
Use pyre_extensions none_throws for assertions

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,7 @@ numpy
 fsspec
 tensorboard
 psutil
+pyre_extensions
 typing_extensions
 setuptools
 tqdm

--- a/torchtnt/runner/callbacks/base_csv_writer.py
+++ b/torchtnt/runner/callbacks/base_csv_writer.py
@@ -9,6 +9,8 @@ import os
 from abc import ABC, abstractmethod
 from typing import Any, List, TextIO, Union
 
+from pyre_extensions import none_throws
+
 from torchtnt.runner.callback import Callback
 from torchtnt.runner.state import EntryPoint, State
 from torchtnt.runner.unit import TEvalUnit, TPredictUnit, TTrainUnit
@@ -67,8 +69,8 @@ class BaseCSVWriter(Callback, ABC):
             self._writer.writerow(self.header_row)
 
     def on_predict_step_end(self, state: State, unit: TPredictUnit) -> None:
-        assert state.predict_state is not None
-        step_output = state.predict_state.step_output
+        predict_state = none_throws(state.predict_state)
+        step_output = predict_state.step_output
         output_rows = self.get_step_output_rows(state, unit, step_output)
 
         # Check whether the first item is a list or not

--- a/torchtnt/runner/callbacks/garbage_collector.py
+++ b/torchtnt/runner/callbacks/garbage_collector.py
@@ -6,6 +6,8 @@
 
 import gc
 
+from pyre_extensions import none_throws
+
 from torchtnt.runner.callback import Callback
 from torchtnt.runner.state import State
 from torchtnt.runner.unit import TEvalUnit, TPredictUnit, TTrainUnit
@@ -40,11 +42,8 @@ class GarbageCollector(Callback):
         gc.disable()
 
     def on_train_step_end(self, state: State, unit: TTrainUnit) -> None:
-        if (
-            state.train_state
-            and (state.train_state.progress.num_steps_completed) % self._step_interval
-            == 0
-        ):
+        train_state = none_throws(state.train_state)
+        if train_state.progress.num_steps_completed % self._step_interval == 0:
             gc.collect()
 
     def on_train_end(self, state: State, unit: TTrainUnit) -> None:
@@ -54,11 +53,8 @@ class GarbageCollector(Callback):
         gc.disable()
 
     def on_eval_step_end(self, state: State, unit: TEvalUnit) -> None:
-        if (
-            state.eval_state
-            and (state.eval_state.progress.num_steps_completed) % self._step_interval
-            == 0
-        ):
+        eval_state = none_throws(state.eval_state)
+        if eval_state.progress.num_steps_completed % self._step_interval == 0:
             gc.collect()
 
     def on_eval_end(self, state: State, unit: TEvalUnit) -> None:
@@ -68,11 +64,8 @@ class GarbageCollector(Callback):
         gc.disable()
 
     def on_predict_step_end(self, state: State, unit: TPredictUnit) -> None:
-        if (
-            state.predict_state
-            and (state.predict_state.progress.num_steps_completed) % self._step_interval
-            == 0
-        ):
+        predict_state = none_throws(state.predict_state)
+        if predict_state.progress.num_steps_completed % self._step_interval == 0:
             gc.collect()
 
     def on_predict_end(self, state: State, unit: TPredictUnit) -> None:

--- a/torchtnt/runner/callbacks/learning_rate_monitor.py
+++ b/torchtnt/runner/callbacks/learning_rate_monitor.py
@@ -6,6 +6,8 @@
 
 from typing import Dict, List, Union
 
+from pyre_extensions import none_throws
+
 from torch.optim.optimizer import Optimizer
 from torchtnt.loggers.logger import MetricLogger
 from torchtnt.runner.callback import Callback
@@ -98,8 +100,7 @@ class LearningRateMonitor(Callback):
 
         lr_stats = _extract_lr(unit)
 
-        train_state = state.train_state
-        assert train_state
+        train_state = none_throws(state.train_state)
 
         step = train_state.progress.num_steps_completed
         _write_stats(self._loggers, lr_stats, step)
@@ -113,8 +114,7 @@ class LearningRateMonitor(Callback):
 
         lr_stats = _extract_lr(unit)
 
-        train_state = state.train_state
-        assert train_state
+        train_state = none_throws(state.train_state)
 
         step = train_state.progress.num_steps_completed
         _write_stats(self._loggers, lr_stats, step)

--- a/torchtnt/runner/callbacks/tensorboard_parameter_monitor.py
+++ b/torchtnt/runner/callbacks/tensorboard_parameter_monitor.py
@@ -7,6 +7,9 @@
 from typing import Dict, Optional, Union
 
 import torch
+
+from pyre_extensions import none_throws
+
 from torch.utils.tensorboard import SummaryWriter
 from torchtnt.loggers.tensorboard import TensorBoardLogger
 from torchtnt.runner.callback import Callback
@@ -46,8 +49,7 @@ class TensorBoardParameterMonitor(Callback):
         if not writer:
             return
 
-        train_state = state.train_state
-        assert train_state
+        train_state = none_throws(state.train_state)
 
         step = train_state.progress.num_steps_completed
         modules = unit.tracked_modules()

--- a/torchtnt/runner/callbacks/torchsnapshot_saver.py
+++ b/torchtnt/runner/callbacks/torchsnapshot_saver.py
@@ -7,6 +7,8 @@
 import os
 from typing import Dict, List, Optional, Set
 
+from pyre_extensions import none_throws
+
 from torchtnt.runner.callback import Callback
 from torchtnt.runner.state import EntryPoint, State
 from torchtnt.runner.unit import _Stateful as StatefulProtocol, TTrainUnit
@@ -78,8 +80,7 @@ class TorchSnapshotSaver(Callback):
         _check_app_state_collision(app_state)
 
     def on_train_step_end(self, state: State, unit: TTrainUnit) -> None:
-        train_state = state.train_state
-        assert train_state
+        train_state = none_throws(state.train_state)
 
         global_step = train_state.progress.num_steps_completed
         every_n_train_steps = self._save_every_n_train_steps
@@ -100,8 +101,7 @@ class TorchSnapshotSaver(Callback):
         rank_zero_info(f"Saved snapshot to path: {snapshot_path}")
 
     def on_train_epoch_end(self, state: State, unit: TTrainUnit) -> None:
-        train_state = state.train_state
-        assert train_state
+        train_state = none_throws(state.train_state)
 
         train_progress = train_state.progress
         epoch = train_progress.num_epochs_completed
@@ -132,8 +132,7 @@ def _get_snapshot_save_path(dirpath: str, epoch: int, step: int) -> str:
 def _get_app_state(
     state: State, unit: TTrainUnit, replicated: Set[str], *, intra_epoch: bool
 ) -> Dict[str, _TStateful]:
-    train_state = state.train_state
-    assert train_state
+    train_state = none_throws(state.train_state)
 
     train_progress = train_state.progress
     app_state = unit.app_state()
@@ -151,8 +150,7 @@ def _get_app_state(
 
     if state.entry_point == EntryPoint.FIT:
         # include evaluation states if fitting
-        eval_state = state.eval_state
-        assert eval_state
+        eval_state = none_throws(state.eval_state)
 
         app_state[EVAL_PROGRESS_STATE_KEY] = eval_state.progress
         eval_prog_glob = f"{EVAL_PROGRESS_STATE_KEY}/*"

--- a/torchtnt/runner/callbacks/tqdm_progress_bar.py
+++ b/torchtnt/runner/callbacks/tqdm_progress_bar.py
@@ -7,6 +7,8 @@
 from collections.abc import Sized
 from typing import Iterable, Optional
 
+from pyre_extensions import none_throws
+
 from torchtnt.runner.callback import Callback
 from torchtnt.runner.state import State
 from torchtnt.runner.unit import TEvalUnit, TPredictUnit, TTrainUnit
@@ -31,83 +33,89 @@ class TQDMProgressBar(Callback):
         self._predict_progress_bar: Optional[tqdm] = None
 
     def on_train_epoch_start(self, state: State, unit: TTrainUnit) -> None:
-        if state.train_state:
-            self._train_progress_bar = _create_progress_bar(
-                state.train_state.dataloader,
-                desc="Train Epoch",
-                num_epochs_completed=state.train_state.progress.num_epochs_completed,
-                num_steps_completed=state.train_state.progress.num_steps_completed,
-                max_steps=state.train_state.max_steps,
-                max_steps_per_epoch=state.train_state.max_steps_per_epoch,
-            )
+        train_state = none_throws(state.train_state)
+        self._train_progress_bar = _create_progress_bar(
+            train_state.dataloader,
+            desc="Train Epoch",
+            num_epochs_completed=train_state.progress.num_epochs_completed,
+            num_steps_completed=train_state.progress.num_steps_completed,
+            max_steps=train_state.max_steps,
+            max_steps_per_epoch=train_state.max_steps_per_epoch,
+        )
 
     def on_train_step_end(self, state: State, unit: TTrainUnit) -> None:
-        if self._train_progress_bar is not None and state.train_state:
+        train_state = none_throws(state.train_state)
+        if self._train_progress_bar is not None:
             _update_progress_bar(
                 self._train_progress_bar,
-                state.train_state.progress.num_steps_completed,
+                train_state.progress.num_steps_completed,
                 self._refresh_rate,
             )
 
     def on_train_epoch_end(self, state: State, unit: TTrainUnit) -> None:
-        if self._train_progress_bar is not None and state.train_state:
+        train_state = none_throws(state.train_state)
+        if self._train_progress_bar is not None:
             _close_progress_bar(
                 self._train_progress_bar,
-                state.train_state.progress.num_steps_completed,
+                train_state.progress.num_steps_completed,
                 self._refresh_rate,
             )
 
     def on_eval_epoch_start(self, state: State, unit: TEvalUnit) -> None:
-        if state.eval_state:
-            self._eval_progress_bar = _create_progress_bar(
-                state.eval_state.dataloader,
-                desc="Eval Epoch",
-                num_epochs_completed=state.eval_state.progress.num_epochs_completed,
-                num_steps_completed=state.eval_state.progress.num_steps_completed,
-                max_steps=state.eval_state.max_steps,
-                max_steps_per_epoch=state.eval_state.max_steps_per_epoch,
-            )
+        eval_state = none_throws(state.eval_state)
+        self._eval_progress_bar = _create_progress_bar(
+            eval_state.dataloader,
+            desc="Eval Epoch",
+            num_epochs_completed=eval_state.progress.num_epochs_completed,
+            num_steps_completed=eval_state.progress.num_steps_completed,
+            max_steps=eval_state.max_steps,
+            max_steps_per_epoch=eval_state.max_steps_per_epoch,
+        )
 
     def on_eval_step_end(self, state: State, unit: TEvalUnit) -> None:
-        if self._eval_progress_bar is not None and state.eval_state:
+        eval_state = none_throws(state.eval_state)
+        if self._eval_progress_bar is not None:
             _update_progress_bar(
                 self._eval_progress_bar,
-                state.eval_state.progress.num_steps_completed,
+                eval_state.progress.num_steps_completed,
                 self._refresh_rate,
             )
 
     def on_eval_epoch_end(self, state: State, unit: TEvalUnit) -> None:
+        eval_state = none_throws(state.eval_state)
         if self._eval_progress_bar is not None and state.eval_state:
             _close_progress_bar(
                 self._eval_progress_bar,
-                state.eval_state.progress.num_steps_completed,
+                eval_state.progress.num_steps_completed,
                 self._refresh_rate,
             )
 
     def on_predict_epoch_start(self, state: State, unit: TPredictUnit) -> None:
-        if state.predict_state:
-            self._predict_progress_bar = _create_progress_bar(
-                state.predict_state.dataloader,
-                desc="Predict Epoch",
-                num_epochs_completed=state.predict_state.progress.num_epochs_completed,
-                num_steps_completed=state.predict_state.progress.num_steps_completed,
-                max_steps=state.predict_state.max_steps,
-                max_steps_per_epoch=state.predict_state.max_steps_per_epoch,
-            )
+        predict_state = none_throws(state.predict_state)
+        self._predict_progress_bar = _create_progress_bar(
+            predict_state.dataloader,
+            desc="Predict Epoch",
+            num_epochs_completed=predict_state.progress.num_epochs_completed,
+            num_steps_completed=predict_state.progress.num_steps_completed,
+            max_steps=predict_state.max_steps,
+            max_steps_per_epoch=predict_state.max_steps_per_epoch,
+        )
 
     def on_predict_step_end(self, state: State, unit: TPredictUnit) -> None:
-        if self._predict_progress_bar is not None and state.predict_state:
+        predict_state = none_throws(state.predict_state)
+        if self._predict_progress_bar is not None:
             _update_progress_bar(
                 self._predict_progress_bar,
-                state.predict_state.progress.num_steps_completed,
+                predict_state.progress.num_steps_completed,
                 self._refresh_rate,
             )
 
     def on_predict_epoch_end(self, state: State, unit: TPredictUnit) -> None:
-        if self._predict_progress_bar is not None and state.predict_state:
+        predict_state = none_throws(state.predict_state)
+        if self._predict_progress_bar is not None:
             _close_progress_bar(
                 self._predict_progress_bar,
-                state.predict_state.progress.num_steps_completed,
+                predict_state.progress.num_steps_completed,
                 self._refresh_rate,
             )
 

--- a/torchtnt/runner/evaluate.py
+++ b/torchtnt/runner/evaluate.py
@@ -8,6 +8,7 @@ import logging
 from typing import Iterable, List, Optional
 
 import torch
+from pyre_extensions import none_throws
 from torchtnt.runner.callback import Callback
 
 from torchtnt.runner.state import ActivePhase, EntryPoint, PhaseState, State
@@ -86,9 +87,7 @@ def _evaluate_impl(
     callbacks: List[Callback],
 ) -> None:
     # input validation
-    eval_state = state.eval_state
-    if not eval_state:
-        raise RuntimeError("Expected eval_state to be initialized!")
+    eval_state = none_throws(state.eval_state)
 
     state._active_phase = ActivePhase.EVALUATE
     logger.info(

--- a/torchtnt/runner/fit.py
+++ b/torchtnt/runner/fit.py
@@ -7,8 +7,8 @@
 import logging
 from typing import Iterable, List, Optional
 
+from pyre_extensions import none_throws
 from torchtnt.runner.callback import Callback
-
 from torchtnt.runner.state import EntryPoint, PhaseState, State
 from torchtnt.runner.train import _train_epoch_impl
 from torchtnt.runner.unit import EvalUnit, TEvalData, TrainUnit, TTrainData, TTrainUnit
@@ -100,12 +100,8 @@ def _fit_impl(
     if not isinstance(unit, EvalUnit):
         raise TypeError("Expected unit to implement EvalUnit interface.")
 
-    train_state = state.train_state
-    if not train_state:
-        raise RuntimeError("Expected train_state to be initialized")
-    eval_state = state.eval_state
-    if not eval_state:
-        raise RuntimeError("Expected eval_state to be initialized")
+    train_state = none_throws(state.train_state)
+    eval_state = none_throws(state.eval_state)
 
     logger.info(
         f"Started fit with max_epochs={train_state.max_epochs} "

--- a/torchtnt/runner/predict.py
+++ b/torchtnt/runner/predict.py
@@ -8,6 +8,7 @@ import logging
 from typing import Iterable, List, Optional
 
 import torch
+from pyre_extensions import none_throws
 from torchtnt.runner.callback import Callback
 
 from torchtnt.runner.state import ActivePhase, EntryPoint, PhaseState, State
@@ -86,9 +87,7 @@ def _predict_impl(
     callbacks: List[Callback],
 ) -> None:
     # input validation
-    predict_state = state.predict_state
-    if not predict_state:
-        raise RuntimeError("Expected predict_state to be initialized!")
+    predict_state = none_throws(state.predict_state)
 
     state._active_phase = ActivePhase.PREDICT
     logger.info(

--- a/torchtnt/runner/train.py
+++ b/torchtnt/runner/train.py
@@ -8,6 +8,7 @@ import logging
 from typing import Iterable, List, Optional
 
 import torch
+from pyre_extensions import none_throws
 from torchtnt.runner.callback import Callback
 from torchtnt.runner.evaluate import _evaluate_impl
 from torchtnt.runner.state import ActivePhase, EntryPoint, PhaseState, State
@@ -93,9 +94,7 @@ def _train_impl(
     train_unit: TTrainUnit,
     callbacks: List[Callback],
 ) -> None:
-    train_state = state.train_state
-    if not train_state:
-        raise RuntimeError("Expected train_state to be initialized!")
+    train_state = none_throws(state.train_state)
 
     logger.info(
         f"Started train with max_epochs={train_state.max_epochs}, max_steps={train_state.max_steps}, max_steps_per_epoch={train_state.max_steps_per_epoch}"
@@ -146,9 +145,7 @@ def train_epoch(
     """
     callbacks = callbacks or []
     try:
-        train_state = state.train_state
-        if not train_state:
-            raise RuntimeError("Expected train_state to be initialized!")
+        train_state = none_throws(state.train_state)
         if not train_state.max_epochs == 1:
             raise RuntimeError(
                 f"Expected state.train_state.max_epochs to be 1, but received {train_state.max_epochs}."
@@ -185,8 +182,7 @@ def _train_epoch_impl(
     tracked_modules = train_unit.tracked_modules()
     prior_module_train_states = _set_module_training_mode(tracked_modules, True)
 
-    train_state = state.train_state
-    assert train_state is not None
+    train_state = none_throws(state.train_state)
 
     evaluate_every_n_steps = None
     evaluate_every_n_epochs = None


### PR DESCRIPTION
Summary: Saves one line of assertions per validation callsite

Reviewed By: JKSenthil

Differential Revision: D41393263

