### PR TITLE
Refactor callback.py class

### DIFF
--- a/torchtnt/framework/callback.py
+++ b/torchtnt/framework/callback.py
@@ -13,7 +13,12 @@ from torchtnt.framework.unit import TEvalUnit, TPredictUnit, TTrainUnit
 logger: logging.Logger = logging.getLogger(__name__)
 
 
-class _OnExceptionMixin:
+class Callback:
+    @property
+    def name(self) -> str:
+        """Should be a distinct name per instance. This is useful for debugging, profiling, and checkpointing purposes."""
+        return self.__class__.__qualname__
+
     def on_exception(
         self,
         state: State,
@@ -22,15 +27,6 @@ class _OnExceptionMixin:
     ) -> None:
         pass
 
-
-class _NameMixin:
-    @property
-    def name(self) -> str:
-        """Should be a distinct name per instance. This is useful for debugging, profiling, and checkpointing purposes."""
-        return self.__class__.__qualname__
-
-
-class _TrainCallback:
     def on_train_start(self, state: State, unit: TTrainUnit) -> None:
         pass
 
@@ -49,8 +45,6 @@ class _TrainCallback:
     def on_train_end(self, state: State, unit: TTrainUnit) -> None:
         pass
 
-
-class _EvalCallback:
     def on_eval_start(self, state: State, unit: TEvalUnit) -> None:
         pass
 
@@ -69,8 +63,6 @@ class _EvalCallback:
     def on_eval_end(self, state: State, unit: TEvalUnit) -> None:
         pass
 
-
-class _PredictCallback:
     def on_predict_start(self, state: State, unit: TPredictUnit) -> None:
         pass
 
@@ -88,9 +80,3 @@ class _PredictCallback:
 
     def on_predict_end(self, state: State, unit: TPredictUnit) -> None:
         pass
-
-
-class Callback(
-    _TrainCallback, _EvalCallback, _PredictCallback, _OnExceptionMixin, _NameMixin
-):
-    pass


### PR DESCRIPTION
Summary: Make callback.py one class rather than inherit from other classes. This will make the Callback API appear in the docs as currently it does not: https://pytorch.org/tnt/stable/torchtnt.framework.html#torchtnt.framework.Callback

Differential Revision: D42550053

