### PR TITLE
Fix rank zero logging utilities for python 3.7

### DIFF
--- a/tests/utils/test_rank_zero_log.py
+++ b/tests/utils/test_rank_zero_log.py
@@ -8,6 +8,8 @@
 import unittest
 from unittest.mock import MagicMock, patch
 
+from packaging.version import Version
+
 from torchtnt.utils.rank_zero_log import (
     rank_zero_critical,
     rank_zero_debug,
@@ -15,6 +17,7 @@ from torchtnt.utils.rank_zero_log import (
     rank_zero_info,
     rank_zero_warn,
 )
+from torchtnt.utils.version import get_python_version
 
 
 class RankZeroLogTest(unittest.TestCase):
@@ -22,21 +25,37 @@ class RankZeroLogTest(unittest.TestCase):
     def test_rank_zero_fn_rank_zero(self) -> None:
 
         logger = MagicMock()
+        supports_stacklevel = get_python_version() >= Version("3.8.0")
 
         rank_zero_debug("foo", logger=logger)
-        logger.debug.assert_called_once_with("foo", stacklevel=2)
+        if supports_stacklevel:
+            logger.debug.assert_called_once_with("foo", stacklevel=2)
+        else:
+            logger.debug.assert_called_once_with("foo")
 
         rank_zero_info("foo", logger=logger)
-        logger.info.assert_called_once_with("foo", stacklevel=2)
+        if supports_stacklevel:
+            logger.info.assert_called_once_with("foo", stacklevel=2)
+        else:
+            logger.info.assert_called_once_with("foo")
 
         rank_zero_warn("foo", logger=logger)
-        logger.warn.assert_called_once_with("foo", stacklevel=2)
+        if supports_stacklevel:
+            logger.warning.assert_called_once_with("foo", stacklevel=2)
+        else:
+            logger.warning.assert_called_once_with("foo")
 
         rank_zero_error("foo", logger=logger)
-        logger.error.assert_called_once_with("foo", stacklevel=2)
+        if supports_stacklevel:
+            logger.error.assert_called_once_with("foo", stacklevel=2)
+        else:
+            logger.error.assert_called_once_with("foo")
 
         rank_zero_critical("foo", logger=logger)
-        logger.critical.assert_called_once_with("foo", stacklevel=2)
+        if supports_stacklevel:
+            logger.critical.assert_called_once_with("foo", stacklevel=2)
+        else:
+            logger.critical.assert_called_once_with("foo")
 
     @patch.dict("os.environ", {"RANK": "1"}, clear=True)
     def test_rank_zero_fn_rank_non_zero(self) -> None:
@@ -50,7 +69,7 @@ class RankZeroLogTest(unittest.TestCase):
         logger.info.assert_not_called()
 
         rank_zero_warn("foo", logger=logger)
-        logger.warn.assert_not_called()
+        logger.warning.assert_not_called()
 
         rank_zero_error("foo", logger=logger)
         logger.error.assert_not_called()

--- a/torchtnt/utils/rank_zero_log.py
+++ b/torchtnt/utils/rank_zero_log.py
@@ -8,7 +8,10 @@
 import logging
 from typing import Any, Optional
 
+from packaging.version import Version
+
 from torchtnt.utils.distributed import get_global_rank
+from torchtnt.utils.version import get_python_version
 
 _LOGGER: logging.Logger = logging.getLogger(__name__)
 
@@ -25,7 +28,9 @@ def rank_zero_debug(
     if get_global_rank() != 0:
         return
     logger = logger or _LOGGER
-    logger.debug(*args, stacklevel=2, **kwargs)
+    if _supports_stacklevel():
+        kwargs["stacklevel"] = 2
+    logger.debug(*args, **kwargs)
 
 
 def rank_zero_info(
@@ -34,7 +39,9 @@ def rank_zero_info(
     if get_global_rank() != 0:
         return
     logger = logger or _LOGGER
-    logger.info(*args, stacklevel=2, **kwargs)
+    if _supports_stacklevel():
+        kwargs["stacklevel"] = 2
+    logger.info(*args, **kwargs)
 
 
 def rank_zero_warn(
@@ -43,7 +50,9 @@ def rank_zero_warn(
     if get_global_rank() != 0:
         return
     logger = logger or _LOGGER
-    logger.warn(*args, stacklevel=2, **kwargs)
+    if _supports_stacklevel():
+        kwargs["stacklevel"] = 2
+    logger.warning(*args, **kwargs)
 
 
 def rank_zero_error(
@@ -52,7 +61,9 @@ def rank_zero_error(
     if get_global_rank() != 0:
         return
     logger = logger or _LOGGER
-    logger.error(*args, stacklevel=2, **kwargs)
+    if _supports_stacklevel():
+        kwargs["stacklevel"] = 2
+    logger.error(*args, **kwargs)
 
 
 def rank_zero_critical(
@@ -61,4 +72,10 @@ def rank_zero_critical(
     if get_global_rank() != 0:
         return
     logger = logger or _LOGGER
-    logger.critical(*args, stacklevel=2, **kwargs)
+    if _supports_stacklevel():
+        kwargs["stacklevel"] = 2
+    logger.critical(*args, **kwargs)
+
+
+def _supports_stacklevel() -> bool:
+    return get_python_version() >= Version("3.8.0")


### PR DESCRIPTION
Summary:
`stacklevel` was introduced in python3.8, which means we have to conditionally pass this parameter, as long as we support python 3.7: https://docs.python.org/3.8/library/logging.html#logging.Logger.debug

also update to use logging.warning instead of warn (which is deprecated)

this was surfaced in the CI for https://github.com/pytorch/tnt/pull/278
so splitting out the changes here to make that PR easier to go through

Differential Revision: D41699844

