### PR TITLE
set tqdm start at current num_steps_completed

### DIFF
--- a/tests/framework/callbacks/test_tqdm_progress_bar.py
+++ b/tests/framework/callbacks/test_tqdm_progress_bar.py
@@ -111,6 +111,32 @@ class TQDMProgressBarTest(unittest.TestCase):
         progress_bar.on_predict_epoch_start(state, my_unit)
         self.assertEqual(progress_bar._predict_progress_bar.total, expected_total)
 
+    def test_progress_bar_mid_progress(self) -> None:
+        """
+        Test TQDMProgressBar callback when progress already has occurred (can occur when loading checkpoint)
+        """
+        input_dim = 2
+        dataset_len = 10
+        batch_size = 2
+        max_epochs = 1
+        expected_total = dataset_len / batch_size
+
+        dataloader = generate_random_dataloader(dataset_len, input_dim, batch_size)
+        state = State(
+            entry_point=EntryPoint.PREDICT,
+            predict_state=PhaseState(
+                dataloader=dataloader,
+                max_epochs=max_epochs,
+            ),
+        )
+        state.predict_state.progress._num_steps_completed = 2
+
+        my_unit = MagicMock(spec=DummyPredictUnit)
+        progress_bar = TQDMProgressBar()
+        progress_bar.on_predict_epoch_start(state, my_unit)
+        self.assertEqual(progress_bar._predict_progress_bar.total, expected_total)
+        self.assertEqual(progress_bar._predict_progress_bar.n, 2)
+
     def test_estimated_steps_in_epoch(self) -> None:
         """
         Test TQDMProgressBar's _estimate_steps_in_epoch function

--- a/torchtnt/framework/callbacks/tqdm_progress_bar.py
+++ b/torchtnt/framework/callbacks/tqdm_progress_bar.py
@@ -140,7 +140,9 @@ def _create_progress_bar(
         max_steps=max_steps,
         max_steps_per_epoch=max_steps_per_epoch,
     )
-    return tqdm(desc=f"{desc} {current_epoch}", total=total)
+    return tqdm(
+        desc=f"{desc} {current_epoch}", total=total, initial=num_steps_completed
+    )
 
 
 def _update_progress_bar(


### PR DESCRIPTION
Summary:
When loading a checkpoint with intermittent progress, progress bar starts from step 0, even though the checkpoint may start step 100

Fix is to set the `initial=num_steps_completed` in tqdm initialization so that it starts at whatever the start step is

Differential Revision: D45871996

