### PR TITLE
Add tqdm utils

### DIFF
--- a/tests/framework/callbacks/test_tqdm_progress_bar.py
+++ b/tests/framework/callbacks/test_tqdm_progress_bar.py
@@ -14,10 +14,7 @@ from torchtnt.framework._test_utils import (
     DummyTrainUnit,
     generate_random_dataloader,
 )
-from torchtnt.framework.callbacks.tqdm_progress_bar import (
-    _estimated_steps_in_epoch,
-    TQDMProgressBar,
-)
+from torchtnt.framework.callbacks.tqdm_progress_bar import TQDMProgressBar
 from torchtnt.framework.state import EntryPoint, PhaseState, State
 from torchtnt.framework.train import init_train_state, train
 
@@ -136,52 +133,3 @@ class TQDMProgressBarTest(unittest.TestCase):
         progress_bar.on_predict_epoch_start(state, my_unit)
         self.assertEqual(progress_bar._predict_progress_bar.total, expected_total)
         self.assertEqual(progress_bar._predict_progress_bar.n, 2)
-
-    def test_estimated_steps_in_epoch(self) -> None:
-        """
-        Test TQDMProgressBar's _estimate_steps_in_epoch function
-        """
-
-        input_dim = 2
-        dataset_len = 20
-        batch_size = 2
-        dataloader_size = dataset_len / batch_size
-
-        dataloader = generate_random_dataloader(dataset_len, input_dim, batch_size)
-
-        self.assertEqual(
-            _estimated_steps_in_epoch(
-                dataloader, num_steps_completed=0, max_steps=5, max_steps_per_epoch=5
-            ),
-            5,
-        )
-        self.assertEqual(
-            _estimated_steps_in_epoch(
-                dataloader, num_steps_completed=4, max_steps=5, max_steps_per_epoch=4
-            ),
-            1,
-        )
-        self.assertEqual(
-            _estimated_steps_in_epoch(
-                dataloader, num_steps_completed=0, max_steps=4, max_steps_per_epoch=10
-            ),
-            4,
-        )
-        self.assertEqual(
-            _estimated_steps_in_epoch(
-                dataloader,
-                num_steps_completed=0,
-                max_steps=None,
-                max_steps_per_epoch=None,
-            ),
-            dataloader_size,
-        )
-        self.assertEqual(
-            _estimated_steps_in_epoch(
-                dataloader,
-                num_steps_completed=0,
-                max_steps=None,
-                max_steps_per_epoch=500,
-            ),
-            dataloader_size,
-        )

--- a/tests/utils/test_progress.py
+++ b/tests/utils/test_progress.py
@@ -7,7 +7,9 @@
 
 import unittest
 
-from torchtnt.utils.progress import Progress
+from torchtnt.framework._test_utils import generate_random_dataloader
+
+from torchtnt.utils.progress import estimated_steps_in_epoch, Progress
 
 
 class ProgressTest(unittest.TestCase):
@@ -34,3 +36,49 @@ class ProgressTest(unittest.TestCase):
         self.assertEqual(new_progress.num_epochs_completed, 2)
         self.assertEqual(new_progress.num_steps_completed, 8)
         self.assertEqual(new_progress.num_steps_completed_in_epoch, 4)
+
+    def test_estimated_steps_in_epoch(self) -> None:
+
+        input_dim = 2
+        dataset_len = 20
+        batch_size = 2
+        dataloader_size = dataset_len / batch_size
+
+        dataloader = generate_random_dataloader(dataset_len, input_dim, batch_size)
+
+        self.assertEqual(
+            estimated_steps_in_epoch(
+                dataloader, num_steps_completed=0, max_steps=5, max_steps_per_epoch=5
+            ),
+            5,
+        )
+        self.assertEqual(
+            estimated_steps_in_epoch(
+                dataloader, num_steps_completed=4, max_steps=5, max_steps_per_epoch=4
+            ),
+            1,
+        )
+        self.assertEqual(
+            estimated_steps_in_epoch(
+                dataloader, num_steps_completed=0, max_steps=4, max_steps_per_epoch=10
+            ),
+            4,
+        )
+        self.assertEqual(
+            estimated_steps_in_epoch(
+                dataloader,
+                num_steps_completed=0,
+                max_steps=None,
+                max_steps_per_epoch=None,
+            ),
+            dataloader_size,
+        )
+        self.assertEqual(
+            estimated_steps_in_epoch(
+                dataloader,
+                num_steps_completed=0,
+                max_steps=None,
+                max_steps_per_epoch=500,
+            ),
+            dataloader_size,
+        )

