### PR TITLE
Add build_docs job to release_build github workflow

### DIFF
--- a/.github/workflows/release_build.yaml
+++ b/.github/workflows/release_build.yaml
@@ -66,3 +66,39 @@ jobs:
           pip install twine
           python setup.py sdist bdist_wheel
           twine upload --username "$PYPI_USER" --password "$PYPI_TOKEN" dist/* --verbose
+  build_docs:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repo
+        uses: actions/checkout@v2
+      - name: Setup conda env
+        uses: conda-incubator/setup-miniconda@v2
+        with:
+          miniconda-version: "latest"
+          activate-environment: test
+      - name: Install dependencies
+        shell: bash -l {0}
+        run: |
+          set -eux
+          conda activate test
+          conda install pytorch cpuonly -c pytorch-nightly
+          pip install -r requirements.txt
+          pip install -r dev-requirements.txt
+          python setup.py sdist bdist_wheel
+          pip install dist/*.whl
+      - name: Build docs
+        shell: bash -l {0}
+        run: |
+          set -eux
+          conda activate test
+          cd docs
+          pip install -r requirements.txt
+          RELEASE_BUILD=1 make html
+          touch build/html/.nojekyll
+          cd ..
+      - name: Deploy docs to Github pages
+        uses: JamesIves/github-pages-deploy-action@v4.4.1
+        with:
+            branch: gh-pages # The branch the action should deploy to.
+            folder: docs/build/html # The folder the action should deploy.
+            target-folder: stable


### PR DESCRIPTION
Summary: This will automatically build the docs for the new version using RELEASE_BUILD=1 every time we make a release

Reviewed By: kit1980

Differential Revision: D42268000

