### PR TITLE
In TorchSnapshotSaver set wait=True in on_train_end when taking an async snapshot

### DIFF
--- a/tests/framework/callbacks/test_torchsnapshot_saver.py
+++ b/tests/framework/callbacks/test_torchsnapshot_saver.py
@@ -240,11 +240,18 @@ class TorchSnapshotSaverTest(unittest.TestCase):
                 ValueError, "Invalid value passed for save_every_n_train_steps.*"
             ):
                 TorchSnapshotSaver(temp_dir, save_every_n_train_steps=-2)
-
+            with self.assertRaisesRegex(
+                ValueError, "Invalid value passed for save_every_n_train_steps.*"
+            ):
+                TorchSnapshotSaver(temp_dir, save_every_n_train_steps=0)
             with self.assertRaisesRegex(
                 ValueError, "Invalid value passed for save_every_n_epochs.*"
             ):
                 TorchSnapshotSaver(temp_dir, save_every_n_epochs=-2)
+            with self.assertRaisesRegex(
+                ValueError, "Invalid value passed for save_every_n_epochs.*"
+            ):
+                TorchSnapshotSaver(temp_dir, save_every_n_epochs=0)
 
 
 Batch = Tuple[torch.tensor, torch.tensor]

--- a/torchtnt/framework/callbacks/torchsnapshot_saver.py
+++ b/torchtnt/framework/callbacks/torchsnapshot_saver.py
@@ -75,13 +75,13 @@ class TorchSnapshotSaver(Callback):
         replicated: Optional[List[str]] = None,
     ) -> None:
         _validate_snapshot_available()
-        if save_every_n_train_steps is not None and save_every_n_train_steps < 0:
+        if save_every_n_train_steps is not None and save_every_n_train_steps <= 0:
             raise ValueError(
-                f"Invalid value passed for save_every_n_train_steps. Expected to receive either None or non-negative number, but received {save_every_n_train_steps}"
+                f"Invalid value passed for save_every_n_train_steps. Expected to receive either None or positive number, but received {save_every_n_train_steps}"
             )
-        if save_every_n_epochs is not None and save_every_n_epochs < 0:
+        if save_every_n_epochs is not None and save_every_n_epochs <= 0:
             raise ValueError(
-                f"Invalid value passed for save_every_n_epochs. Expected to receive either None or non-negative number, but received {save_every_n_epochs}"
+                f"Invalid value passed for save_every_n_epochs. Expected to receive either None or positive number, but received {save_every_n_epochs}"
             )
         self._save_every_n_epochs = save_every_n_epochs
         self._save_every_n_train_steps = save_every_n_train_steps

--- a/torchtnt/framework/callbacks/torchsnapshot_saver.py
+++ b/torchtnt/framework/callbacks/torchsnapshot_saver.py
@@ -155,7 +155,7 @@ class TorchSnapshotSaver(Callback):
         snapshot_path = _get_snapshot_save_path(
             self._dirpath, epoch, num_steps_completed
         )
-        self._async_snapshot(snapshot_path, app_state, wait=False)
+        self._async_snapshot(snapshot_path, app_state, wait=True)
         self._wait()
 
     def on_exception(


### PR DESCRIPTION
Summary: This will guarantee that we save a snapshot at the end of training - otherwise if there is some previous snapshot pending we will skip saving the last snapshot.

Differential Revision: D47270831

