### PR TITLE
Add auto-timing back to the framework

### DIFF
--- a/tests/framework/test_fit.py
+++ b/tests/framework/test_fit.py
@@ -307,3 +307,45 @@ class FitTest(unittest.TestCase):
             max_epochs=max_epochs,
         )
         fit(state, my_unit, callbacks=[PhaseTestCallback()])
+
+    def test_fit_auto_timing(self) -> None:
+        """
+        Test fit timing in predict
+        """
+
+        input_dim = 2
+        dataset_len = 10
+        batch_size = 2
+        max_steps_per_epoch = 1
+        max_epochs = 1
+        evaluate_every_n_epochs = 1
+
+        dataloader = generate_random_dataloader(dataset_len, input_dim, batch_size)
+
+        state = init_fit_state(
+            train_dataloader=dataloader,
+            eval_dataloader=dataloader,
+            max_train_steps_per_epoch=max_steps_per_epoch,
+            max_epochs=max_epochs,
+            evaluate_every_n_epochs=evaluate_every_n_epochs,
+        )
+        fit(
+            state,
+            DummyFitUnit(input_dim=input_dim),
+        )
+        self.assertIsNone(state.timer)
+
+        state = init_fit_state(
+            train_dataloader=dataloader,
+            eval_dataloader=dataloader,
+            max_train_steps_per_epoch=max_steps_per_epoch,
+            max_epochs=max_epochs,
+            evaluate_every_n_epochs=evaluate_every_n_epochs,
+            auto_timing=True,
+        )
+        fit(state, DummyFitUnit(input_dim=input_dim))
+        for k in [
+            "train.DummyFitUnit.on_train_start",
+            "train.DummyFitUnit.on_train_end",
+        ]:
+            self.assertTrue(k in state.timer.recorded_durations.keys())

--- a/tests/framework/test_train.py
+++ b/tests/framework/test_train.py
@@ -258,6 +258,40 @@ class TrainTest(unittest.TestCase):
             my_unit.train_step.call_count, max_epochs * expected_steps_per_epoch
         )
 
+    def test_train_auto_timing(self) -> None:
+        """
+        Test auto timing in train
+        """
+
+        input_dim = 2
+        dataset_len = 10
+        batch_size = 2
+        max_steps_per_epoch = 1
+        max_epochs = 1
+
+        dataloader = generate_random_dataloader(dataset_len, input_dim, batch_size)
+
+        state = init_train_state(
+            dataloader=dataloader,
+            max_steps_per_epoch=max_steps_per_epoch,
+            max_epochs=max_epochs,
+        )
+        train(state, DummyTrainUnit(input_dim=input_dim))
+        self.assertIsNone(state.timer)
+
+        state = init_train_state(
+            dataloader=dataloader,
+            max_steps_per_epoch=max_steps_per_epoch,
+            max_epochs=max_epochs,
+            auto_timing=True,
+        )
+        train(state, DummyTrainUnit(input_dim=input_dim))
+        for k in [
+            "train.DummyTrainUnit.on_train_start",
+            "train.DummyTrainUnit.on_train_end",
+        ]:
+            self.assertTrue(k in state.timer.recorded_durations.keys())
+
 
 Batch = Tuple[torch.Tensor, torch.Tensor]
 

--- a/torchtnt/framework/state.py
+++ b/torchtnt/framework/state.py
@@ -14,7 +14,7 @@ from enum import auto, Enum
 from typing import Any, Iterable, Optional
 
 from torchtnt.framework.progress import Progress
-from torchtnt.utils import Timer
+from torchtnt.utils.timer import Timer
 
 _logger: logging.Logger = logging.getLogger(__name__)
 
@@ -148,7 +148,7 @@ class State:
         predict_state: Optional[PhaseState] = None,
     ) -> None:
         self._entry_point = entry_point
-        self._timer: Timer = timer or Timer()
+        self._timer = timer
         self._train_state = train_state
         self._eval_state = eval_state
         self._predict_state = predict_state
@@ -166,7 +166,7 @@ class State:
         return self._active_phase
 
     @property
-    def timer(self) -> Timer:
+    def timer(self) -> Optional[Timer]:
         """A :class:`~torchtnt.framework.Timer` object which can be used for debugging to record latencies of key events during loop execution."""
         return self._timer
 


### PR DESCRIPTION
Summary: Add auto timing back to framework, with the addition of `auto_timing` flag when calling `train()`, `predict()`, `evaluate()`, and `fit()` which enables timing if set to true (defaults to false)

Differential Revision: D45249504

