### PR TITLE
Only run callback methods that implement something

### DIFF
--- a/tests/framework/test_callback_handler.py
+++ b/tests/framework/test_callback_handler.py
@@ -1,0 +1,216 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+import unittest
+from typing import Set, Union
+from unittest.mock import MagicMock
+
+from torchtnt.framework._callback_handler import CallbackHandler
+from torchtnt.framework.callback import Callback
+from torchtnt.framework.state import EntryPoint, State
+from torchtnt.framework.unit import TEvalUnit, TPredictUnit, TTrainUnit
+from torchtnt.utils.timer import Timer
+
+
+class DummyCallback(Callback):
+    def __init__(self) -> None:
+        self.called_hooks: Set[str] = set()
+
+    def on_exception(
+        self,
+        state: State,
+        unit: Union[TTrainUnit, TEvalUnit, TPredictUnit],
+        exc: BaseException,
+    ):
+        self.called_hooks.add("on_exception")
+
+    def on_train_start(self, state: State, unit: TTrainUnit) -> None:
+        self.called_hooks.add("on_train_start")
+
+    def on_train_epoch_start(self, state: State, unit: TTrainUnit) -> None:
+        self.called_hooks.add("on_train_epoch_start")
+
+    def on_train_step_start(self, state: State, unit: TTrainUnit) -> None:
+        self.called_hooks.add("on_train_step_start")
+
+    def on_train_step_end(self, state: State, unit: TTrainUnit) -> None:
+        self.called_hooks.add("on_train_step_end")
+
+    def on_train_epoch_end(self, state: State, unit: TTrainUnit) -> None:
+        self.called_hooks.add("on_train_epoch_end")
+
+    def on_train_end(self, state: State, unit: TTrainUnit) -> None:
+        self.called_hooks.add("on_train_end")
+
+    def on_eval_start(self, state: State, unit: TEvalUnit) -> None:
+        self.called_hooks.add("on_eval_start")
+
+    def on_eval_epoch_start(self, state: State, unit: TEvalUnit) -> None:
+        self.called_hooks.add("on_eval_epoch_start")
+
+    def on_eval_step_start(self, state: State, unit: TEvalUnit) -> None:
+        self.called_hooks.add("on_eval_step_start")
+
+    def on_eval_step_end(self, state: State, unit: TEvalUnit) -> None:
+        self.called_hooks.add("on_eval_step_end")
+
+    def on_eval_epoch_end(self, state: State, unit: TEvalUnit) -> None:
+        self.called_hooks.add("on_eval_epoch_end")
+
+    def on_eval_end(self, state: State, unit: TEvalUnit) -> None:
+        self.called_hooks.add("on_eval_end")
+
+    def on_predict_start(self, state: State, unit: TPredictUnit) -> None:
+        self.called_hooks.add("on_predict_start")
+
+    def on_predict_epoch_start(self, state: State, unit: TPredictUnit) -> None:
+        self.called_hooks.add("on_predict_epoch_start")
+
+    def on_predict_step_start(self, state: State, unit: TPredictUnit) -> None:
+        self.called_hooks.add("on_predict_step_start")
+
+    def on_predict_step_end(self, state: State, unit: TPredictUnit) -> None:
+        self.called_hooks.add("on_predict_step_end")
+
+    def on_predict_epoch_end(self, state: State, unit: TPredictUnit) -> None:
+        self.called_hooks.add("on_predict_epoch_end")
+
+    def on_predict_end(self, state: State, unit: TPredictUnit) -> None:
+        self.called_hooks.add("on_predict_end")
+
+
+class CallbackHandlerTest(unittest.TestCase):
+    def test_callback_handler(self) -> None:
+        """
+        Test CallbackHandler with all of the hooks on Callback
+        """
+        unit = MagicMock(spec=TTrainUnit)
+        timer = Timer()
+        state = State(
+            entry_point=EntryPoint.TRAIN,
+            timer=timer,
+            train_state=None,
+        )
+        callback = DummyCallback()
+        called_hooks = callback.called_hooks
+        cb_handler = CallbackHandler([callback])
+
+        cb_handler.on_exception(state, unit, ValueError("test"))
+        self.assertIn("on_exception", called_hooks)
+        self.assertIn("DummyCallback.on_exception", timer.recorded_durations.keys())
+
+        cb_handler.on_train_start(state, unit)
+        self.assertIn("on_train_start", called_hooks)
+        self.assertIn("DummyCallback.on_train_start", timer.recorded_durations.keys())
+
+        cb_handler.on_train_epoch_start(state, unit)
+        self.assertIn("on_train_epoch_start", called_hooks)
+        self.assertIn(
+            "DummyCallback.on_train_epoch_start", timer.recorded_durations.keys()
+        )
+
+        cb_handler.on_train_step_start(state, unit)
+        self.assertIn("on_train_step_start", called_hooks)
+        self.assertIn(
+            "DummyCallback.on_train_step_start", timer.recorded_durations.keys()
+        )
+
+        cb_handler.on_train_step_end(state, unit)
+        self.assertIn("on_train_step_end", called_hooks)
+        self.assertIn(
+            "DummyCallback.on_train_step_end", timer.recorded_durations.keys()
+        )
+
+        cb_handler.on_train_step_end(state, unit)
+        self.assertIn("on_train_step_end", called_hooks)
+        self.assertIn(
+            "DummyCallback.on_train_step_end", timer.recorded_durations.keys()
+        )
+
+        cb_handler.on_train_epoch_end(state, unit)
+        self.assertIn("on_train_epoch_end", called_hooks)
+        self.assertIn(
+            "DummyCallback.on_train_epoch_end", timer.recorded_durations.keys()
+        )
+
+        cb_handler.on_train_end(state, unit)
+        self.assertIn("on_train_end", called_hooks)
+        self.assertIn("DummyCallback.on_train_end", timer.recorded_durations.keys())
+
+        unit = MagicMock(spec=TEvalUnit)
+        cb_handler.on_eval_start(state, unit)
+        self.assertIn("on_eval_start", called_hooks)
+        self.assertIn("DummyCallback.on_eval_start", timer.recorded_durations.keys())
+
+        cb_handler.on_eval_epoch_start(state, unit)
+        self.assertIn("on_eval_epoch_start", called_hooks)
+        self.assertIn(
+            "DummyCallback.on_eval_epoch_start", timer.recorded_durations.keys()
+        )
+
+        cb_handler.on_eval_step_start(state, unit)
+        self.assertIn("on_eval_step_start", called_hooks)
+        self.assertIn(
+            "DummyCallback.on_eval_step_start", timer.recorded_durations.keys()
+        )
+
+        cb_handler.on_eval_step_end(state, unit)
+        self.assertIn("on_eval_step_end", called_hooks)
+        self.assertIn("DummyCallback.on_eval_step_end", timer.recorded_durations.keys())
+
+        cb_handler.on_eval_step_end(state, unit)
+        self.assertIn("on_eval_step_end", called_hooks)
+        self.assertIn("DummyCallback.on_eval_step_end", timer.recorded_durations.keys())
+
+        cb_handler.on_eval_epoch_end(state, unit)
+        self.assertIn("on_eval_epoch_end", called_hooks)
+        self.assertIn(
+            "DummyCallback.on_eval_epoch_end", timer.recorded_durations.keys()
+        )
+
+        cb_handler.on_eval_end(state, unit)
+        self.assertIn("on_eval_end", called_hooks)
+        self.assertIn("DummyCallback.on_eval_end", timer.recorded_durations.keys())
+
+        unit = MagicMock(spec=TPredictUnit)
+        cb_handler.on_predict_start(state, unit)
+        self.assertIn("on_predict_start", called_hooks)
+        self.assertIn("DummyCallback.on_predict_start", timer.recorded_durations.keys())
+
+        cb_handler.on_predict_epoch_start(state, unit)
+        self.assertIn("on_predict_epoch_start", called_hooks)
+        self.assertIn(
+            "DummyCallback.on_predict_epoch_start", timer.recorded_durations.keys()
+        )
+
+        cb_handler.on_predict_step_start(state, unit)
+        self.assertIn("on_predict_step_start", called_hooks)
+        self.assertIn(
+            "DummyCallback.on_predict_step_start", timer.recorded_durations.keys()
+        )
+
+        cb_handler.on_predict_step_end(state, unit)
+        self.assertIn("on_predict_step_end", called_hooks)
+        self.assertIn(
+            "DummyCallback.on_predict_step_end", timer.recorded_durations.keys()
+        )
+
+        cb_handler.on_predict_step_end(state, unit)
+        self.assertIn("on_predict_step_end", called_hooks)
+        self.assertIn(
+            "DummyCallback.on_predict_step_end", timer.recorded_durations.keys()
+        )
+
+        cb_handler.on_predict_epoch_end(state, unit)
+        self.assertIn("on_predict_epoch_end", called_hooks)
+        self.assertIn(
+            "DummyCallback.on_predict_epoch_end", timer.recorded_durations.keys()
+        )
+
+        cb_handler.on_predict_end(state, unit)
+        self.assertIn("on_predict_end", called_hooks)
+        self.assertIn("DummyCallback.on_predict_end", timer.recorded_durations.keys())

