### PR TITLE
Remove "API" tab in docs

### DIFF
--- a/docs/source/eval.rst
+++ b/docs/source/eval.rst
@@ -1,51 +1,10 @@
 Evaluate
 =======================
-Here we lay out the steps needed to configure and run your evaluation loop.
-
-EvalUnit
-~~~~~~~~~~~~~
-
-In TorchTNT, :class:`~torchtnt.framework.unit.EvalUnit` is the interface that allows you to customize your evaluation loop when run by :py:func:`~torchtnt.framework.evaluate`.
-To use, you must create a class which subclasses :class:`~torchtnt.framework.unit.EvalUnit`.
-You must implement the ``eval_step`` method on your class, and then you can optionally implement any of the hooks which allow you to control the behavior of the loop at different points.
-Below is a simple example of a user's subclass of :class:`~torchtnt.framework.unit.EvalUnit` that implements a basic ``eval_step``.
-
-
-.. code-block:: python
-
- from torchtnt.framework import EvalUnit
-
- class MyEvalUnit(EvalUnit[Batch]):
-     def __init__(
-         self,
-         module: torch.nn.Module,
-     ):
-         super().__init__()
-         self.module = module
-
-     def eval_step(self, state: State, data: Batch) -> None:
-         inputs, targets = data
-         outputs = self.module(inputs)
-         loss = torch.nn.functional.binary_cross_entropy_with_logits(outputs, targets)
-
- eval_unit = MyEvalUnit(module=...)
+.. currentmodule:: torchtnt.framework
 
 Evaluate Entry Point
 ~~~~~~~~~~~~~~~~~~~~
 
-To run your evaluation loop, call :py:func:`~torchtnt.framework.evaluate`.
+.. autofunction:: init_eval_state
 
-The :py:func:`~torchtnt.framework.evaluate` entry point takes a :class:`~torchtnt.framework.EvalUnit` object, a :class:`~torchtnt.framework.State` object, and an optional list of callbacks.
-
-The :class:`~torchtnt.framework.State` object can be initialized with :func:`~torchtnt.framework.init_eval_state`, which takes in a dataloader (can be *any* iterable, including PyTorch DataLoader, numpy, etc.) and some parameters to control the run duration of the loop.
-
-Below is an example of calling the :py:func:`~torchtnt.framework.evaluate` entry point with ``MyEvalUnit`` created above.
-
-.. code-block:: python
-
- from torchtnt.framework import evaluate, init_eval_state
-
- eval_unit = MyEvalUnit(module=..., optimizer=..., lr_scheduler=...)
- dataloader = torch.utils.data.DataLoader(...)
- state = init_eval_state(dataloader=dataloader, max_steps_per_epoch=20)
- evaluate(state, eval_unit)
+.. autofunction:: evaluate

--- a/docs/source/fit.rst
+++ b/docs/source/fit.rst
@@ -1,70 +1,10 @@
 Fit
 =======================
-Here we lay out the steps needed to configure and run your fit loop. The fit loop interleaves training with evaluation,
-to give you immediate feedback about how your model is performing while training.
-
-TrainUnit and EvalUnit
-~~~~~~~~~~~~~~~~~~~~~~~
-
-In TorchTNT the Unit interface allows you to customize your fit loop when run by :py:func:`~torchtnt.framework.fit`.
-For fit, you must create a class which subclasses :class:`~torchtnt.framework.unit.TrainUnit` and :class:`~torchtnt.framework.unit.EvalUnit`.
-You must implement the ``train_step`` and ``eval_step`` methods on your class, and then you can optionally implement any of the hooks which allow you to control the behavior of the loop at different points.
-Below is a simple example of a user's fit Unit that implements a basic ``train_step``, ``eval_step``, and the ``on_train_epoch_end`` hook.
-
-
-.. code-block:: python
-
- from torchtnt.framework import TrainUnit, EvalUnit
-
- class MyFitUnit(TrainUnit[Batch], EvalUnit[Batch]):
-     def __init__(
-         self,
-         module: torch.nn.Module,
-         optimizer: torch.optim.Optimizer,
-         lr_scheduler: torch.optim.lr_scheduler._LRScheduler,
-     ):
-         super().__init__()
-         self.module = module
-         self.optimizer = optimizer
-         self.lr_scheduler = lr_scheduler
-
-     def train_step(self, state: State, data: Batch) -> None:
-         inputs, targets = data
-         outputs = self.module(inputs)
-         loss = torch.nn.functional.binary_cross_entropy_with_logits(outputs, targets)
-         loss.backward()
-
-         self.optimizer.step()
-         self.optimizer.zero_grad()
-
-    def eval_step(self, state: State, data: Batch) -> None:
-         inputs, targets = data
-         outputs = self.module(inputs)
-         loss = torch.nn.functional.binary_cross_entropy_with_logits(outputs, targets)
-
-     def on_train_epoch_end(self, state: State) -> None:
-        # step the learning rate scheduler
-        self.lr_scheduler.step()
-
- fit_unit = MyFitUnit(module=..., optimizer=..., lr_scheduler=...)
+.. currentmodule:: torchtnt.framework
 
 Fit Entry Point
 ~~~~~~~~~~~~~~~~~~~~
 
