### PR TITLE
add SHARDED_STATE_DICT support to fsdp

### DIFF
--- a/torchtnt/framework/callbacks/torchsnapshot_saver.py
+++ b/torchtnt/framework/callbacks/torchsnapshot_saver.py
@@ -60,7 +60,10 @@ class TorchSnapshotSaver(Callback):
         replicated: A glob-pattern of replicated key names that indicate which application state entries have the same state across all processes.
             For more information, see https://pytorch.org/torchsnapshot/main/api_reference.html#torchsnapshot.Snapshot.take .
 
-            Note: If torch.distributed is available and default process group is initialized, the constructor will call a collective operation for rank 0 to broadcast the dirpath to all other ranks
+    Note: If torch.distributed is available and default process group is initialized, the constructor will call a collective operation for rank 0 to broadcast the dirpath to all other ranks
+
+    Note:
+        If checkpointing FSDP model, you can set state_dict type calling `set_state_dict_type <https://pytorch.org/docs/stable/fsdp.html#torch.distributed.fsdp.FullyShardedDataParallel.set_state_dict_type>`_ prior to starting training.
     """
 
     def __init__(


### PR DESCRIPTION
Summary:
Add sharded_state_dict support to tnt

Changes made
1) Added params to `FSDPStrategy` dataclass in AutoUnit to capture arguments to `FSDP.set_state_dict_type()` which is applied after model is wrapped in FSDP
2) Added notes to checkpointing callbacks indicating users to apply `set_state_dict_type` prior to checkpointing

Users can enable using in autounit via
```
FSDPStrategy(
    auto_wrap_policy=policy,
    state_dict_type=StateDictType.SHARDED_STATE_DICT
),
```

Differential Revision: D46501991