--- a/tests/framework/test_train.py
+++ b/tests/framework/test_train.py
@@ -13,6 +13,7 @@ import torch
 from torch import nn
 
 from torchtnt.framework._test_utils import DummyTrainUnit, generate_random_dataloader
+from torchtnt.framework.callback import Callback
 from torchtnt.framework.state import EntryPoint, State
 from torchtnt.framework.train import init_train_state, train
 from torchtnt.framework.unit import TrainUnit
@@ -135,7 +136,7 @@ class TrainTest(unittest.TestCase):
             max_steps_per_epoch=max_steps_per_epoch,
         )
 
-        callback_mock = MagicMock()
+        callback_mock = MagicMock(spec=Callback)
         train(state, my_unit, callbacks=[callback_mock])
         self.assertEqual(callback_mock.on_train_start.call_count, 1)
         self.assertEqual(callback_mock.on_train_epoch_start.call_count, max_epochs)

--- a/tests/framework/test_utils.py
+++ b/tests/framework/test_utils.py
@@ -19,7 +19,6 @@ from torchtnt.utils.version import is_torch_version_geq_2_0
 if is_torch_version_geq_2_0():
     from torch.distributed._composable import fully_shard
 
-
 from torch.distributed import launcher
 from torch.distributed.fsdp import FullyShardedDataParallel as FSDP
 from torch.optim.lr_scheduler import ExponentialLR

