### PR TITLE
Fix module to device in AutoUnit

### DIFF
--- a/torchtnt/framework/auto_unit.py
+++ b/torchtnt/framework/auto_unit.py
@@ -259,7 +259,7 @@ class AutoUnit(
                 # remove ddp comm hook variables from params dict
                 del params_dict["comm_state"]
                 del params_dict["comm_hook"]
-                module = module.to(device)
+                module = module.to(self.device)
                 module = DDP(module, device_ids=device_ids, **params_dict)
                 if torchdynamo_params:
                     # TODO: Add support for dynamo and DDP
@@ -295,7 +295,7 @@ class AutoUnit(
                     **asdict(strategy),
                 )
         else:
-            module = module.to(device)
+            module = module.to(self.device)
 
         self.module: torch.nn.Module = module
 

--- a/torchtnt/utils/__init__.py
+++ b/torchtnt/utils/__init__.py
@@ -6,6 +6,7 @@
 
 from .device import (
     copy_data_to_device,
+    copy_list_tensors_to_device,
     CPUStats,
     get_device_from_env,
     get_nvidia_smi_gpu_stats,
@@ -56,6 +57,7 @@ from .version import (
 
 __all__ = [
     "copy_data_to_device",
+    "copy_list_tensors_to_device",
     "CPUStats",
     "get_device_from_env",
     "get_nvidia_smi_gpu_stats",


### PR DESCRIPTION
Summary:
In D46001765 the `self.device` reference was accidentally changed to `device`. Because of this the module isn't being moved to the device properly and we are seeing errors like:
```
ValueError: DistributedDataParallel device_ids and output_device arguments only work with single-device/multiple-device GPU modules or CPU modules, but got device_ids [1], output_device None, and module parameters {device(type='cpu')}
```
when running vise DDP.

Differential Revision: D46056924