--- a/torchtnt/framework/callbacks/tqdm_progress_bar.py
+++ b/torchtnt/framework/callbacks/tqdm_progress_bar.py
@@ -4,8 +4,7 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
-from collections.abc import Sized
-from typing import Iterable, Optional
+from typing import Optional
 
 from pyre_extensions import none_throws
 
@@ -13,6 +12,11 @@ from torchtnt.framework.callback import Callback
 from torchtnt.framework.state import State
 from torchtnt.framework.unit import TEvalUnit, TPredictUnit, TTrainUnit
 from torchtnt.utils.distributed import get_global_rank
+from torchtnt.utils.tqdm import (
+    close_progress_bar,
+    create_progress_bar,
+    update_progress_bar,
+)
 from tqdm.auto import tqdm
 
 
@@ -34,162 +38,96 @@ class TQDMProgressBar(Callback):
 
     def on_train_epoch_start(self, state: State, unit: TTrainUnit) -> None:
         train_state = none_throws(state.train_state)
-        self._train_progress_bar = _create_progress_bar(
-            train_state.dataloader,
-            desc="Train Epoch",
-            num_epochs_completed=train_state.progress.num_epochs_completed,
-            num_steps_completed=train_state.progress.num_steps_completed_in_epoch,
-            max_steps=train_state.max_steps,
-            max_steps_per_epoch=train_state.max_steps_per_epoch,
-        )
+        if get_global_rank() == 0:
+            self._train_progress_bar = create_progress_bar(
+                train_state.dataloader,
+                desc="Train Epoch",
+                num_epochs_completed=train_state.progress.num_epochs_completed,
+                num_steps_completed=train_state.progress.num_steps_completed_in_epoch,
+                max_steps=train_state.max_steps,
+                max_steps_per_epoch=train_state.max_steps_per_epoch,
+            )
 
     def on_train_step_end(self, state: State, unit: TTrainUnit) -> None:
         train_state = none_throws(state.train_state)
