### PR TITLE
Add log to train when fitting

### DIFF
--- a/torchtnt/framework/train.py
+++ b/torchtnt/framework/train.py
@@ -292,6 +292,7 @@ def _train_epoch_impl(
                 train_unit,
                 callbacks,
             )
+            logger.info("Finished evaluation. Resuming training epoch")
 
         if not pass_data_iter_to_step:
             # pyre-ignore


### PR DESCRIPTION
Summary: Add a log statement to show that we are returning to training after eval

Differential Revision: D43698956