-To run your fit loop, call the fit loop entry point: :py:func:`~torchtnt.framework.fit`.
+.. autofunction:: init_fit_state
 
-The :py:func:`~torchtnt.framework.fit` entry point takes an object subclassing both :class:`~torchtnt.framework.TrainUnit` and :class:`~torchtnt.framework.EvalUnit`, a :class:`~torchtnt.framework.state.State` object, and an optional list of callbacks.
-
-The :class:`~torchtnt.framework.state.State` object can be initialized with :func:`~torchtnt.framework.init_fit_state`, which takes in a dataloader (can be *any* iterable, including PyTorch DataLoader, numpy, etc.) and some parameters to control the run duration of the loop.
-
-Below is an example of calling the :py:func:`~torchtnt.framework.fit` entry point with the TrainUnit/EvalUnit created above.
-
-.. code-block:: python
-
- from torchtnt.framework import fit, init_fit_state
-
- fit_unit = MyFitUnit(module=..., optimizer=..., lr_scheduler=...)
- train_dataloader = torch.utils.data.DataLoader(...)
- eval_dataloader = torch.utils.data.DataLoader(...)
- state = init_fit_state(train_dataloader=train_dataloader, eval_dataloader=eval_dataloader, max_epochs=4)
- fit(state, fit_unit)
+.. autofunction:: fit

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -35,6 +35,17 @@ TorchTNT
    callbacks
    auto_unit
 
+.. fbcode::
+
+   .. toctree::
+      :maxdepth: 2
+      :caption: Utils
+      :glob:
+
+      utils/utils
+      utils/data
+      utils/loggers
+
 .. toctree::
    :maxdepth: 2
    :caption: API

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -46,13 +46,6 @@ TorchTNT
       utils/data
       utils/loggers
 
-.. toctree::
-   :maxdepth: 2
-   :caption: API
-
-   torchtnt.framework.rst
-   torchtnt.utils.rst
-
 .. fbcode::
 
    .. toctree::

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -49,7 +49,7 @@ TorchTNT
       :caption: Framework (Meta)
       :glob:
 
-      meta/callbacks.rst
+      meta/framework.callbacks.rst
 
 .. fbcode::
 
@@ -58,4 +58,6 @@ TorchTNT
       :caption: Utils (Meta)
       :glob:
 
-      meta/torchtnt.meta.utils.rst
+      meta/utils.rst
+      meta/utils.data.rst
+      meta/utils.loggers.rst

--- a/docs/source/predict.rst
+++ b/docs/source/predict.rst
@@ -1,50 +1,10 @@
 Predict
 =======================
-Here we lay out the steps needed to configure and run your prediction loop.
-
-PredictUnit
-~~~~~~~~~~~~~
-
-In TorchTNT, :class:`~torchtnt.framework.unit.PredictUnit` is the interface that allows you to customize your prediction loop when run by :py:func:`~torchtnt.framework.predict`.
-To use, you must create a class which subclasses :class:`~torchtnt.framework.unit.PredictUnit`.
-You must implement the ``predict_step`` method on your class, and then you can optionally implement any of the hooks which allow you to control the behavior of the loop at different points.
-Below is a simple example of a user's subclass of :class:`~torchtnt.framework.unit.PredictUnit` that implements a basic ``predict_step``.
-
-
-.. code-block:: python
-
- from torchtnt.framework import PredictUnit
-
- class MyPredictUnit(PredictUnit[Batch]):
-     def __init__(
-         self,
-         module: torch.nn.Module,
-     ):
-         super().__init__()
-         self.module = module
-
-     def predict_step(self, state: State, data: Batch) -> None:
-         inputs, targets = data
-         outputs = self.module(inputs)
-
- predict_unit = MyPredictUnit(module=...)
+.. currentmodule:: torchtnt.framework
 
 Predict Entry Point
 ~~~~~~~~~~~~~~~~~~~~
 
