### PR TITLE
Add more fine-grained timing to the AutoUnit

### DIFF
--- a/tests/framework/test_evaluate.py
+++ b/tests/framework/test_evaluate.py
@@ -194,14 +194,14 @@ class EvaluateTest(unittest.TestCase):
             auto_timing=True,
         )
         evaluate(state, DummyEvalUnit(input_dim=input_dim))
-        for k in [
-            "eval.DummyEvalUnit.on_eval_start",
-            "eval.DummyEvalUnit.on_eval_epoch_start",
-            "eval.data_iter_next",
-            "eval.DummyEvalUnit.eval_step",
-            "eval.DummyEvalUnit.on_eval_epoch_end",
-            "eval.DummyEvalUnit.on_eval_end",
-        ]:
+        for k in (
+            "DummyEvalUnit.on_eval_start",
+            "DummyEvalUnit.on_eval_epoch_start",
+            "evaluate.next(data_iter)",
+            "DummyEvalUnit.eval_step",
+            "DummyEvalUnit.on_eval_epoch_end",
+            "DummyEvalUnit.on_eval_end",
+        ):
             self.assertTrue(k in state.timer.recorded_durations.keys())
 
 

--- a/tests/framework/test_fit.py
+++ b/tests/framework/test_fit.py
@@ -343,8 +343,8 @@ class FitTest(unittest.TestCase):
             auto_timing=True,
         )
         fit(state, DummyFitUnit(input_dim=input_dim))
-        for k in [
-            "train.DummyFitUnit.on_train_start",
-            "train.DummyFitUnit.on_train_end",
-        ]:
+        for k in (
+            "DummyFitUnit.on_train_start",
+            "DummyFitUnit.on_train_end",
+        ):
             self.assertTrue(k in state.timer.recorded_durations.keys())

--- a/tests/framework/test_predict.py
+++ b/tests/framework/test_predict.py
@@ -199,14 +199,14 @@ class PredictTest(unittest.TestCase):
             auto_timing=True,
         )
         predict(state, DummyPredictUnit(input_dim=input_dim))
-        for k in [
-            "predict.DummyPredictUnit.on_predict_start",
-            "predict.DummyPredictUnit.on_predict_epoch_start",
-            "predict.data_iter_next",
-            "predict.DummyPredictUnit.predict_step",
-            "predict.DummyPredictUnit.on_predict_epoch_end",
-            "predict.DummyPredictUnit.on_predict_end",
-        ]:
+        for k in (
+            "DummyPredictUnit.on_predict_start",
+            "DummyPredictUnit.on_predict_epoch_start",
+            "predict.next(data_iter)",
+            "DummyPredictUnit.predict_step",
+            "DummyPredictUnit.on_predict_epoch_end",
+            "DummyPredictUnit.on_predict_end",
+        ):
             self.assertTrue(k in state.timer.recorded_durations.keys())
 
 

--- a/tests/framework/test_train.py
+++ b/tests/framework/test_train.py
@@ -286,10 +286,11 @@ class TrainTest(unittest.TestCase):
             auto_timing=True,
         )
         train(state, DummyTrainUnit(input_dim=input_dim))
-        for k in [
-            "train.DummyTrainUnit.on_train_start",
-            "train.DummyTrainUnit.on_train_end",
-        ]:
+        for k in (
+            "DummyTrainUnit.on_train_start",
+            "DummyTrainUnit.on_train_end",
+            "train.next(data_iter)",
+        ):
             self.assertTrue(k in state.timer.recorded_durations.keys())
 
 

--- a/torchtnt/framework/fit.py
+++ b/torchtnt/framework/fit.py
@@ -181,7 +181,7 @@ def _fit_impl(
         f"evaluate_every_n_epochs={eval_state.evaluate_every_n_epochs} "
     )
 
-    with _get_timing_context(state, f"train.{unit.__class__.__name__}.on_train_start"):
+    with _get_timing_context(state, f"{unit.__class__.__name__}.on_train_start"):
         unit.on_train_start(state)
     _run_callback_fn(callbacks, "on_train_start", state, unit)
 
@@ -191,6 +191,6 @@ def _fit_impl(
     ):
         _train_epoch_impl(state, unit, callbacks)
 
-    with _get_timing_context(state, f"train.{unit.__class__.__name__}.on_train_end"):
+    with _get_timing_context(state, f"{unit.__class__.__name__}.on_train_end"):
         unit.on_train_end(state)
     _run_callback_fn(callbacks, "on_train_end", state, unit)


### PR DESCRIPTION
Summary:
* Expand `_get_timing_context` to return two context managers:
  - one for timing with the Timer
  - one for calling record_function for PT Profiler
* Replace calls to record_function in AutoUnit with calls to `_get_timing_context` so that we time these functions as well
* Make some small changes to the `event_name`s for better readability

Differential Revision: D45974462

