### PR TITLE
Fix AutoUnit docs

### DIFF
--- a/torchtnt/framework/auto_unit.py
+++ b/torchtnt/framework/auto_unit.py
@@ -215,11 +215,12 @@ class AutoUnit(
         torchdynamo_params: params for TorchDynamo https://pytorch.org/docs/stable/dynamo/index.html
         training: if True, the optimizer and optionally LR scheduler will be created after the class is initialized.
 
-            Note:
-                Stochastic Weight Averaging is currently not supported with the FSDP strategy.
+    Note:
+        Stochastic Weight Averaging is currently not supported with the FSDP strategy.
 
-            Note:
-                TorchDynamo support is only available in PyTorch 2.0 or higher.
+    Note:
+        TorchDynamo support is only available in PyTorch 2.0 or higher.
+
     """
 
     def __init__(


### PR DESCRIPTION
Summary:
Currently the `Note:` section in the docs is messed up:
https://pytorch.org/tnt/stable/framework/auto_unit.html

Differential Revision: D46370257