--- a/torchtnt/framework/_callback_handler.py
+++ b/torchtnt/framework/_callback_handler.py
@@ -1,0 +1,159 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+from typing import List, Union
+
+from torchtnt.framework.callback import Callback
+from torchtnt.framework.state import State
+from torchtnt.framework.unit import TEvalUnit, TPredictUnit, TTrainUnit
+from torchtnt.framework.utils import _get_timing_context
+
+
+class CallbackHandler:
+    """
+    A helper class to run and time callbacks in TorchTNT.
+    """
+
+    def __init__(self, callbacks: List[Callback]) -> None:
+        self._callbacks = callbacks
+
+    def on_exception(
+        self,
+        state: State,
+        unit: Union[TTrainUnit, TEvalUnit, TPredictUnit],
+        exc: BaseException,
+    ) -> None:
+        fn_name = "on_exception"
+        callbacks = self._callbacks
+        for cb in callbacks:
+            with _get_timing_context(state, f"{cb.name}.{fn_name}"):
+                cb.on_exception(state, unit, exc)
+
+    def on_train_start(self, state: State, unit: TTrainUnit) -> None:
+        fn_name = "on_train_start"
+        callbacks = self._callbacks
+        for cb in callbacks:
+            with _get_timing_context(state, f"{cb.name}.{fn_name}"):
+                cb.on_train_start(state, unit)
+
+    def on_train_epoch_start(self, state: State, unit: TTrainUnit) -> None:
+        fn_name = "on_train_epoch_start"
+        callbacks = self._callbacks
+        for cb in callbacks:
+            with _get_timing_context(state, f"{cb.name}.{fn_name}"):
+                cb.on_train_epoch_start(state, unit)
+
+    def on_train_step_start(self, state: State, unit: TTrainUnit) -> None:
+        fn_name = "on_train_step_start"
+        callbacks = self._callbacks
+        for cb in callbacks:
+            with _get_timing_context(state, f"{cb.name}.{fn_name}"):
+                cb.on_train_step_start(state, unit)
+
+    def on_train_step_end(self, state: State, unit: TTrainUnit) -> None:
+        fn_name = "on_train_step_end"
+        callbacks = self._callbacks
+        for cb in callbacks:
+            with _get_timing_context(state, f"{cb.name}.{fn_name}"):
+                cb.on_train_step_end(state, unit)
+
+    def on_train_epoch_end(self, state: State, unit: TTrainUnit) -> None:
+        fn_name = "on_train_epoch_end"
+        callbacks = self._callbacks
+        for cb in callbacks:
+            with _get_timing_context(state, f"{cb.name}.{fn_name}"):
+                cb.on_train_epoch_end(state, unit)
+
+    def on_train_end(self, state: State, unit: TTrainUnit) -> None:
+        fn_name = "on_train_end"
+        callbacks = self._callbacks
+        for cb in callbacks:
+            with _get_timing_context(state, f"{cb.name}.{fn_name}"):
+                cb.on_train_end(state, unit)
+
+    def on_eval_start(self, state: State, unit: TEvalUnit) -> None:
+        fn_name = "on_eval_start"
+        callbacks = self._callbacks
+        for cb in callbacks:
+            with _get_timing_context(state, f"{cb.name}.{fn_name}"):
+                cb.on_eval_start(state, unit)
+
+    def on_eval_epoch_start(self, state: State, unit: TEvalUnit) -> None:
+        fn_name = "on_eval_epoch_start"
+        callbacks = self._callbacks
+        for cb in callbacks:
+            with _get_timing_context(state, f"{cb.name}.{fn_name}"):
+                cb.on_eval_epoch_start(state, unit)
+
+    def on_eval_step_start(self, state: State, unit: TEvalUnit) -> None:
+        fn_name = "on_eval_step_start"
+        callbacks = self._callbacks
+        for cb in callbacks:
+            with _get_timing_context(state, f"{cb.name}.{fn_name}"):
+                cb.on_eval_step_start(state, unit)
+
+    def on_eval_step_end(self, state: State, unit: TEvalUnit) -> None:
+        fn_name = "on_eval_step_end"
+        callbacks = self._callbacks
+        for cb in callbacks:
+            with _get_timing_context(state, f"{cb.name}.{fn_name}"):
+                cb.on_eval_step_end(state, unit)
+
+    def on_eval_epoch_end(self, state: State, unit: TEvalUnit) -> None:
+        fn_name = "on_eval_epoch_end"
+        callbacks = self._callbacks
+        for cb in callbacks:
+            with _get_timing_context(state, f"{cb.name}.{fn_name}"):
+                cb.on_eval_epoch_end(state, unit)
+
+    def on_eval_end(self, state: State, unit: TEvalUnit) -> None:
+        fn_name = "on_eval_end"
+        callbacks = self._callbacks
+        for cb in callbacks:
+            with _get_timing_context(state, f"{cb.name}.{fn_name}"):
+                cb.on_eval_end(state, unit)
+
+    def on_predict_start(self, state: State, unit: TPredictUnit) -> None:
+        fn_name = "on_predict_start"
+        callbacks = self._callbacks
+        for cb in callbacks:
+            with _get_timing_context(state, f"{cb.name}.{fn_name}"):
+                cb.on_predict_start(state, unit)
+
+    def on_predict_epoch_start(self, state: State, unit: TPredictUnit) -> None:
+        fn_name = "on_predict_epoch_start"
+        callbacks = self._callbacks
+        for cb in callbacks:
+            with _get_timing_context(state, f"{cb.name}.{fn_name}"):
+                cb.on_predict_epoch_start(state, unit)
+
+    def on_predict_step_start(self, state: State, unit: TPredictUnit) -> None:
+        fn_name = "on_predict_step_start"
+        callbacks = self._callbacks
+        for cb in callbacks:
+            with _get_timing_context(state, f"{cb.name}.{fn_name}"):
+                cb.on_predict_step_start(state, unit)
+
+    def on_predict_step_end(self, state: State, unit: TPredictUnit) -> None:
+        fn_name = "on_predict_step_end"
+        callbacks = self._callbacks
+        for cb in callbacks:
+            with _get_timing_context(state, f"{cb.name}.{fn_name}"):
+                cb.on_predict_step_end(state, unit)
+
+    def on_predict_epoch_end(self, state: State, unit: TPredictUnit) -> None:
+        fn_name = "on_predict_epoch_end"
+        callbacks = self._callbacks
+        for cb in callbacks:
+            with _get_timing_context(state, f"{cb.name}.{fn_name}"):
+                cb.on_predict_epoch_end(state, unit)
+
+    def on_predict_end(self, state: State, unit: TPredictUnit) -> None:
+        fn_name = "on_predict_end"
+        callbacks = self._callbacks
+        for cb in callbacks:
+            with _get_timing_context(state, f"{cb.name}.{fn_name}"):
+                cb.on_predict_end(state, unit)

