### PR TITLE
Improve docs for train entry point

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -27,6 +27,7 @@ TorchTNT
    :maxdepth: 1
    :caption: Framework
 
+   unit
    train
    eval
    predict

--- a/docs/source/train.rst
+++ b/docs/source/train.rst
@@ -1,63 +1,10 @@
 Train
 =======================
-Here we lay out the steps needed to configure and run your training loop.
-
-TrainUnit
-~~~~~~~~~~~~~
-
-In TorchTNT, :class:`~torchtnt.framework.unit.TrainUnit` is the interface that allows you to customize your training loop when run by :py:func:`~torchtnt.framework.train`.
-To use, you must create a class which subclasses :class:`~torchtnt.framework.unit.TrainUnit`.
-You must implement the ``train_step`` method on your class, and then you can optionally implement any of the hooks which allow you to control the behavior of the loop at different points.
-Below is a simple example of a user's subclass of :class:`~torchtnt.framework.unit.TrainUnit` that implements a basic ``train_step``, and the ``on_train_epoch_end`` hook.
-
-
-.. code-block:: python
-
- from torchtnt.framework import TrainUnit
-
- class MyTrainUnit(TrainUnit[Batch]):
-     def __init__(
-         self,
-         module: torch.nn.Module,
-         optimizer: torch.optim.Optimizer,
-         lr_scheduler: torch.optim.lr_scheduler._LRScheduler,
-     ):
-         super().__init__()
-         self.module = module
-         self.optimizer = optimizer
-         self.lr_scheduler = lr_scheduler
-
-     def train_step(self, state: State, data: Batch) -> None:
-         inputs, targets = data
-         outputs = self.module(inputs)
-         loss = torch.nn.functional.binary_cross_entropy_with_logits(outputs, targets)
-         loss.backward()
-
-         self.optimizer.step()
-         self.optimizer.zero_grad()
-
-     def on_train_epoch_end(self, state: State) -> None:
-        # step the learning rate scheduler
-        self.lr_scheduler.step()
-
- train_unit = MyTrainUnit(module=..., optimizer=..., lr_scheduler=...)
+.. currentmodule:: torchtnt.framework
 
 Train Entry Point
 ~~~~~~~~~~~~~~~~~~~~
 
-To run your training loop, call the training loop entry point: :py:func:`~torchtnt.framework.train`.
+.. autofunction:: init_train_state
 
-The :py:func:`~torchtnt.framework.train` entry point takes a :class:`~torchtnt.framework.TrainUnit` object, a :class:`~torchtnt.framework.State` object, and an optional list of callbacks.
-
-The :class:`~torchtnt.framework.State` object can be initialized with :func:`~torchtnt.framework.init_train_state`, which takes in a dataloader (can be *any* iterable, including PyTorch DataLoader, numpy, etc.) and some parameters to control the run duration of the loop.
-
-Below is an example of calling the :py:func:`~torchtnt.framework.train` entry point with ``MyTrainUnit`` created above.
-
-.. code-block:: python
-
- from torchtnt.framework import init_train_state, train
-
- train_unit = MyTrainUnit(module=..., optimizer=..., lr_scheduler=...)
- dataloader = torch.utils.data.DataLoader(...)
- state = init_train_state(dataloader=dataloader, max_epochs=4)
- train(state, train_unit)
+.. autofunction:: train

