### PR TITLE
Document max_eval_steps_per_epoch

### DIFF
--- a/torchtnt/framework/fit.py
+++ b/torchtnt/framework/fit.py
@@ -49,7 +49,8 @@ def init_fit_state(
         eval_dataloader: dataloader to be used during evaluation, which can be *any* iterable, including PyTorch DataLoader, DataLoader2, etc.
         max_epochs: the max number of epochs to run for training. ``None`` means no limit (infinite training) unless stopped by max_steps.
         max_steps: the max number of steps to run for training. ``None`` means no limit (infinite training) unless stopped by max_epochs.
-        max_train_steps_per_epoch: the max number of steps to run per epoch for training. None means train until the dataloader is exhausted.
+        max_train_steps_per_epoch: the max number of steps to run per epoch for training. None means train until ``train_dataloader`` is exhausted.
+        max_eval_steps_per_epoch: the max number of steps to run per epoch for evaluation. None means evaluate until ``eval_dataloader`` is exhausted.
         evaluate_every_n_steps: how often to run the evaluation loop in terms of training steps.
         evaluate_every_n_epochs: how often to run the evaluation loop in terms of training epochs.
         auto_timing: whether to automatically time the training and evaluation loop, using the state's timer (enabling auto_timing may degrade performance).


### PR DESCRIPTION
Summary:
Noticed this doc was missing (just assuming it follows the same as max_train_steps_per_epoch)

Created from CodeHub with https://fburl.com/edit-in-codehub

Reviewed By: ananthsub

Differential Revision: D47168889

