### PR TITLE
Add utils to profile dataloading

### DIFF
--- a/tests/utils/data/test_profile_dataloader.py
+++ b/tests/utils/data/test_profile_dataloader.py
@@ -1,0 +1,56 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+import unittest
+from typing import Iterator
+
+import torch
+from torch.profiler import ProfilerActivity
+from torchtnt.utils.data.profile_dataloader import profile_dataloader
+
+
+class DummyIterable:
+    def __init__(self, count: int) -> None:
+        self.count: int = count
+
+    def __iter__(self) -> Iterator[int]:
+        for i in range(self.count):
+            yield i
+
+
+class ProfileDataLoaderTest(unittest.TestCase):
+    def test_profile_dataloader(self) -> None:
+        max_length = 10
+        iterable = DummyIterable(max_length)
+        timer = profile_dataloader(iterable)
+        self.assertEqual(len(timer.recorded_durations["next(iter)"]), max_length)
+
+    def test_profile_dataloader_max_steps(self) -> None:
+        max_length = 10
+        max_steps = 5
+        iterable = DummyIterable(max_length)
+        timer = profile_dataloader(iterable, max_steps=max_steps)
+        self.assertEqual(len(timer.recorded_durations["next(iter)"]), max_steps)
+
+    def test_profile_dataloader_profiler(self) -> None:
+        max_length = 10
+        iterable = DummyIterable(max_length)
+        profiler = _get_torch_profiler()
+        timer = profile_dataloader(iterable, profiler=profiler)
+        self.assertEqual(len(timer.recorded_durations["next(iter)"]), max_length)
+
+
+def _get_torch_profiler() -> torch.profiler.profile:
+    profiler_schedule = torch.profiler.schedule(
+        wait=0,
+        warmup=1,
+        active=1,
+    )
+    return torch.profiler.profile(
+        activities=[ProfilerActivity.CPU],
+        schedule=profiler_schedule,
+    )

--- a/torchtnt/utils/data/__init__.py
+++ b/torchtnt/utils/data/__init__.py
@@ -15,6 +15,7 @@ from .iterators import (
     RoundRobinIterator,
 )
 from .multi_dataloader import MultiDataLoader
+from .profile_dataloader import profile_dataloader
 
 __all__ = [
     "AllDatasetBatchesIterator",
@@ -26,4 +27,5 @@ __all__ = [
     "MultiIterator",
     "RandomizedBatchSamplerIterator",
     "RoundRobinIterator",
+    "profile_dataloader",
 ]

--- a/torchtnt/utils/data/profile_dataloader.py
+++ b/torchtnt/utils/data/profile_dataloader.py
@@ -1,0 +1,60 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+import logging
+from typing import Iterable, Optional
+
+import torch
+from torch.profiler import record_function
+from torchtnt.utils.distributed import get_global_rank
+from torchtnt.utils.timer import get_timer_summary, Timer
+
+_log: logging.Logger = logging.getLogger(__name__)
+
+
+def profile_dataloader(
+    dataloader: Iterable[object],
+    *,
+    max_steps: Optional[int] = None,
+    profiler: Optional[torch.profiler.profile] = None,
+    timer: Optional[Timer] = None,
+) -> Timer:
+    """
+    A helper function that profiles the dataloader iterations.
+
+    Args:
+        dataloader: dataloader to be profiled.
+        max_steps (optional): maximum number of steps to run for. If not set, the dataloader will run until its iterator is exhausted.
+        profiler (optional): torch profiler to be used.
+        timer (optional): timer to be used to track duration.
+    """
+    timer = timer if timer is not None else Timer()
+    with timer.time("iter(dataloader)"), record_function("iter(dataloader)"):
+        data_iter = iter(dataloader)
+
+    # If max_steps is not set, run until the dataloader is exhausted
+    steps_completed = 0
+
+    if profiler:
+        profiler.start()
+
+    while max_steps is None or (steps_completed < max_steps):
+        try:
+            with timer.time("next(iter)"), record_function("next(iter)"):
+                next(data_iter)
+            steps_completed += 1
+            if profiler:
+                profiler.step()
+        except StopIteration:
+            break
+
+    if profiler:
+        profiler.stop()
+
+    rank = get_global_rank()
+    _log.info(f"Timer summary for rank {rank}:\n{get_timer_summary(timer)}")
+    return timer


### PR DESCRIPTION
Summary: this is a tiny utility to step over a data loader and time fetches, so we can profile data loading independently of training/batch inference

Reviewed By: HarounH

Differential Revision: D46865328

