### PR TITLE
Add data prefetching to AutoUnit

### DIFF
--- a/tests/framework/test_utils.py
+++ b/tests/framework/test_utils.py
@@ -33,7 +33,6 @@ from torchtnt.framework.utils import (
     _is_done,
     _is_epoch_done,
     _is_fsdp_module,
-    _is_last_batch_in_epoch,
     _maybe_set_distributed_sampler_epoch,
     _reset_module_training_mode,
     _run_callback_fn,
@@ -257,39 +256,6 @@ class UtilsTest(unittest.TestCase):
         self.assertFalse(_is_epoch_done(p, max_steps_per_epoch=None, max_steps=200))
         self.assertFalse(_is_epoch_done(p, max_steps_per_epoch=6, max_steps=None))
         self.assertFalse(_is_epoch_done(p, max_steps_per_epoch=None, max_steps=None))
-
-    def test_is_last_batch_in_epoch(self) -> None:
-        p = Progress(
-            num_epochs_completed=2,
-            num_steps_completed=99,
-            num_steps_completed_in_epoch=9,
-        )
-
-        self.assertTrue(
-            _is_last_batch_in_epoch(p, max_steps_per_epoch=10, max_steps=200)
-        )
-        self.assertTrue(
-            _is_last_batch_in_epoch(p, max_steps_per_epoch=10, max_steps=None)
-        )
-        self.assertTrue(
-            _is_last_batch_in_epoch(p, max_steps_per_epoch=100, max_steps=100)
-        )
-        self.assertTrue(
-            _is_last_batch_in_epoch(p, max_steps_per_epoch=None, max_steps=100)
-        )
-
-        self.assertFalse(
-            _is_last_batch_in_epoch(p, max_steps_per_epoch=11, max_steps=200)
-        )
-        self.assertFalse(
-            _is_last_batch_in_epoch(p, max_steps_per_epoch=None, max_steps=200)
-        )
-        self.assertFalse(
-            _is_last_batch_in_epoch(p, max_steps_per_epoch=11, max_steps=None)
-        )
-        self.assertFalse(
-            _is_last_batch_in_epoch(p, max_steps_per_epoch=None, max_steps=None)
-        )
 
     def test_get_current_progress(self) -> None:
         train_state = PhaseState(

--- a/tests/utils/test_device.py
+++ b/tests/utils/test_device.py
@@ -19,6 +19,7 @@ from torchtnt.utils.device import (
     get_device_from_env,
     get_nvidia_smi_gpu_stats,
     get_psutil_cpu_stats,
+    record_data_in_stream,
 )
 
 
@@ -293,3 +294,57 @@ class DeviceTest(unittest.TestCase):
         self.assertGreaterEqual(gpu_stats["memory_free_mb"], 0)
         self.assertGreaterEqual(gpu_stats["temperature_gpu_celsius"], 0)
         self.assertGreaterEqual(gpu_stats["temperature_memory_celsius"], 0)
+
+    @unittest.skipUnless(
+        condition=(cuda_available), reason="This test must run on a GPU host."
+    )
+    def test_record_data_in_stream_dict(self) -> None:
+        curr_stream = torch.cuda.current_stream()
+        a = torch.tensor([1, 2, 3])
+        b = torch.tensor([4, 5, 6])
+        data = {"a": a, "b": b}
+
+        with mock.patch.object(
+            a, "record_stream"
+        ) as mock_record_stream_a, mock.patch.object(
+            b, "record_stream"
+        ) as mock_record_stream_b:
+            record_data_in_stream(data, curr_stream)
+            mock_record_stream_a.assert_called_once()
+            mock_record_stream_b.assert_called_once()
+
+    @unittest.skipUnless(
+        condition=(cuda_available), reason="This test must run on a GPU host."
+    )
+    def test_record_data_in_stream_tuple(self) -> None:
+        curr_stream = torch.cuda.current_stream()
+        a = torch.tensor([1, 2, 3])
+        b = torch.tensor([4, 5, 6])
+        data = (a, b)
+
+        with mock.patch.object(
+            a, "record_stream"
+        ) as mock_record_stream_a, mock.patch.object(
+            b, "record_stream"
+        ) as mock_record_stream_b:
+            record_data_in_stream(data, curr_stream)
+            mock_record_stream_a.assert_called_once()
+            mock_record_stream_b.assert_called_once()
+
+    @unittest.skipUnless(
+        condition=(cuda_available), reason="This test must run on a GPU host."
+    )
+    def test_record_data_in_stream_list(self) -> None:
+        curr_stream = torch.cuda.current_stream()
+        a = torch.tensor([1, 2, 3])
+        b = torch.tensor([4, 5, 6])
+        data = [a, b]
+
+        with mock.patch.object(
+            a, "record_stream"
+        ) as mock_record_stream_a, mock.patch.object(
+            b, "record_stream"
+        ) as mock_record_stream_b:
+            record_data_in_stream(data, curr_stream)
+            mock_record_stream_a.assert_called_once()
+            mock_record_stream_b.assert_called_once()

--- a/torchtnt/framework/utils.py
+++ b/torchtnt/framework/utils.py
@@ -47,17 +47,6 @@ def _is_epoch_done(
     )
 
 
-def _is_last_batch_in_epoch(
-    progress: Progress, max_steps_per_epoch: Optional[int], max_steps: Optional[int]
-) -> bool:
-    return (
-        max_steps is not None and progress.num_steps_completed >= max_steps - 1
-    ) or (
-        max_steps_per_epoch is not None
-        and progress.num_steps_completed_in_epoch >= max_steps_per_epoch - 1
-    )
-
-
 def _maybe_set_distributed_sampler_epoch(
     # pyre-ignore: Missing parameter annotation [2]
     dataloader: Iterable[Any],

--- a/torchtnt/utils/__init__.py
+++ b/torchtnt/utils/__init__.py
@@ -12,6 +12,7 @@ from .device import (
     get_psutil_cpu_stats,
     GPUStats,
     maybe_enable_tf32,
+    record_data_in_stream,
 )
 from .distributed import (
     all_gather_tensors,
@@ -61,6 +62,7 @@ __all__ = [
     "get_psutil_cpu_stats",
     "GPUStats",
     "maybe_enable_tf32",
+    "record_data_in_stream",
     "all_gather_tensors",
     "get_global_rank",
     "get_process_group_backend_from_device",

--- a/torchtnt/utils/device.py
+++ b/torchtnt/utils/device.py
@@ -123,6 +123,55 @@ def copy_data_to_device(data: T, device: torch.device, *args: Any, **kwargs: Any
     return data
 
 
+def record_data_in_stream(data: T, stream: torch.cuda.streams.Stream) -> None:
+    """
+    As mentioned in
+    https://pytorch.org/docs/stable/generated/torch.Tensor.record_stream.html, PyTorch
+    uses the "caching allocator" for memory allocation for tensors. When a tensor is
+    freed, its memory is likely to be reused by newly constructed tensors. By default,
+    this allocator traces whether a tensor is still in use by only the CUDA stream where
+    it was created. When a tensor is used by additional CUDA streams, we need to call
+    `record_stream` to tell the allocator about these streams. Otherwise, the allocator
+    might free the underlying memory of the tensor once it is no longer used by the
+    creator stream. This is a notable programming trick when we write programs using
+    multiple CUDA streams.
+
+    Args:
+        data: The data on which to call record_stream
+        stream: The CUDA stream with which to call record_stream
+    """
+
+    # Redundant isinstance(data, tuple) check is required here to make pyre happy
+    if _is_named_tuple(data) and isinstance(data, tuple):
+        record_data_in_stream(data._asdict(), stream)
+    elif isinstance(data, (list, tuple)):
+        for e in data:
+            record_data_in_stream(e, stream)
+    elif isinstance(data, Mapping):
+        for _, v in data.items():
+            record_data_in_stream(v, stream)
+    elif is_dataclass(data) and not isinstance(data, type):
+        for field in fields(data):
+            record_data_in_stream(getattr(data, field.name), stream)
+    elif isinstance(data, _MultistreamableData):
+        data.record_stream(stream)
+
+
+@runtime_checkable
+class _MultistreamableData(Protocol):
+    """
+    Objects implementing this interface are allowed to be transferred
+    from one CUDA stream to another.
+    torch.Tensor implements this interface.
+    """
+
+    def record_stream(self, stream: torch.cuda.streams.Stream) -> None:
+        """
+        See https://pytorch.org/docs/stable/generated/torch.Tensor.record_stream.html
+        """
+        ...
+
+
 class GPUStats(TypedDict):
     utilization_gpu_percent: float
     utilization_memory_percent: float


### PR DESCRIPTION
Summary:
This runs the host to device data copy in a parallel cuda stream for a performance improvement.
In order to enable this we need to pass the data iterator to the train_step rather than passing the batch.
Also removed `is_last_batch` from PhaseState and `_is_last_batch_in_epoch` from utils

Differential Revision: D44750106