--- a/torchtnt/framework/_callback_handler.py
+++ b/torchtnt/framework/_callback_handler.py
@@ -4,12 +4,90 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
-from typing import List, Union
+import logging
+from functools import partial
+from typing import Dict, List, Type, Union
+from unittest.mock import Mock
 
 from torchtnt.framework.callback import Callback
 from torchtnt.framework.state import State
 from torchtnt.framework.unit import TEvalUnit, TPredictUnit, TTrainUnit
 from torchtnt.framework.utils import _get_timing_context
+
+logger: logging.Logger = logging.getLogger(__name__)
+
+
+def _has_method_override(
+    method_name: str, instance: object, base_class: Type[object]
+) -> bool:
+    """
+    Checks if a class instance overrides a specific method from a particular base class.
+    """
+
+    if isinstance(instance, Mock):
+        # Special case Mocks for testing purposes
+        return True
+
+    instance_method = getattr(instance, method_name, None)
+    if instance_method is None:
+        return False
+    base_method = getattr(base_class, method_name, None)
+    # for functools wraps
+    if hasattr(instance_method, "__wrapped__"):
+        instance_method = instance_method.__wrapped__
+    if isinstance(instance_method, partial):
+        instance_method = instance_method.func
+    if instance_method is None:
+        return False
+
+    return instance_method.__code__ != base_method.__code__
+
+
+def _get_implemented_callback_mapping(
+    callbacks: List[Callback],
+) -> Dict[str, List[Callback]]:
+    """
+    Processes a list of callbacks and returns a dictionary mapping each hook
+    to a list of Callback classes that implement that method.
+
+    Since the base Callback class is a no-op for each of these methods, if the code is different between
+    the callback instance passed in and the base class, there is logic to run.
+
+    This upfront processing is useful to avoid timing and profiling overheads, especially those done each step
+    in the corresponding training, evaluation or prediction loop.
+
+    Within each hook, the original ordering from the Callback list is preserved.
+    """
+    callback_hooks = (
+        "on_exception",
+        "on_train_start",
+        "on_train_epoch_start",
+        "on_train_step_start",
+        "on_train_step_end",
+        "on_train_epoch_end",
+        "on_train_end",
+        "on_eval_start",
+        "on_eval_epoch_start",
+        "on_eval_step_start",
+        "on_eval_step_end",
+        "on_eval_epoch_end",
+        "on_eval_end",
+        "on_predict_start",
+        "on_predict_epoch_start",
+        "on_predict_step_start",
+        "on_predict_step_end",
+        "on_predict_epoch_end",
+        "on_predict_end",
+    )
+    cb_overrides: Dict[str, List[Callback]] = {}
+    for hook in callback_hooks:
+        for cb in callbacks:
+            if _has_method_override(hook, cb, Callback):
+                if hook not in cb_overrides:
+                    cb_overrides[hook] = [cb]
+                else:
+                    cb_overrides[hook].append(cb)
+    return cb_overrides
 
 
 class CallbackHandler:
