### PR TITLE
Consolidate meta callbacks and oss callbacks in docs

### DIFF
--- a/docs/source/framework/callbacks.rst
+++ b/docs/source/framework/callbacks.rst
@@ -30,3 +30,17 @@ We offer several pre-written callbacks which are ready to be used out of the box
     TorchSnapshotSaver
     TQDMProgressBar
     TrainProgressMonitor
+
+.. fbcode::
+
+   .. currentmodule:: torchtnt.meta.framework.callbacks
+
+   .. autosummary::
+      :nosignatures:
+      :toctree: generated/
+      :template: class_template.rst
+
+      BaseHiveWriter
+      ModelStoreCheckpointer
+      StuckJobDetector
+      ZoomerProfiler

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -82,15 +82,6 @@ Documentation
 
    .. toctree::
       :maxdepth: 2
-      :caption: Framework (Meta)
-      :glob:
-
-      meta/framework/callbacks
-
-.. fbcode::
-
-   .. toctree::
-      :maxdepth: 2
       :caption: Utils (Meta)
       :glob:
 


### PR DESCRIPTION
Summary: Instead of having two sections for callbacks in the docs, one for OSS and one for Meta we can combine these into one section for better discoverability of callbacks. The one downside of this change is it exposes some Meta-internal names to OSS.

Differential Revision: D46847563

