### PR TITLE
In fit for evaluate_every_n_steps use num_steps_completed instead of num_steps_completed_in_epoch in epoch

### DIFF
--- a/tests/framework/test_fit.py
+++ b/tests/framework/test_fit.py
@@ -5,6 +5,7 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
+import math
 import unittest
 from typing import Tuple
 from unittest.mock import MagicMock
@@ -73,21 +74,19 @@ class FitTest(unittest.TestCase):
 
     def test_fit_evaluate_every_n_steps(self) -> None:
         """
-        Test fit entry point with evaluate_every_n_steps=2
+        Test fit entry point with evaluate_every_n_steps=5
         """
         input_dim = 2
         train_dataset_len = 16
         eval_dataset_len = 4
         batch_size = 2
         max_epochs = 3
-        evaluate_every_n_steps = 2
+        evaluate_every_n_steps = 5
         expected_train_steps_per_epoch = train_dataset_len / batch_size
+        expected_total_train_steps = expected_train_steps_per_epoch * max_epochs
         expected_eval_steps_per_epoch = eval_dataset_len / batch_size
-        expected_num_evaluate_calls_per_train_epoch = (
-            expected_train_steps_per_epoch / evaluate_every_n_steps
-        )
-        expected_num_evaluate_calls = (
-            expected_num_evaluate_calls_per_train_epoch * max_epochs
+        expected_num_evaluate_calls = math.floor(
+            expected_total_train_steps / evaluate_every_n_steps
         )
 
         my_unit = DummyFitUnit(input_dim=input_dim)

--- a/torchtnt/framework/train.py
+++ b/torchtnt/framework/train.py
@@ -310,8 +310,7 @@ def _train_epoch_impl(
 
             if (
                 evaluate_every_n_steps
-                and train_state.progress.num_steps_completed_in_epoch
-                % evaluate_every_n_steps
+                and train_state.progress.num_steps_completed % evaluate_every_n_steps
                 == 0
             ):
                 _evaluate_impl(


### PR DESCRIPTION
Summary: The current code can lead to unexpected behavior in TB logs if logging based on num_steps_completed and evaluating based on num_steps_completed_in_epoch

Reviewed By: ananthsub

Differential Revision: D45372747

