### PR TITLE
Set active_phase to TRAIN during fit after eval

### DIFF
--- a/torchtnt/framework/train.py
+++ b/torchtnt/framework/train.py
@@ -284,6 +284,7 @@ def _train_epoch_impl(
                 callbacks,
             )
             logger.info("Finished evaluation. Resuming training epoch")
+            state._active_phase = ActivePhase.TRAIN
 
         if not pass_data_iter_to_step:
             # pyre-ignore
@@ -312,6 +313,7 @@ def _train_epoch_impl(
             train_unit,
             callbacks,
         )
+        state._active_phase = ActivePhase.TRAIN
 
     # Reset training mode for modules at the end of the epoch
     # This ensures that side-effects made by the loop are reset before


### PR DESCRIPTION
Summary:
This was missed when originally added - Need to reset the active phase to train after eval since in eval we set it to EVALUATE: https://www.internalfb.com/code/fbsource/[4b90a0fd9c12d9b3bed8fe502b96283b48e23a46]/fbcode/torchtnt/framework/evaluate.py?lines=114

but then when we go back to train we need to set the active_phase back to TRAIN.

Reviewed By: JKSenthil

Differential Revision: D43880687

