### PR TITLE
Return unscaled loss in AutoUnit

### DIFF
--- a/torchtnt/framework/auto_unit.py
+++ b/torchtnt/framework/auto_unit.py
@@ -428,8 +428,9 @@ class AutoUnit(TrainUnit[TData], EvalUnit[TData], PredictUnit[Any], ABC):
 
             grad_scaler = self.grad_scaler
             if grad_scaler:
-                loss = grad_scaler.scale(loss)
-            loss.backward()
+                grad_scaler.scale(loss).backward()
+            else:
+                loss.backward()
         return loss, outputs
 
     def _run_optimizer_lr_scheduler_step(self, state: State) -> None:


### PR DESCRIPTION
Summary: Currently we are returning the scaled loss in the case of fp16 training with a grad scaler. This means we are logging the scaled loss as well, which is not desired.

Differential Revision: D43969338

