### PR TITLE
Add state_dict/load_state_dict support for MultiDataloader

### DIFF
--- a/torchtnt/framework/callbacks/torchsnapshot_saver.py
+++ b/torchtnt/framework/callbacks/torchsnapshot_saver.py
@@ -15,15 +15,11 @@ from torchsnapshot.snapshot import PendingSnapshot, Snapshot
 
 from torchtnt.framework.callback import Callback
 from torchtnt.framework.state import EntryPoint, State
-from torchtnt.framework.unit import (
-    _Stateful as StatefulProtocol,
-    AppStateMixin,
-    TEvalUnit,
-    TPredictUnit,
-    TTrainUnit,
-)
+from torchtnt.framework.unit import AppStateMixin, TEvalUnit, TPredictUnit, TTrainUnit
 from torchtnt.framework.utils import _construct_tracked_optimizers
-from torchtnt.utils import get_global_rank, rank_zero_info, rank_zero_warn
+from torchtnt.utils.distributed import get_global_rank
+from torchtnt.utils.rank_zero_log import rank_zero_info, rank_zero_warn
+from torchtnt.utils.stateful import Stateful
 
 try:
     import torchsnapshot
@@ -31,7 +27,7 @@ try:
     _TStateful = torchsnapshot.Stateful
     _TORCHSNAPSHOT_AVAILABLE = True
 except Exception:
-    _TStateful = StatefulProtocol
+    _TStateful = Stateful
     _TORCHSNAPSHOT_AVAILABLE = False
 
 _EVAL_PROGRESS_STATE_KEY = "eval_progress"

--- a/torchtnt/framework/unit.py
+++ b/torchtnt/framework/unit.py
@@ -14,21 +14,12 @@ from typing import Any, Dict, Generic, TypeVar
 import torch
 
 from torchtnt.framework.state import State
-from torchtnt.utils import TLRScheduler
-from typing_extensions import Protocol, runtime_checkable
+from torchtnt.utils.lr_scheduler import TLRScheduler
+from torchtnt.utils.stateful import Stateful
 
 """
 This file defines mixins and interfaces for users to customize hooks in training, evaluation, and prediction loops.
 """
-
-
-@runtime_checkable
-class _Stateful(Protocol):
-    def state_dict(self) -> Dict[str, Any]:
-        ...
-
-    def load_state_dict(self, state_dict: Dict[str, Any]) -> None:
-        ...
 
 
 def _remove_from_dicts(name_to_remove: str, *dicts: Dict[str, Any]) -> None:
@@ -131,7 +122,7 @@ class AppStateMixin:
                 value,
                 self.__dict__.get("_lr_schedulers"),
             )
-        elif isinstance(value, _Stateful):
+        elif isinstance(value, Stateful):
             self._update_attr(
                 name,
                 value,

--- a/torchtnt/utils/__init__.py
+++ b/torchtnt/utils/__init__.py
@@ -47,6 +47,7 @@ from .rank_zero_log import (
     rank_zero_print,
     rank_zero_warn,
 )
+from .stateful import Stateful
 from .timer import FullSyncPeriodicTimer, get_timer_summary, Timer
 from .tqdm import close_progress_bar, create_progress_bar, update_progress_bar
 from .version import (
@@ -105,6 +106,7 @@ __all__ = [
     "rank_zero_info",
     "rank_zero_print",
     "rank_zero_warn",
+    "Stateful",
     "FullSyncPeriodicTimer",
     "get_timer_summary",
     "transfer_batch_norm_stats",

--- a/torchtnt/utils/stateful.py
+++ b/torchtnt/utils/stateful.py
@@ -1,0 +1,20 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+from typing import Any, Dict
+
+from typing_extensions import Protocol, runtime_checkable
+
+
+@runtime_checkable
+class Stateful(Protocol):
+    """Defines the interface for checkpoint saving and loading."""
+
+    def state_dict(self) -> Dict[str, Any]:
+        ...
+
+    def load_state_dict(self, state_dict: Dict[str, Any]) -> None:
+        ...


### PR DESCRIPTION
Summary: As title - MultiDataloader now supports the stateful protocol for checkpoint saving/loading. The dataloader generates a state dict based on the names of `individual_dataloaders` and if the underlying dataloaders themselves are Stateful.

Differential Revision: D47409954