-To run your prediction loop, call the prediction loop entry point: :py:func:`~torchtnt.framework.predict`.
+.. autofunction:: init_predict_state
 
-The :py:func:`~torchtnt.framework.predict` entry point takes a :class:`~torchtnt.framework.PredictUnit` object, a :class:`~torchtnt.framework.State` object, and an optional list of callbacks.
-
-The :class:`~torchtnt.framework.State` object can be initialized with :func:`~torchtnt.framework.init_predict_state`, which takes in a dataloader (can be *any* iterable, including PyTorch DataLoader, numpy, etc.) and some parameters to control the run duration of the loop.
-
-Below is an example of calling the :py:func:`~torchtnt.framework.predict` entry point with ``MyPredictUnit`` created above.
-
-.. code-block:: python
-
- from torchtnt.framework import init_predict_state, predict
-
- predict_unit = MyPredictUnit(module=..., optimizer=..., lr_scheduler=...)
- dataloader = torch.utils.data.DataLoader(...)
- state = init_predict_state(dataloader=dataloader, max_steps_per_epoch=20)
- predict(state, predict_unit)
+.. autofunction:: predict

--- a/docs/source/utils/data.rst
+++ b/docs/source/utils/data.rst
@@ -1,0 +1,6 @@
+Data
+=============
+
+.. automodule:: torchtnt.utils.data
+   :members:
+   :undoc-members:

--- a/docs/source/utils/loggers.rst
+++ b/docs/source/utils/loggers.rst
@@ -1,0 +1,6 @@
+Loggers
+=============
+
+.. automodule:: torchtnt.utils.loggers
+   :members:
+   :undoc-members:

--- a/docs/source/utils/utils.rst
+++ b/docs/source/utils/utils.rst
@@ -1,0 +1,6 @@
+Utils
+=============
+
+.. automodule:: torchtnt.utils
+   :members:
+   :undoc-members:

