### PR TITLE
rearrange dev-requirements.txt installation to fix nightly build issue

### DIFF
--- a/.github/workflows/nightly_build_cpu.yaml
+++ b/.github/workflows/nightly_build_cpu.yaml
@@ -33,9 +33,9 @@ jobs:
           conda activate test
           conda install pytorch cpuonly -c pytorch-nightly
           pip install -r requirements.txt
-          pip install -r dev-requirements.txt
           python setup.py sdist bdist_wheel
           pip install dist/*.whl
+          pip install -r dev-requirements.txt
       - name: Run unit tests
         shell: bash -l {0}
         run: |
@@ -62,7 +62,6 @@ jobs:
           conda activate test
           conda install pytorch cpuonly -c pytorch-nightly
           pip install -r requirements.txt
-          pip install -r dev-requirements.txt
           pip install --no-build-isolation -e ".[dev]"
       - name: Upload to PyPI
         shell: bash -l {0}

--- a/.github/workflows/release_build.yaml
+++ b/.github/workflows/release_build.yaml
@@ -25,9 +25,9 @@ jobs:
           conda activate test
           conda install pytorch cpuonly -c pytorch-nightly
           pip install -r requirements.txt
-          pip install -r dev-requirements.txt
           python setup.py sdist bdist_wheel
           pip install dist/*.whl
+          pip install -r dev-requirements.txt
       - name: Run unit tests
         shell: bash -l {0}
         run: |
@@ -54,7 +54,6 @@ jobs:
           conda activate test
           conda install pytorch cpuonly -c pytorch-nightly
           pip install -r requirements.txt
-          pip install -r dev-requirements.txt
           pip install  --no-build-isolation -e ".[dev]"
       - name: Upload to PyPI
         shell: bash -l {0}


### PR DESCRIPTION
Summary: resolve recursive dependency by installing dev-requirement packages after torchtnt has been built

Differential Revision: D42283910