@@ -18,7 +96,9 @@ class CallbackHandler:
     """
 
     def __init__(self, callbacks: List[Callback]) -> None:
-        self._callbacks = callbacks
+        self._callbacks: Dict[str, List[Callback]] = _get_implemented_callback_mapping(
+            callbacks
+        )
 
     def on_exception(
         self,
@@ -27,133 +107,133 @@ class CallbackHandler:
         exc: BaseException,
     ) -> None:
         fn_name = "on_exception"
-        callbacks = self._callbacks
+        callbacks = self._callbacks.get(fn_name, [])
         for cb in callbacks:
             with _get_timing_context(state, f"{cb.name}.{fn_name}"):
                 cb.on_exception(state, unit, exc)
 
     def on_train_start(self, state: State, unit: TTrainUnit) -> None:
         fn_name = "on_train_start"
-        callbacks = self._callbacks
+        callbacks = self._callbacks.get(fn_name, [])
         for cb in callbacks:
             with _get_timing_context(state, f"{cb.name}.{fn_name}"):
                 cb.on_train_start(state, unit)
 
     def on_train_epoch_start(self, state: State, unit: TTrainUnit) -> None:
         fn_name = "on_train_epoch_start"
-        callbacks = self._callbacks
+        callbacks = self._callbacks.get(fn_name, [])
         for cb in callbacks:
             with _get_timing_context(state, f"{cb.name}.{fn_name}"):
                 cb.on_train_epoch_start(state, unit)
 
     def on_train_step_start(self, state: State, unit: TTrainUnit) -> None:
         fn_name = "on_train_step_start"
-        callbacks = self._callbacks
+        callbacks = self._callbacks.get(fn_name, [])
         for cb in callbacks:
             with _get_timing_context(state, f"{cb.name}.{fn_name}"):
                 cb.on_train_step_start(state, unit)
 
     def on_train_step_end(self, state: State, unit: TTrainUnit) -> None:
         fn_name = "on_train_step_end"
-        callbacks = self._callbacks
+        callbacks = self._callbacks.get(fn_name, [])
         for cb in callbacks:
             with _get_timing_context(state, f"{cb.name}.{fn_name}"):
                 cb.on_train_step_end(state, unit)
 
     def on_train_epoch_end(self, state: State, unit: TTrainUnit) -> None:
         fn_name = "on_train_epoch_end"
-        callbacks = self._callbacks
+        callbacks = self._callbacks.get(fn_name, [])
         for cb in callbacks:
             with _get_timing_context(state, f"{cb.name}.{fn_name}"):
                 cb.on_train_epoch_end(state, unit)
 
     def on_train_end(self, state: State, unit: TTrainUnit) -> None:
         fn_name = "on_train_end"
-        callbacks = self._callbacks
+        callbacks = self._callbacks.get(fn_name, [])
         for cb in callbacks:
             with _get_timing_context(state, f"{cb.name}.{fn_name}"):
                 cb.on_train_end(state, unit)
 
     def on_eval_start(self, state: State, unit: TEvalUnit) -> None:
         fn_name = "on_eval_start"
-        callbacks = self._callbacks
+        callbacks = self._callbacks.get(fn_name, [])
         for cb in callbacks:
             with _get_timing_context(state, f"{cb.name}.{fn_name}"):
                 cb.on_eval_start(state, unit)
 
     def on_eval_epoch_start(self, state: State, unit: TEvalUnit) -> None:
         fn_name = "on_eval_epoch_start"
-        callbacks = self._callbacks
+        callbacks = self._callbacks.get(fn_name, [])
         for cb in callbacks:
             with _get_timing_context(state, f"{cb.name}.{fn_name}"):
                 cb.on_eval_epoch_start(state, unit)
 
     def on_eval_step_start(self, state: State, unit: TEvalUnit) -> None:
         fn_name = "on_eval_step_start"
-        callbacks = self._callbacks
+        callbacks = self._callbacks.get(fn_name, [])
         for cb in callbacks:
             with _get_timing_context(state, f"{cb.name}.{fn_name}"):
                 cb.on_eval_step_start(state, unit)
 
     def on_eval_step_end(self, state: State, unit: TEvalUnit) -> None:
         fn_name = "on_eval_step_end"
-        callbacks = self._callbacks
+        callbacks = self._callbacks.get(fn_name, [])
         for cb in callbacks:
             with _get_timing_context(state, f"{cb.name}.{fn_name}"):
                 cb.on_eval_step_end(state, unit)
 
     def on_eval_epoch_end(self, state: State, unit: TEvalUnit) -> None:
         fn_name = "on_eval_epoch_end"
-        callbacks = self._callbacks
+        callbacks = self._callbacks.get(fn_name, [])
         for cb in callbacks:
             with _get_timing_context(state, f"{cb.name}.{fn_name}"):
                 cb.on_eval_epoch_end(state, unit)
 
     def on_eval_end(self, state: State, unit: TEvalUnit) -> None:
         fn_name = "on_eval_end"
-        callbacks = self._callbacks
+        callbacks = self._callbacks.get(fn_name, [])
         for cb in callbacks:
             with _get_timing_context(state, f"{cb.name}.{fn_name}"):
                 cb.on_eval_end(state, unit)
 
     def on_predict_start(self, state: State, unit: TPredictUnit) -> None:
         fn_name = "on_predict_start"
-        callbacks = self._callbacks
+        callbacks = self._callbacks.get(fn_name, [])
         for cb in callbacks:
             with _get_timing_context(state, f"{cb.name}.{fn_name}"):
                 cb.on_predict_start(state, unit)
 
     def on_predict_epoch_start(self, state: State, unit: TPredictUnit) -> None:
         fn_name = "on_predict_epoch_start"
-        callbacks = self._callbacks
+        callbacks = self._callbacks.get(fn_name, [])
         for cb in callbacks:
             with _get_timing_context(state, f"{cb.name}.{fn_name}"):
                 cb.on_predict_epoch_start(state, unit)
 
     def on_predict_step_start(self, state: State, unit: TPredictUnit) -> None:
         fn_name = "on_predict_step_start"
-        callbacks = self._callbacks
+        callbacks = self._callbacks.get(fn_name, [])
         for cb in callbacks:
             with _get_timing_context(state, f"{cb.name}.{fn_name}"):
                 cb.on_predict_step_start(state, unit)
 
     def on_predict_step_end(self, state: State, unit: TPredictUnit) -> None:
         fn_name = "on_predict_step_end"
-        callbacks = self._callbacks
+        callbacks = self._callbacks.get(fn_name, [])
         for cb in callbacks:
             with _get_timing_context(state, f"{cb.name}.{fn_name}"):
                 cb.on_predict_step_end(state, unit)
 
     def on_predict_epoch_end(self, state: State, unit: TPredictUnit) -> None:
         fn_name = "on_predict_epoch_end"
-        callbacks = self._callbacks
+        callbacks = self._callbacks.get(fn_name, [])
         for cb in callbacks:
             with _get_timing_context(state, f"{cb.name}.{fn_name}"):
                 cb.on_predict_epoch_end(state, unit)
 
     def on_predict_end(self, state: State, unit: TPredictUnit) -> None:
         fn_name = "on_predict_end"
-        callbacks = self._callbacks
+        callbacks = self._callbacks.get(fn_name, [])
         for cb in callbacks:
             with _get_timing_context(state, f"{cb.name}.{fn_name}"):
                 cb.on_predict_end(state, unit)

--- a/torchtnt/framework/utils.py
+++ b/torchtnt/framework/utils.py
@@ -27,7 +27,6 @@ if is_torch_version_geq_2_0():
 
 
 from pyre_extensions import none_throws
-from torchtnt.framework.callback import Callback
 from torchtnt.framework.state import ActivePhase, EntryPoint, State
 from torchtnt.framework.unit import AppStateMixin
 from torchtnt.utils.lr_scheduler import TLRScheduler
@@ -104,21 +103,6 @@ def _get_timing_context(state: State, event_name: str, skip_timer: bool = False)
     profiler_context = record_function(event_name)
     with timer_context, profiler_context:
         yield (timer_context, profiler_context)
-
-
-def _run_callback_fn(
-    callbacks: List[Callback],
-    fn_name: str,
-    state: State,
-    *args: Any,
-    **kwargs: Any,
-) -> None:
-    for cb in callbacks:
-        fn = getattr(cb, fn_name)
-        if not callable(fn):
-            raise ValueError(f"Invalid callback method name provided: {fn_name}")
-        with _get_timing_context(state, f"{cb.name}.{fn_name}"):
-            fn(state, *args, **kwargs)
 
 
 def log_api_usage(entry_point: str) -> None:

--- a/torchtnt/framework/utils.py
+++ b/torchtnt/framework/utils.py
@@ -25,12 +25,12 @@ if is_torch_version_geq_2_0():
     from torch.distributed._composable_state import _get_module_state
     from torch.distributed.fsdp._common_utils import _FSDPState
 
-
 from pyre_extensions import none_throws
 from torchtnt.framework.state import ActivePhase, EntryPoint, State
 from torchtnt.framework.unit import AppStateMixin
 from torchtnt.utils.lr_scheduler import TLRScheduler
 from torchtnt.utils.progress import Progress
+
 
 _logger: logging.Logger = logging.getLogger(__name__)
 


### PR DESCRIPTION
Summary: Only run callback methods if they override the base class. This aims to benefit timing/profiling summaries. Right now, the loops run O(|callbacks| * |num hooks|), even if what's implemented is much sparser than that. This can add extra overhead with timing/profiler contexts.

Reviewed By: daniellepintz

Differential Revision: D46713221

