### PR TITLE
Change variable name every_n_train_steps to save_every_n_train_steps and every_n_epochs to save_every_n_epochs

### DIFF
--- a/torchtnt/framework/callbacks/torchsnapshot_saver.py
+++ b/torchtnt/framework/callbacks/torchsnapshot_saver.py
@@ -88,8 +88,11 @@ class TorchSnapshotSaver(Callback):
         train_state = none_throws(state.train_state)
 
         global_step = train_state.progress.num_steps_completed
-        every_n_train_steps = self._save_every_n_train_steps
-        if every_n_train_steps is None or global_step % every_n_train_steps != 0:
+        save_every_n_train_steps = self._save_every_n_train_steps
+        if (
+            save_every_n_train_steps is None
+            or global_step % save_every_n_train_steps != 0
+        ):
             return
 
         app_state = _get_app_state(state, unit, self._replicated, intra_epoch=True)
@@ -105,8 +108,8 @@ class TorchSnapshotSaver(Callback):
 
         train_progress = train_state.progress
         epoch = train_progress.num_epochs_completed
-        every_n_epochs = self._save_every_n_epochs
-        if every_n_epochs is None or epoch % every_n_epochs != 0:
+        save_every_n_epochs = self._save_every_n_epochs
+        if save_every_n_epochs is None or epoch % save_every_n_epochs != 0:
             return
 
         app_state = _get_app_state(

--- a/torchtnt/framework/train.py
+++ b/torchtnt/framework/train.py
@@ -284,6 +284,7 @@ def _train_epoch_impl(
                 callbacks,
             )
             logger.info("Finished evaluation. Resuming training epoch")
+            state._active_phase = ActivePhase.TRAIN
 
         if not pass_data_iter_to_step:
             # pyre-ignore
@@ -312,6 +313,7 @@ def _train_epoch_impl(
             train_unit,
             callbacks,
         )
+        state._active_phase = ActivePhase.TRAIN
 
     # Reset training mode for modules at the end of the epoch
     # This ensures that side-effects made by the loop are reset before


### PR DESCRIPTION
Summary: This matches how we name other variables, e.g. https://www.internalfb.com/code/fbsource/[63de76b303b898c7a5092ad45ce1244aae0081fc]/fbcode/torchtnt/framework/fit.py?lines=34-35

Reviewed By: JKSenthil

Differential Revision: D43880894