--- a/docs/source/unit.rst
+++ b/docs/source/unit.rst
@@ -1,0 +1,73 @@
+Unit
+=========
+.. currentmodule:: torchtnt.framework
+
+The Unit concept represents the primary place to organize your model code in TorchTNT. TorchTNT offers three different types of Unit classes for training, evaluation, and prediction. These interfaces are mutually exclusive and can be combined as needed.
+for example in the case of fitting (interleaving training and prediction).
+
+TrainUnit
+~~~~~~~~~~~~~~~~~
+.. autoclass:: TrainUnit
+   :members:
+   :undoc-members:
+
+EvalUnit
+~~~~~~~~~~~~~~~~~
+.. autoclass:: EvalUnit
+   :members:
+   :undoc-members:
+
+PredictUnit
+~~~~~~~~~~~~~~~~~
+.. autoclass:: PredictUnit
+   :members:
+   :undoc-members:
+
+Combining Multiple Units
+~~~~~~~~~~~~~~~~~~~~~~~~~~
+In some cases, it is convenient to implement multiple Unit interfaces under the same class, e.g. if you plan to use your class to run several different phases;
+for example, running training and then prediction, or running training and evaluation interleaved (referred to as fitting).
+Here is an example of a unit which extends TrainUnit, EvalUnit, and PredictUnit.
+
+.. code-block:: python
+
+ from torchtnt.framework import TrainUnit, EvalUnit, PredictUnit
+
+ Batch = Tuple[torch.tensor, torch.tensor]
+
+ class MyUnit(TrainUnit[Batch], EvalUnit[Batch], PredictUnit[Batch]):
+     def __init__(
+         self,
+         module: torch.nn.Module,
+         optimizer: torch.optim.Optimizer,
+         lr_scheduler: torch.optim.lr_scheduler._LRScheduler,
+     ):
+         super().__init__()
+         self.module = module
+         self.optimizer = optimizer
+         self.lr_scheduler = lr_scheduler
+
+     def train_step(self, state: State, data: Batch) -> None:
+         inputs, targets = data
+         outputs = self.module(inputs)
+         loss = torch.nn.functional.binary_cross_entropy_with_logits(outputs, targets)
+         loss.backward()
+
+         self.optimizer.step()
+         self.optimizer.zero_grad()
+
+    def eval_step(self, state: State, data: Batch) -> None:
+         inputs, targets = data
+         outputs = self.module(inputs)
+         loss = torch.nn.functional.binary_cross_entropy_with_logits(outputs, targets)
+
+    def predict_step(self, state: State, data: Batch) -> torch.tensor:
+         inputs, targets = data
+         outputs = self.module(inputs)
+         return outputs
+
+     def on_train_epoch_end(self, state: State) -> None:
+        # step the learning rate scheduler
+        self.lr_scheduler.step()
+
+ my_unit = MyUnit(module=..., optimizer=..., lr_scheduler=...)

--- a/torchtnt/framework/train.py
+++ b/torchtnt/framework/train.py
@@ -36,16 +36,29 @@ def init_train_state(
     max_steps_per_epoch: Optional[int] = None,
 ) -> State:
     """
-    Helper function that initializes a :class:`~torchtnt.framework.State` object for training.
+    ``init_train_state`` is a helper function that initializes a :class:`~torchtnt.framework.State` object for training. This :class:`~torchtnt.framework.State` object
+    can then be passed to the :func:`~torchtnt.framework.train` entry point.
 
     Args:
-        dataloader: dataloader to be used during training.
+        dataloader: dataloader to be used during training, which can be *any* iterable, including PyTorch DataLoader, DataLoader2, etc.
         max_epochs: the max number of epochs to run. ``None`` means no limit (infinite training) unless stopped by max_steps.
         max_steps: the max number of steps to run. ``None`` means no limit (infinite training) unless stopped by max_epochs.
         max_steps_per_epoch: the max number of steps to run per epoch. None means train until the dataloader is exhausted.
 
     Returns:
         An initialized state object containing metadata.
+
+    Below is an example of calling :py:func:`~torchtnt.framework.init_train_state` and :py:func:`~torchtnt.framework.train` together.
+
+    .. code-block:: python
+
+      from torchtnt.framework import init_train_state, train
+
+      train_unit = MyTrainUnit(module=..., optimizer=..., lr_scheduler=...)
+      dataloader = torch.utils.data.DataLoader(...)
+      state = init_train_state(dataloader=dataloader, max_epochs=4)
+      train(state, train_unit)
+
     """
 
     return State(
@@ -67,12 +80,25 @@ def train(
     callbacks: Optional[List[Callback]] = None,
 ) -> None:
     """
-    The ``train`` entry point takes in a :class:`~torchtnt.framework.State` object and a :class:`~torchtnt.framework.TrainUnit` object and runs the training loop.
+    The ``train`` entry point takes in a :class:`~torchtnt.framework.State` object, a :class:`~torchtnt.framework.TrainUnit` object, and an optional list of :class:`~torchtnt.framework.Callback` s,
+    and runs the training loop. The :class:`~torchtnt.framework.State` object can be initialized with :func:`~torchtnt.framework.init_train_state`.
 
     Args:
         state: a :class:`~torchtnt.framework.State` object containing metadata about the training run.
         train_unit: an instance of :class:`~torchtnt.framework.TrainUnit` which implements `train_step`.
         callbacks: an optional list of callbacks.
+
+    Below is an example of calling :py:func:`~torchtnt.framework.init_train_state` and :py:func:`~torchtnt.framework.train` together.
+
+    .. code-block:: python
+
+      from torchtnt.framework import init_train_state, train
+
+      train_unit = MyTrainUnit(module=..., optimizer=..., lr_scheduler=...)
+      dataloader = torch.utils.data.DataLoader(...)
+      state = init_train_state(dataloader=dataloader, max_epochs=4)
+      train(state, train_unit)
+
     """
     log_api_usage("train")
     callbacks = callbacks or []


### PR DESCRIPTION
Summary: Add docstrings to `init_train_state` and `train` and simplify docs page

Reviewed By: ananthsub

Differential Revision: D42901898