-        if self._train_progress_bar is not None:
-            _update_progress_bar(
-                self._train_progress_bar,
+        pbar = self._train_progress_bar
+        if pbar is not None:
+            update_progress_bar(
+                pbar,
                 train_state.progress.num_steps_completed_in_epoch,
                 self._refresh_rate,
             )
 
     def on_train_epoch_end(self, state: State, unit: TTrainUnit) -> None:
         train_state = none_throws(state.train_state)
-        if self._train_progress_bar is not None:
-            _close_progress_bar(
-                self._train_progress_bar,
+        pbar = self._train_progress_bar
+        if pbar is not None:
+            close_progress_bar(
+                pbar,
                 train_state.progress.num_steps_completed_in_epoch,
                 self._refresh_rate,
             )
 
     def on_eval_epoch_start(self, state: State, unit: TEvalUnit) -> None:
         eval_state = none_throws(state.eval_state)
-        self._eval_progress_bar = _create_progress_bar(
-            eval_state.dataloader,
-            desc="Eval Epoch",
-            num_epochs_completed=eval_state.progress.num_epochs_completed,
-            num_steps_completed=eval_state.progress.num_steps_completed_in_epoch,
-            max_steps=eval_state.max_steps,
-            max_steps_per_epoch=eval_state.max_steps_per_epoch,
-        )
+        if get_global_rank() == 0:
+            self._eval_progress_bar = create_progress_bar(
+                eval_state.dataloader,
+                desc="Eval Epoch",
+                num_epochs_completed=eval_state.progress.num_epochs_completed,
+                num_steps_completed=eval_state.progress.num_steps_completed_in_epoch,
+                max_steps=eval_state.max_steps,
+                max_steps_per_epoch=eval_state.max_steps_per_epoch,
+            )
 
     def on_eval_step_end(self, state: State, unit: TEvalUnit) -> None:
         eval_state = none_throws(state.eval_state)
-        if self._eval_progress_bar is not None:
-            _update_progress_bar(
-                self._eval_progress_bar,
+        pbar = self._eval_progress_bar
+        if pbar is not None:
+            update_progress_bar(
+                pbar,
                 eval_state.progress.num_steps_completed_in_epoch,
                 self._refresh_rate,
             )
 
     def on_eval_epoch_end(self, state: State, unit: TEvalUnit) -> None:
         eval_state = none_throws(state.eval_state)
-        if self._eval_progress_bar is not None and state.eval_state:
-            _close_progress_bar(
-                self._eval_progress_bar,
+        pbar = self._eval_progress_bar
+        if pbar is not None and state.eval_state:
+            close_progress_bar(
+                pbar,
                 eval_state.progress.num_steps_completed_in_epoch,
                 self._refresh_rate,
             )
 
     def on_predict_epoch_start(self, state: State, unit: TPredictUnit) -> None:
         predict_state = none_throws(state.predict_state)
-        self._predict_progress_bar = _create_progress_bar(
-            predict_state.dataloader,
-            desc="Predict Epoch",
-            num_epochs_completed=predict_state.progress.num_epochs_completed,
-            num_steps_completed=predict_state.progress.num_steps_completed,
-            max_steps=predict_state.max_steps,
-            max_steps_per_epoch=predict_state.max_steps_per_epoch,
-        )
+        if get_global_rank() == 0:
+            self._predict_progress_bar = create_progress_bar(
+                predict_state.dataloader,
+                desc="Predict Epoch",
+                num_epochs_completed=predict_state.progress.num_epochs_completed,
+                num_steps_completed=predict_state.progress.num_steps_completed,
+                max_steps=predict_state.max_steps,
+                max_steps_per_epoch=predict_state.max_steps_per_epoch,
+            )
 
     def on_predict_step_end(self, state: State, unit: TPredictUnit) -> None:
         predict_state = none_throws(state.predict_state)
-        if self._predict_progress_bar is not None:
-            _update_progress_bar(
-                self._predict_progress_bar,
+        pbar = self._predict_progress_bar
+        if pbar is not None:
+            update_progress_bar(
+                pbar,
                 predict_state.progress.num_steps_completed_in_epoch,
                 self._refresh_rate,
             )
 
     def on_predict_epoch_end(self, state: State, unit: TPredictUnit) -> None:
         predict_state = none_throws(state.predict_state)
-        if self._predict_progress_bar is not None:
-            _close_progress_bar(
-                self._predict_progress_bar,
+        pbar = self._predict_progress_bar
+        if pbar is not None:
+            close_progress_bar(
+                pbar,
                 predict_state.progress.num_steps_completed_in_epoch,
                 self._refresh_rate,
             )
-
-
-def _create_progress_bar(
-    # pyre-ignore: Invalid type parameters [24]
-    dataloader: Iterable,
-    *,
-    desc: str,
-    num_epochs_completed: int,
-    num_steps_completed: int,
-    max_steps: Optional[int],
-    max_steps_per_epoch: Optional[int],
-) -> Optional[tqdm]:
-    if not get_global_rank() == 0:
-        return None
-
-    current_epoch = num_epochs_completed
-    total = _estimated_steps_in_epoch(
-        dataloader,
-        num_steps_completed=num_steps_completed,
-        max_steps=max_steps,
-        max_steps_per_epoch=max_steps_per_epoch,
-    )
-    return tqdm(
-        desc=f"{desc} {current_epoch}",
-        total=total,
-        initial=num_steps_completed,
-        bar_format="{l_bar}{bar}{r_bar}\n",
-    )
-
-
-def _update_progress_bar(
-    progress_bar: tqdm, num_steps_completed: int, refresh_rate: int
-) -> None:
-    if not get_global_rank() == 0:
-        return
-
-    if num_steps_completed % refresh_rate == 0:
-        progress_bar.update(refresh_rate)
-
-
-def _close_progress_bar(
-    progress_bar: tqdm, num_steps_completed: int, refresh_rate: int
-) -> None:
-    if not get_global_rank() == 0:
-        return
-
-    # complete remaining progress in bar
-    progress_bar.update(num_steps_completed % refresh_rate)
-    progress_bar.close()
-
-
-def _estimated_steps_in_epoch(
-    # pyre-ignore: Invalid type parameters [24]
-    dataloader: Iterable,
-    *,
-    num_steps_completed: int,
-    max_steps: Optional[int],
-    max_steps_per_epoch: Optional[int],
-) -> float:
-    """estimate number of steps in current epoch for tqdm"""
-
-    total = float("inf")
-    if isinstance(dataloader, Sized):
-        try:
-            total = len(dataloader)
-        except NotImplementedError:
-            pass
-
-    if max_steps_per_epoch and max_steps:
-        total = min(total, max_steps_per_epoch, max_steps - num_steps_completed)
-    elif max_steps:
-        total = min(total, max_steps - num_steps_completed)
-    elif max_steps_per_epoch:
-        total = min(total, max_steps_per_epoch)
-    return total

--- a/torchtnt/utils/__init__.py
+++ b/torchtnt/utils/__init__.py
@@ -47,6 +47,7 @@ from .rank_zero_log import (
     rank_zero_warn,
 )
 from .timer import FullSyncPeriodicTimer, get_timer_summary, Timer
+from .tqdm import close_progress_bar, create_progress_bar, update_progress_bar
 from .version import (
     get_python_version,
     get_torch_version,
@@ -104,6 +105,9 @@ __all__ = [
     "transfer_batch_norm_stats",
     "transfer_weights",
     "Timer",
+    "create_progress_bar",
+    "close_progress_bar",
+    "update_progress_bar",
     "TLRScheduler",
     "get_python_version",
     "get_torch_version",

--- a/torchtnt/utils/tqdm.py
+++ b/torchtnt/utils/tqdm.py
@@ -1,0 +1,53 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+import logging
+from typing import Iterable, Optional
+
+from torchtnt.utils.progress import estimated_steps_in_epoch
+from tqdm.auto import tqdm
+
+logger: logging.Logger = logging.getLogger(__name__)
+
+
+def create_progress_bar(
+    dataloader: Iterable[object],
+    *,
+    desc: str,
+    num_epochs_completed: int,
+    num_steps_completed: int,
+    max_steps: Optional[int],
+    max_steps_per_epoch: Optional[int],
+) -> tqdm:
+    current_epoch = num_epochs_completed
+    total = estimated_steps_in_epoch(
+        dataloader,
+        num_steps_completed=num_steps_completed,
+        max_steps=max_steps,
+        max_steps_per_epoch=max_steps_per_epoch,
+    )
+    return tqdm(
+        desc=f"{desc} {current_epoch}",
+        total=total,
+        initial=num_steps_completed,
+        bar_format="{l_bar}{bar}{r_bar}\n",
+    )
+
+
+def update_progress_bar(
+    progress_bar: tqdm, num_steps_completed: int, refresh_rate: int
+) -> None:
+    if num_steps_completed % refresh_rate == 0:
+        progress_bar.update(refresh_rate)
+
+
+def close_progress_bar(
+    progress_bar: tqdm, num_steps_completed: int, refresh_rate: int
+) -> None:
+    # complete remaining progress in bar
+    progress_bar.update(num_steps_completed % refresh_rate)
+    progress_bar.close()


### PR DESCRIPTION
Summary: Split out the private helpers inside the tqdm callback out into a separate utils file for users who want to build their own progress bar independent of the tnt framework's

Differential Revision: D46874851