--- a/torchtnt/framework/evaluate.py
+++ b/torchtnt/framework/evaluate.py
@@ -32,14 +32,26 @@ def init_eval_state(
     max_steps_per_epoch: Optional[int] = None,
 ) -> State:
     """
-    Helper function that initializes a :class:`~torchtnt.framework.state.State` object for evaluation.
+    ``init_eval_state`` is a helper function that initializes a :class:`~torchtnt.framework.State` object for evaluation. This :class:`~torchtnt.framework.State` object
+    can then be passed to the :func:`~torchtnt.framework.evaluate` entry point.
 
     Args:
-        dataloader: dataloader to be used during evaluation.
+        dataloader: dataloader to be used during evaluation, which can be *any* iterable, including PyTorch DataLoader, DataLoader2, etc.
         max_steps_per_epoch: the max number of steps to run per epoch. None means evaluate until the dataloader is exhausted.
 
     Returns:
         An initialized state object containing metadata.
+
+    Below is an example of calling :py:func:`~torchtnt.framework.init_eval_state` and :py:func:`~torchtnt.framework.evaluate` together.
+
+    .. code-block:: python
+
+      from torchtnt.framework import init_eval_state, evaluate
+
+      eval_unit = MyEvalUnit(module=..., optimizer=..., lr_scheduler=...)
+      dataloader = torch.utils.data.DataLoader(...)
+      state = init_eval_state(dataloader=dataloader, max_steps_per_epoch=20)
+      evaluate(state, eval_unit)
     """
 
     return State(
@@ -58,12 +70,24 @@ def evaluate(
     callbacks: Optional[List[Callback]] = None,
 ) -> None:
     """
-    The``evaluate``entry point takes in a :class:`~torchtnt.framework.State` and :class:`~torchtnt.framework.unit.EvalUnit` and runs the evaluation loop over the data.
+    The ``evaluate`` entry point takes in a :class:`~torchtnt.framework.State` object, a :class:`~torchtnt.framework.EvalUnit` object, and an optional list of :class:`~torchtnt.framework.Callback` s,
+    and runs the evaluation loop. The :class:`~torchtnt.framework.State` object can be initialized with :func:`~torchtnt.framework.init_eval_state`.
 
     Args:
         state: a :class:`~torchtnt.framework.State` object containing metadata about the evaluation run.
         eval_unit: an instance of :class:`~torchtnt.framework.EvalUnit` which implements `eval_step`.
         callbacks: an optional list of callbacks.
+
+    Below is an example of calling :py:func:`~torchtnt.framework.init_eval_state` and :py:func:`~torchtnt.framework.evaluate` together.
+
+    .. code-block:: python
+
+      from torchtnt.framework import init_eval_state, evaluate
+
+      eval_unit = MyEvalUnit(module=..., optimizer=..., lr_scheduler=...)
+      dataloader = torch.utils.data.DataLoader(...)
+      state = init_eval_state(dataloader=dataloader, max_steps_per_epoch=20)
+      evaluate(state, eval_unit)
     """
     log_api_usage("evaluate")
     callbacks = callbacks or []

--- a/torchtnt/framework/fit.py
+++ b/torchtnt/framework/fit.py
@@ -35,11 +35,12 @@ def init_fit_state(
     evaluate_every_n_epochs: Optional[int] = 1,
 ) -> State:
     """
-    Helper function that initializes a :class:`~torchtnt.framework.State` object for fitting.
+    ``init_fit_state`` is a helper function that initializes a :class:`~torchtnt.framework.State` object for fitting. This :class:`~torchtnt.framework.State` object
+    can then be passed to the :func:`~torchtnt.framework.fit` entry point.
 
     Args:
-        train_dataloader: dataloader to be used during training.
-        eval_dataloader: dataloader to be used during evaluation.
+        train_dataloader: dataloader to be used during training, which can be *any* iterable, including PyTorch DataLoader, DataLoader2, etc.
+        eval_dataloader: dataloader to be used during evaluation, which can be *any* iterable, including PyTorch DataLoader, DataLoader2, etc.
         max_epochs: the max number of epochs to run for training. ``None`` means no limit (infinite training) unless stopped by max_steps.
         max_steps: the max number of steps to run for training. ``None`` means no limit (infinite training) unless stopped by max_epochs.
         max_train_steps_per_epoch: the max number of steps to run per epoch for training. None means train until the dataloader is exhausted.
@@ -48,6 +49,18 @@ def init_fit_state(
 
     Returns:
         An initialized state object containing metadata.
+
+    Below is an example of calling :py:func:`~torchtnt.framework.init_fit_state` and :py:func:`~torchtnt.framework.fit` together.
+
+    .. code-block:: python
+
+      from torchtnt.framework import fit, init_fit_state
+
+      fit_unit = MyFitUnit(module=..., optimizer=..., lr_scheduler=...)
+      train_dataloader = torch.utils.data.DataLoader(...)
+      eval_dataloader = torch.utils.data.DataLoader(...)
+      state = init_fit_state(train_dataloader=train_dataloader, eval_dataloader=eval_dataloader, max_epochs=4)
+      fit(state, fit_unit)
     """
 
     return State(
@@ -71,7 +84,8 @@ def fit(
     state: State, unit: TTrainUnit, *, callbacks: Optional[List[Callback]] = None
 ) -> None:
     """
-    The ``fit`` entry point interleaves training and evaluation loops.
+    The ``fit`` entry point interleaves training and evaluation loops.  It takes in a :class:`~torchtnt.framework.State` object, an object which subclasses both :class:`~torchtnt.framework.TrainUnit` and :class:`~torchtnt.framework.EvalUnit`,
+    and an optional list of :class:`~torchtnt.framework.Callback` s, and runs the fit loop. The :class:`~torchtnt.framework.State` object can be initialized with :func:`~torchtnt.framework.init_fit_state`.
 
     Args:
         state: a :class:`~torchtnt.framework.State` object containing metadata about the fitting run.
@@ -79,6 +93,18 @@ def fit(
         unit: an instance that subclasses both :class:`~torchtnt.framework.unit.TrainUnit` and :class:`~torchtnt.framework.unit.EvalUnit`,
          implementing :meth:`~torchtnt.framework.TrainUnit.train_step` and :meth:`~torchtnt.framework.EvalUnit.eval_step`.
         callbacks: an optional list of callbacks.
+
+    Below is an example of calling :py:func:`~torchtnt.framework.init_fit_state` and :py:func:`~torchtnt.framework.fit` together.
+
+    .. code-block:: python
+
+      from torchtnt.framework import fit, init_fit_state
+
+      fit_unit = MyFitUnit(module=..., optimizer=..., lr_scheduler=...)
+      train_dataloader = torch.utils.data.DataLoader(...)
+      eval_dataloader = torch.utils.data.DataLoader(...)
+      state = init_fit_state(train_dataloader=train_dataloader, eval_dataloader=eval_dataloader, max_epochs=4)
+      fit(state, fit_unit)
     """
     log_api_usage("fit")
     callbacks = callbacks or []

--- a/torchtnt/framework/predict.py
+++ b/torchtnt/framework/predict.py
@@ -32,14 +32,27 @@ def init_predict_state(
     max_steps_per_epoch: Optional[int] = None,
 ) -> State:
     """
-    Helper function that initializes a :class:`~torchtnt.framework.State` object for prediction.
+    ``init_predict_state`` is a helper function that initializes a :class:`~torchtnt.framework.State` object for prediction. This :class:`~torchtnt.framework.State` object
+    can then be passed to the :func:`~torchtnt.framework.predict` entry point.
 
     Args:
-        dataloader: dataloader to be used during prediction.
+        dataloader: dataloader to be used during prediction, which can be *any* iterable, including PyTorch DataLoader, DataLoader2, etc.
         max_steps_per_epoch: the max number of steps to run per epoch. None means predict until the dataloader is exhausted.
 
     Returns:
         An initialized state object containing metadata.
+
+    Below is an example of calling :py:func:`~torchtnt.framework.init_predict_state` and :py:func:`~torchtnt.framework.predict` together.
+
+    .. code-block:: python
+
+      from torchtnt.framework import init_predict_state, predict
+
+      predict_unit = MyPredictUnit(module=..., optimizer=..., lr_scheduler=...)
+      dataloader = torch.utils.data.DataLoader(...)
+      state = init_predict_state(dataloader=dataloader, max_steps_per_epoch=20)
+      predict(state, predict_unit)
+
     """
 
     return State(
@@ -58,12 +71,24 @@ def predict(
     callbacks: Optional[List[Callback]] = None,
 ) -> None:
     """
-    The ``predict`` entry point takes in a :class:`~torchtnt.framework.State` and :class:`~torchtnt.framework.PredictUnit` and runs the prediction loop over the data.
+    The ``predict`` entry point takes in a :class:`~torchtnt.framework.State` object, a :class:`~torchtnt.framework.PredictUnit` object, and an optional list of :class:`~torchtnt.framework.Callback` s,
+    and runs the prediction loop. The :class:`~torchtnt.framework.State` object can be initialized with :func:`~torchtnt.framework.init_predict_state`.
 
     Args:
         state: a State object containing metadata about the prediction run. This can be initialized using :func:`~torchtnt.framework.init_predict_state`.
         predict_unit: an instance of :class:`~torchtnt.framework.PredictUnit` which implements `predict_step`.
         callbacks: an optional list of callbacks.
+
+    Below is an example of calling :py:func:`~torchtnt.framework.init_predict_state` and :py:func:`~torchtnt.framework.predict` together.
+
+    .. code-block:: python
+
+      from torchtnt.framework import init_predict_state, predict
+
+      predict_unit = MyPredictUnit(module=..., optimizer=..., lr_scheduler=...)
+      dataloader = torch.utils.data.DataLoader(...)
+      state = init_predict_state(dataloader=dataloader, max_steps_per_epoch=20)
+      predict(state, predict_unit)
     """
     log_api_usage("predict")
     callbacks = callbacks or []


### PR DESCRIPTION
Summary: Removing this section, in favor of the other tabs we currently have in the docs (left side) which cover the API in parts

Differential Revision: D43024443

