### PR TITLE
Add wrapper for log audio to tensorboard logger

### DIFF
--- a/torchtnt/utils/loggers/tensorboard.py
+++ b/torchtnt/utils/loggers/tensorboard.py
@@ -160,6 +160,17 @@ class TensorBoardLogger(MetricLogger):
         if writer:
             writer.add_images(*args, **kwargs)
 
+    def log_audio(self, *args: Any, **kwargs: Any) -> None:
+        """Add audio data to TensorBoard.
+
+        Args:
+            *args (Any): Positional arguments passed to SummaryWriter.add_audio
+            **kwargs (Any): Keyword arguments passed to SummaryWriter.add_audio
+        """
+        writer = self._writer
+        if writer:
+            writer.add_audio(*args, **kwargs)
+
     def flush(self) -> None:
         """Writes pending logs to disk."""
 


### PR DESCRIPTION
Summary: Convenience function to add audio data to tensorboard. Following the same approach as what was done for images, forwarding args/kwargs to the summary writer if it's instantiated

Reviewed By: JKSenthil

Differential Revision: D47274243

