### PR TITLE
Breaking Change - Remove `state` from TorchSnapshotSaver.restore

### DIFF
--- a/examples/mnist/main.py
+++ b/examples/mnist/main.py
@@ -106,12 +106,6 @@ class MyUnit(AutoUnit[Batch]):
     def on_eval_step_end(
         self, state: State, data: Batch, step: int, loss: torch.Tensor, outputs: Any
     ) -> None:
-        # step_count = state.eval_state.progress.num_steps_completed
-        # data = copy_data_to_device(data, self.device)
-        # inputs, targets = data
-
-        # outputs = self.module(inputs)
-        # loss = torch.nn.functional.nll_loss(outputs, targets)
         if step % self.log_every_n_steps == 0:
             self.tb_logger.log("evaluation loss", loss, step)
 

--- a/examples/torchdata_train_example.py
+++ b/examples/torchdata_train_example.py
@@ -115,7 +115,7 @@ class MyTrainUnit(TrainUnit[Batch]):
 
         # update metrics & logs
         self.train_accuracy.update(outputs, targets)
-        step_count = state.train_state.progress.num_steps_completed
+        step_count = self.train_progress.num_steps_completed
         if (step_count + 1) % self.log_every_n_steps == 0:
             accuracy = self.train_accuracy.compute()
             self.tb_logger.log("loss", loss, step_count)
@@ -123,7 +123,7 @@ class MyTrainUnit(TrainUnit[Batch]):
 
     def on_train_epoch_end(self, state: State) -> None:
         # compute and log the metrics at the end of epoch
-        step_count = state.train_state.progress.num_steps_completed
+        step_count = self.train_progress.num_steps_completed
         accuracy = self.train_accuracy.compute()
         self.tb_logger.log("accuracy_epoch", accuracy, step_count)
 

--- a/examples/torchrec/main.py
+++ b/examples/torchrec/main.py
@@ -42,7 +42,6 @@ from torchrec.optim.optimizers import in_backward_optimizer_filter
 
 from torchtnt.framework import EvalUnit, fit, init_fit_state, State, TrainUnit
 from torchtnt.framework.callbacks import TQDMProgressBar
-from torchtnt.framework.utils import get_current_progress
 from torchtnt.utils import (
     get_process_group_backend_from_device,
     init_from_env,
@@ -202,7 +201,7 @@ class MyUnit(TrainUnit[Batch], EvalUnit[Batch]):
         self.log_every_n_steps = log_every_n_steps
 
     def train_step(self, state: State, data: Iterator[Batch]) -> None:
-        step = get_current_progress(state).num_steps_completed
+        step = self.train_progress.num_steps_completed
         loss, logits, labels = self.pipeline.progress(data)
         preds = torch.sigmoid(logits)
         self.train_auroc.update(preds, labels)
@@ -217,7 +216,7 @@ class MyUnit(TrainUnit[Batch], EvalUnit[Batch]):
         self.train_auroc.reset()
 
     def eval_step(self, state: State, data: Iterator[Batch]) -> None:
-        step = get_current_progress(state).num_steps_completed
+        step = self.eval_progress.num_steps_completed
         loss, _, _ = self.pipeline.progress(data)
         if step % self.log_every_n_steps == 0:
             self.tb_logger.log("evaluation_loss", loss, step)

--- a/examples/train_unit_example.py
+++ b/examples/train_unit_example.py
@@ -93,7 +93,7 @@ class MyTrainUnit(TrainUnit[Batch]):
 
         # update metrics & logs
         self.train_accuracy.update(outputs, targets)
-        step_count = state.train_state.progress.num_steps_completed
+        step_count = self.train_progress.num_steps_completed
         if (step_count + 1) % self.log_every_n_steps == 0:
             acc = self.train_accuracy.compute()
             self.tb_logger.log("loss", loss, step_count)
@@ -101,7 +101,7 @@ class MyTrainUnit(TrainUnit[Batch]):
 
     def on_train_epoch_end(self, state: State) -> None:
         # compute and log the metric at the end of the epoch
-        step_count = state.train_state.progress.num_steps_completed
+        step_count = self.train_progress.num_steps_completed
         acc = self.train_accuracy.compute()
         self.tb_logger.log("accuracy_epoch", acc, step_count)
 

--- a/tests/framework/callbacks/test_csv_writer.py
+++ b/tests/framework/callbacks/test_csv_writer.py
@@ -8,7 +8,6 @@
 import tempfile
 import unittest
 from typing import Any, List, Union
-from unittest.mock import MagicMock
 
 from torchtnt.framework._test_utils import DummyPredictUnit, generate_random_dataloader
 from torchtnt.framework.callbacks.base_csv_writer import BaseCSVWriter
@@ -49,7 +48,7 @@ class BaseCSVWriterTest(unittest.TestCase):
         dataset_len = 10
         batch_size = 2
 
-        my_unit = MagicMock(spec=DummyPredictUnit)
+        my_unit = DummyPredictUnit(2)
         dataloader = generate_random_dataloader(dataset_len, input_dim, batch_size)
         state = init_predict_state(dataloader=dataloader)
 
@@ -73,7 +72,7 @@ class BaseCSVWriterTest(unittest.TestCase):
         dataset_len = 10
         batch_size = 2
 
-        my_unit = MagicMock(spec=DummyPredictUnit)
+        my_unit = DummyPredictUnit(2)
         dataloader = generate_random_dataloader(dataset_len, input_dim, batch_size)
         state = init_predict_state(dataloader=dataloader)
 
@@ -96,7 +95,7 @@ class BaseCSVWriterTest(unittest.TestCase):
         dataset_len = 10
         batch_size = 2
 
-        my_unit = MagicMock(spec=DummyPredictUnit)
+        my_unit = DummyPredictUnit(2)
         dataloader = generate_random_dataloader(dataset_len, input_dim, batch_size)
         state = init_predict_state(dataloader=dataloader)
 

--- a/tests/framework/callbacks/test_garbage_collector.py
+++ b/tests/framework/callbacks/test_garbage_collector.py
@@ -35,7 +35,7 @@ class GarbageCollectorTest(unittest.TestCase):
         max_epochs = 2
         expected_num_total_steps = dataset_len / batch_size * max_epochs
 
-        my_unit = MagicMock(spec=DummyTrainUnit)
+        my_unit = DummyTrainUnit(2)
         gc_callback_mock = MagicMock(spec=GarbageCollector)
 
         dataloader = generate_random_dataloader(dataset_len, input_dim, batch_size)
@@ -57,7 +57,7 @@ class GarbageCollectorTest(unittest.TestCase):
         batch_size = 2
         max_epochs = 2
 
-        my_unit = MagicMock(spec=DummyTrainUnit)
+        my_unit = DummyTrainUnit(2)
         gc_callback = GarbageCollector(2)
 
         dataloader = generate_random_dataloader(dataset_len, input_dim, batch_size)
@@ -76,7 +76,7 @@ class GarbageCollectorTest(unittest.TestCase):
         batch_size = 2
         expected_num_total_steps = dataset_len / batch_size
 
-        my_unit = MagicMock(spec=DummyEvalUnit)
+        my_unit = DummyEvalUnit(2)
         gc_callback_mock = MagicMock(spec=GarbageCollector)
 
         dataloader = generate_random_dataloader(dataset_len, input_dim, batch_size)
@@ -97,7 +97,7 @@ class GarbageCollectorTest(unittest.TestCase):
         dataset_len = 10
         batch_size = 2
 
-        my_unit = MagicMock(spec=DummyEvalUnit)
+        my_unit = DummyEvalUnit(2)
         gc_callback = GarbageCollector(2)
 
         dataloader = generate_random_dataloader(dataset_len, input_dim, batch_size)
@@ -116,7 +116,7 @@ class GarbageCollectorTest(unittest.TestCase):
         batch_size = 2
         expected_num_total_steps = dataset_len / batch_size
 
-        my_unit = MagicMock(spec=DummyPredictUnit)
+        my_unit = DummyPredictUnit(2)
         gc_callback_mock = MagicMock(spec=GarbageCollector)
 
         dataloader = generate_random_dataloader(dataset_len, input_dim, batch_size)
@@ -137,7 +137,7 @@ class GarbageCollectorTest(unittest.TestCase):
         dataset_len = 10
         batch_size = 2
 
-        my_unit = MagicMock(spec=DummyPredictUnit)
+        my_unit = DummyPredictUnit(2)
         gc_callback = GarbageCollector(2)
 
         dataloader = generate_random_dataloader(dataset_len, input_dim, batch_size)
@@ -163,7 +163,7 @@ class GarbageCollectorTest(unittest.TestCase):
         )
         gc_step_interval = 4
 
-        my_unit = MagicMock(spec=DummyFitUnit)
+        my_unit = DummyFitUnit(2)
         gc_callback = GarbageCollector(gc_step_interval)
 
         train_dataloader = generate_random_dataloader(
@@ -201,7 +201,7 @@ class GarbageCollectorTest(unittest.TestCase):
         max_epochs = 2
         evaluate_every_n_epochs = 1
 
-        my_unit = MagicMock(spec=DummyFitUnit)
+        my_unit = DummyFitUnit(2)
         gc_callback = GarbageCollector(2)
 
         train_dataloader = generate_random_dataloader(

--- a/tests/framework/callbacks/test_pytorch_profiler.py
+++ b/tests/framework/callbacks/test_pytorch_profiler.py
@@ -32,7 +32,7 @@ class PyTorchProfilerTest(unittest.TestCase):
         max_epochs = 2
         expected_num_total_steps = dataset_len / batch_size * max_epochs
 
-        my_unit = MagicMock(spec=DummyTrainUnit)
+        my_unit = DummyTrainUnit(input_dim)
         profiler_mock = MagicMock(spec=torch.profiler.profile)
 
         profiler = PyTorchProfiler(profiler=profiler_mock)
@@ -53,7 +53,7 @@ class PyTorchProfilerTest(unittest.TestCase):
         batch_size = 2
         expected_num_total_steps = dataset_len / batch_size
 
-        my_unit = MagicMock(spec=DummyEvalUnit)
+        my_unit = DummyEvalUnit(2)
         profiler_mock = MagicMock(spec=torch.profiler.profile)
 
         profiler = PyTorchProfiler(profiler=profiler_mock)
@@ -75,7 +75,7 @@ class PyTorchProfilerTest(unittest.TestCase):
         batch_size = 2
         expected_num_total_steps = dataset_len / batch_size
 
-        my_unit = MagicMock(spec=DummyPredictUnit)
+        my_unit = DummyPredictUnit(2)
         profiler_mock = MagicMock(spec=torch.profiler.profile)
 
         profiler = PyTorchProfiler(profiler=profiler_mock)

--- a/tests/framework/callbacks/test_torchsnapshot_saver.py
+++ b/tests/framework/callbacks/test_torchsnapshot_saver.py
@@ -124,7 +124,7 @@ class TorchSnapshotSaverTest(unittest.TestCase):
 
             end_num_steps_completed = my_unit.train_progress.num_steps_completed
             self.assertGreater(len(expected_paths), 0)
-            snapshot_cb.restore(expected_paths[0], state, my_unit)
+            snapshot_cb.restore(expected_paths[0], my_unit)
             restored_num_steps_completed = my_unit.train_progress.num_steps_completed
             # A snapshot is saved every n steps
             # so the first snapshot's progress will be equal to save_every_n_train_steps
@@ -165,7 +165,7 @@ class TorchSnapshotSaverTest(unittest.TestCase):
             end_num_steps_completed = my_unit.train_progress.num_steps_completed
             self.assertGreater(len(expected_paths), 0)
             snapshot_cb.restore(
-                expected_paths[0], state, my_unit, restore_train_progress=False
+                expected_paths[0], my_unit, restore_train_progress=False
             )
             restored_num_steps_completed = my_unit.train_progress.num_steps_completed
             # no train progress was restored so the progress after restoration should be the same as the progress before restoration
@@ -264,7 +264,7 @@ class TorchSnapshotSaverTest(unittest.TestCase):
             )
             # get latest checkpoint
             ckpt_path = os.path.join(temp_dir, f"epoch_{max_epochs}_step_10")
-            snapshot_cb.restore(ckpt_path, state, my_new_unit)
+            snapshot_cb.restore(ckpt_path, my_new_unit)
             tc.assertEqual(
                 my_new_unit.optimizer.state_dict(), my_unit.optimizer.state_dict()
             )

--- a/tests/framework/callbacks/test_torchsnapshot_saver.py
+++ b/tests/framework/callbacks/test_torchsnapshot_saver.py
@@ -122,16 +122,54 @@ class TorchSnapshotSaverTest(unittest.TestCase):
             )
             train(state, my_unit, callbacks=[snapshot_cb])
 
-            end_num_steps_completed = state.train_state.progress.num_steps_completed
+            end_num_steps_completed = my_unit.train_progress.num_steps_completed
             self.assertGreater(len(expected_paths), 0)
             snapshot_cb.restore(expected_paths[0], state, my_unit)
-            restored_num_steps_completed = (
-                state.train_state.progress.num_steps_completed
-            )
+            restored_num_steps_completed = my_unit.train_progress.num_steps_completed
             # A snapshot is saved every n steps
             # so the first snapshot's progress will be equal to save_every_n_train_steps
             self.assertNotEqual(restored_num_steps_completed, end_num_steps_completed)
             self.assertEqual(restored_num_steps_completed, save_every_n_train_steps)
+
+    def test_save_restore_no_train_progress(self) -> None:
+        input_dim = 2
+        dataset_len = 10
+        batch_size = 2
+        max_epochs = 2
+        expected_steps_per_epoch = math.ceil(dataset_len / batch_size)
+        save_every_n_train_steps = 2
+
+        my_unit = DummyTrainUnit(input_dim=input_dim)
+        dataloader = generate_random_dataloader(dataset_len, input_dim, batch_size)
+        state = init_train_state(dataloader=dataloader, max_epochs=max_epochs)
+        expected_paths: List[str] = []
+        with tempfile.TemporaryDirectory() as temp_dir:
+            cumulative_steps = 0
+            for epoch in range(max_epochs):
+                for _ in range(
+                    save_every_n_train_steps,
+                    expected_steps_per_epoch + 1,
+                    save_every_n_train_steps,
+                ):
+                    cumulative_steps += save_every_n_train_steps
+                    expected_paths.append(
+                        os.path.join(temp_dir, f"epoch_{epoch}_step_{cumulative_steps}")
+                    )
+            snapshot_cb = TorchSnapshotSaver(
+                temp_dir,
+                save_every_n_train_steps=save_every_n_train_steps,
+                replicated=["**"],
+            )
+            train(state, my_unit, callbacks=[snapshot_cb])
+
+            end_num_steps_completed = my_unit.train_progress.num_steps_completed
+            self.assertGreater(len(expected_paths), 0)
+            snapshot_cb.restore(
+                expected_paths[0], state, my_unit, restore_train_progress=False
+            )
+            restored_num_steps_completed = my_unit.train_progress.num_steps_completed
+            # no train progress was restored so the progress after restoration should be the same as the progress before restoration
+            self.assertEqual(restored_num_steps_completed, end_num_steps_completed)
 
     def test_save_on_train_end(self) -> None:
         input_dim = 2

--- a/tests/framework/callbacks/test_tqdm_progress_bar.py
+++ b/tests/framework/callbacks/test_tqdm_progress_bar.py
@@ -6,7 +6,6 @@
 # LICENSE file in the root directory of this source tree.
 
 import unittest
-from unittest.mock import MagicMock
 
 from torchtnt.framework._test_utils import (
     DummyEvalUnit,
@@ -39,7 +38,7 @@ class TQDMProgressBarTest(unittest.TestCase):
             ),
         )
 
-        my_unit = MagicMock(spec=DummyTrainUnit)
+        my_unit = DummyTrainUnit(2)
         progress_bar = TQDMProgressBar()
         progress_bar.on_train_epoch_start(state, my_unit)
         self.assertEqual(progress_bar._train_progress_bar.total, expected_total)
@@ -56,7 +55,7 @@ class TQDMProgressBarTest(unittest.TestCase):
         dataloader = generate_random_dataloader(dataset_len, input_dim, batch_size)
         state = init_train_state(dataloader=dataloader, max_epochs=max_epochs)
 
-        my_unit = MagicMock(spec=DummyTrainUnit)
+        my_unit = DummyTrainUnit(2)
         progress_bar = TQDMProgressBar()
         train(state, my_unit, callbacks=[progress_bar])
 
@@ -79,7 +78,7 @@ class TQDMProgressBarTest(unittest.TestCase):
             ),
         )
 
-        my_unit = MagicMock(spec=DummyEvalUnit)
+        my_unit = DummyEvalUnit(2)
         progress_bar = TQDMProgressBar()
         progress_bar.on_eval_epoch_start(state, my_unit)
         self.assertEqual(progress_bar._eval_progress_bar.total, expected_total)
@@ -103,7 +102,7 @@ class TQDMProgressBarTest(unittest.TestCase):
             ),
         )
 
-        my_unit = MagicMock(spec=DummyPredictUnit)
+        my_unit = DummyPredictUnit(2)
         progress_bar = TQDMProgressBar()
         progress_bar.on_predict_epoch_start(state, my_unit)
         self.assertEqual(progress_bar._predict_progress_bar.total, expected_total)
@@ -126,9 +125,8 @@ class TQDMProgressBarTest(unittest.TestCase):
                 max_epochs=max_epochs,
             ),
         )
-        state.predict_state.progress._num_steps_completed = 2
-
-        my_unit = MagicMock(spec=DummyPredictUnit)
+        my_unit = DummyPredictUnit(2)
+        my_unit.predict_progress._num_steps_completed = 2
         progress_bar = TQDMProgressBar()
         progress_bar.on_predict_epoch_start(state, my_unit)
         self.assertEqual(progress_bar._predict_progress_bar.total, expected_total)

--- a/tests/framework/test_auto_unit.py
+++ b/tests/framework/test_auto_unit.py
@@ -465,7 +465,7 @@ class TestAutoUnit(unittest.TestCase):
             auto_unit.train_step(state=state, data=dummy_iterator)
             no_sync_mock.assert_called_once()
 
-        state.train_state.progress.increment_step()
+        auto_unit.train_progress.increment_step()
         # for the second step no_sync should not be called since we run optimizer step
         with patch.object(auto_unit.module, "no_sync") as no_sync_mock:
             auto_unit.train_step(state=state, data=dummy_iterator)
@@ -496,7 +496,7 @@ class TestAutoUnit(unittest.TestCase):
             auto_unit.train_step(state=state, data=dummy_iterator)
             no_sync_mock.assert_called_once()
 
-        state.train_state.progress.increment_step()
+        auto_unit.train_progress.increment_step()
         # for the second step no_sync should not be called since we run optimizer step
         with patch.object(auto_unit.module, "no_sync") as no_sync_mock:
             auto_unit.train_step(state=state, data=dummy_iterator)
@@ -1108,7 +1108,7 @@ class LastBatchAutoUnit(AutoUnit[Batch]):
         tc = unittest.TestCase()
         tc.assertEqual(
             self._is_last_train_batch,
-            state.train_state.progress.num_steps_completed_in_epoch + 1
+            self.train_progress.num_steps_completed_in_epoch + 1
             == self.expected_steps_per_epoch,
         )
         inputs, targets = data

--- a/tests/framework/test_evaluate.py
+++ b/tests/framework/test_evaluate.py
@@ -34,9 +34,9 @@ class EvaluateTest(unittest.TestCase):
         state = init_eval_state(dataloader=dataloader)
         evaluate(state, my_unit)
 
-        self.assertEqual(state.eval_state.progress.num_epochs_completed, 1)
-        self.assertEqual(state.eval_state.progress.num_steps_completed_in_epoch, 0)
-        self.assertEqual(state.eval_state.progress.num_steps_completed, expected_steps)
+        self.assertEqual(my_unit.eval_progress.num_epochs_completed, 1)
+        self.assertEqual(my_unit.eval_progress.num_steps_completed_in_epoch, 0)
+        self.assertEqual(my_unit.eval_progress.num_steps_completed, expected_steps)
         self.assertEqual(state.entry_point, EntryPoint.EVALUATE)
 
         # step_output should be reset to None
@@ -62,11 +62,9 @@ class EvaluateTest(unittest.TestCase):
         )
         evaluate(state, my_unit)
 
-        self.assertEqual(state.eval_state.progress.num_epochs_completed, 1)
-        self.assertEqual(state.eval_state.progress.num_steps_completed_in_epoch, 0)
-        self.assertEqual(
-            state.eval_state.progress.num_steps_completed, max_steps_per_epoch
-        )
+        self.assertEqual(my_unit.eval_progress.num_epochs_completed, 1)
+        self.assertEqual(my_unit.eval_progress.num_steps_completed_in_epoch, 0)
+        self.assertEqual(my_unit.eval_progress.num_steps_completed, max_steps_per_epoch)
         self.assertEqual(state.entry_point, EntryPoint.EVALUATE)
 
         # step_output should be reset to None
@@ -93,10 +91,10 @@ class EvaluateTest(unittest.TestCase):
         )
         evaluate(state, my_unit)
 
-        self.assertEqual(state.eval_state.progress.num_epochs_completed, 1)
-        self.assertEqual(state.eval_state.progress.num_steps_completed_in_epoch, 0)
+        self.assertEqual(my_unit.eval_progress.num_epochs_completed, 1)
+        self.assertEqual(my_unit.eval_progress.num_steps_completed_in_epoch, 0)
         self.assertEqual(
-            my_unit.steps_processed, state.eval_state.progress.num_steps_completed
+            my_unit.steps_processed, my_unit.eval_progress.num_steps_completed
         )
         self.assertEqual(my_unit.steps_processed, steps_before_stopping)
 
@@ -129,9 +127,9 @@ class EvaluateTest(unittest.TestCase):
         state = init_eval_state(dataloader=dataloader)
         evaluate(state, my_unit)
 
-        self.assertEqual(state.eval_state.progress.num_epochs_completed, 1)
-        self.assertEqual(state.eval_state.progress.num_steps_completed_in_epoch, 0)
-        self.assertEqual(state.eval_state.progress.num_steps_completed, expected_steps)
+        self.assertEqual(my_unit.eval_progress.num_epochs_completed, 1)
+        self.assertEqual(my_unit.eval_progress.num_steps_completed_in_epoch, 0)
+        self.assertEqual(my_unit.eval_progress.num_steps_completed, expected_steps)
 
         # step_output should be reset to None
         self.assertEqual(state.eval_state.step_output, None)
@@ -148,7 +146,7 @@ class EvaluateTest(unittest.TestCase):
         max_steps_per_epoch = 6
         expected_num_steps = dataset_len / batch_size
 
-        my_unit = MagicMock()
+        my_unit = DummyEvalUnit(2)
         dataloader = generate_random_dataloader(dataset_len, input_dim, batch_size)
         state = init_eval_state(
             dataloader=dataloader, max_steps_per_epoch=max_steps_per_epoch
@@ -225,7 +223,7 @@ class StopEvalUnit(EvalUnit[Tuple[torch.Tensor, torch.Tensor]]):
 
         assert state.eval_state
         if (
-            state.eval_state.progress.num_steps_completed_in_epoch + 1
+            self.eval_progress.num_steps_completed_in_epoch + 1
             == self.steps_before_stopping
         ):
             state.stop()

--- a/tests/framework/test_fit.py
+++ b/tests/framework/test_fit.py
@@ -50,20 +50,20 @@ class FitTest(unittest.TestCase):
         )
         fit(state, my_unit)
 
-        self.assertEqual(state.train_state.progress.num_epochs_completed, max_epochs)
-        self.assertEqual(state.train_state.progress.num_steps_completed_in_epoch, 0)
+        self.assertEqual(my_unit.train_progress.num_epochs_completed, max_epochs)
+        self.assertEqual(my_unit.train_progress.num_steps_completed_in_epoch, 0)
         self.assertEqual(
-            state.train_state.progress.num_steps_completed,
+            my_unit.train_progress.num_steps_completed,
             max_epochs * expected_train_steps_per_epoch,
         )
 
         self.assertEqual(
-            state.eval_state.progress.num_epochs_completed,
+            my_unit.eval_progress.num_epochs_completed,
             expected_num_evaluate_calls,
         )
-        self.assertEqual(state.eval_state.progress.num_steps_completed_in_epoch, 0)
+        self.assertEqual(my_unit.eval_progress.num_steps_completed_in_epoch, 0)
         self.assertEqual(
-            state.eval_state.progress.num_steps_completed,
+            my_unit.eval_progress.num_steps_completed,
             max_epochs * expected_eval_steps_per_epoch,
         )
         self.assertEqual(state.entry_point, EntryPoint.FIT)
@@ -107,20 +107,20 @@ class FitTest(unittest.TestCase):
         )
         fit(state, my_unit)
 
-        self.assertEqual(state.train_state.progress.num_epochs_completed, max_epochs)
-        self.assertEqual(state.train_state.progress.num_steps_completed_in_epoch, 0)
+        self.assertEqual(my_unit.train_progress.num_epochs_completed, max_epochs)
+        self.assertEqual(my_unit.train_progress.num_steps_completed_in_epoch, 0)
         self.assertEqual(
-            state.train_state.progress.num_steps_completed,
+            my_unit.train_progress.num_steps_completed,
             max_epochs * expected_train_steps_per_epoch,
         )
 
         self.assertEqual(
-            state.eval_state.progress.num_epochs_completed,
+            my_unit.eval_progress.num_epochs_completed,
             expected_num_evaluate_calls,
         )
-        self.assertEqual(state.eval_state.progress.num_steps_completed_in_epoch, 0)
+        self.assertEqual(my_unit.eval_progress.num_steps_completed_in_epoch, 0)
         self.assertEqual(
-            state.eval_state.progress.num_steps_completed,
+            my_unit.eval_progress.num_steps_completed,
             expected_num_evaluate_calls * expected_eval_steps_per_epoch,
         )
         self.assertEqual(state.entry_point, EntryPoint.FIT)
@@ -156,7 +156,7 @@ class FitTest(unittest.TestCase):
 
                 assert state.train_state
                 if (
-                    state.train_state.progress.num_steps_completed_in_epoch + 1
+                    my_unit.train_progress.num_steps_completed_in_epoch + 1
                     == self.steps_before_stopping
                 ):
                     state.stop()
@@ -194,15 +194,15 @@ class FitTest(unittest.TestCase):
         )
         fit(state, my_unit)
 
-        self.assertEqual(state.train_state.progress.num_epochs_completed, 1)
-        self.assertEqual(state.train_state.progress.num_steps_completed_in_epoch, 0)
+        self.assertEqual(my_unit.train_progress.num_epochs_completed, 1)
+        self.assertEqual(my_unit.train_progress.num_steps_completed_in_epoch, 0)
         self.assertEqual(
-            my_unit.steps_processed, state.train_state.progress.num_steps_completed
+            my_unit.steps_processed, my_unit.train_progress.num_steps_completed
         )
         self.assertEqual(my_unit.steps_processed, steps_before_stopping)
-        self.assertEqual(state.eval_state.progress.num_epochs_completed, 1)
-        self.assertEqual(state.eval_state.progress.num_steps_completed, 0)
-        self.assertEqual(state.eval_state.progress.num_steps_completed_in_epoch, 0)
+        self.assertEqual(my_unit.eval_progress.num_epochs_completed, 1)
+        self.assertEqual(my_unit.eval_progress.num_steps_completed, 0)
+        self.assertEqual(my_unit.eval_progress.num_steps_completed_in_epoch, 0)
 
     def test_fit_max_steps(self) -> None:
         max_steps = 3
@@ -211,8 +211,7 @@ class FitTest(unittest.TestCase):
         batch_size = 2
         expected_eval_steps_per_epoch = dataset_len / batch_size
 
-        my_unit = MagicMock(spec=DummyFitUnit)
-        my_unit.modules = MagicMock(return_value={})
+        my_unit = DummyFitUnit(2)
         train_dl = generate_random_dataloader(dataset_len, input_dim, batch_size)
         eval_dl = generate_random_dataloader(dataset_len, input_dim, batch_size)
         state = init_fit_state(
@@ -220,12 +219,10 @@ class FitTest(unittest.TestCase):
         )
         fit(state, my_unit)
 
-        self.assertEqual(state.train_state.progress.num_steps_completed, max_steps)
-        self.assertEqual(my_unit.train_step.call_count, max_steps)
+        self.assertEqual(my_unit.train_progress.num_steps_completed, max_steps)
         self.assertEqual(
-            state.eval_state.progress.num_steps_completed, expected_eval_steps_per_epoch
+            my_unit.eval_progress.num_steps_completed, expected_eval_steps_per_epoch
         )
-        self.assertEqual(my_unit.eval_step.call_count, expected_eval_steps_per_epoch)
 
     def test_fit_with_callback(self) -> None:
         """
@@ -239,7 +236,7 @@ class FitTest(unittest.TestCase):
         expected_num_total_train_steps = train_dataset_len / batch_size * max_epochs
         expected_num_total_eval_steps = eval_dataset_len / batch_size * max_epochs
 
-        my_unit = MagicMock(spec=DummyFitUnit)
+        my_unit = DummyFitUnit(2)
         train_dataloader = generate_random_dataloader(
             train_dataset_len, input_dim, batch_size
         )

--- a/tests/framework/test_predict.py
+++ b/tests/framework/test_predict.py
@@ -36,11 +36,9 @@ class PredictTest(unittest.TestCase):
         state = init_predict_state(dataloader=dataloader)
         predict(state, my_unit)
 
-        self.assertEqual(state.predict_state.progress.num_epochs_completed, 1)
-        self.assertEqual(state.predict_state.progress.num_steps_completed_in_epoch, 0)
-        self.assertEqual(
-            state.predict_state.progress.num_steps_completed, expected_steps
-        )
+        self.assertEqual(my_unit.predict_progress.num_epochs_completed, 1)
+        self.assertEqual(my_unit.predict_progress.num_steps_completed_in_epoch, 0)
+        self.assertEqual(my_unit.predict_progress.num_steps_completed, expected_steps)
         self.assertEqual(state.entry_point, EntryPoint.PREDICT)
 
         # step_output should be reset to None
@@ -66,10 +64,10 @@ class PredictTest(unittest.TestCase):
         )
         predict(state, my_unit)
 
-        self.assertEqual(state.predict_state.progress.num_epochs_completed, 1)
-        self.assertEqual(state.predict_state.progress.num_steps_completed_in_epoch, 0)
+        self.assertEqual(my_unit.predict_progress.num_epochs_completed, 1)
+        self.assertEqual(my_unit.predict_progress.num_steps_completed_in_epoch, 0)
         self.assertEqual(
-            state.predict_state.progress.num_steps_completed, max_steps_per_epoch
+            my_unit.predict_progress.num_steps_completed, max_steps_per_epoch
         )
 
         # step_output should be reset to None
@@ -96,10 +94,10 @@ class PredictTest(unittest.TestCase):
         )
         predict(state, my_unit)
 
-        self.assertEqual(state.predict_state.progress.num_epochs_completed, 1)
-        self.assertEqual(state.predict_state.progress.num_steps_completed_in_epoch, 0)
+        self.assertEqual(my_unit.predict_progress.num_epochs_completed, 1)
+        self.assertEqual(my_unit.predict_progress.num_steps_completed_in_epoch, 0)
         self.assertEqual(
-            my_unit.steps_processed, state.predict_state.progress.num_steps_completed
+            my_unit.steps_processed, my_unit.predict_progress.num_steps_completed
         )
         self.assertEqual(my_unit.steps_processed, steps_before_stopping)
 
@@ -113,7 +111,7 @@ class PredictTest(unittest.TestCase):
         max_steps_per_epoch = 6
         expected_num_steps = dataset_len / batch_size
 
-        my_unit = MagicMock()
+        my_unit = DummyPredictUnit(2)
         dataloader = generate_random_dataloader(dataset_len, input_dim, batch_size)
         callback_mock = MagicMock()
         state = init_predict_state(
@@ -163,11 +161,9 @@ class PredictTest(unittest.TestCase):
         state = init_predict_state(dataloader=dataloader)
         predict(state, my_unit)
 
-        self.assertEqual(state.predict_state.progress.num_epochs_completed, 1)
-        self.assertEqual(state.predict_state.progress.num_steps_completed_in_epoch, 0)
-        self.assertEqual(
-            state.predict_state.progress.num_steps_completed, expected_steps
-        )
+        self.assertEqual(my_unit.predict_progress.num_epochs_completed, 1)
+        self.assertEqual(my_unit.predict_progress.num_steps_completed_in_epoch, 0)
+        self.assertEqual(my_unit.predict_progress.num_steps_completed, expected_steps)
 
         # step_output should be reset to None
         self.assertEqual(state.predict_state.step_output, None)
@@ -226,7 +222,7 @@ class StopPredictUnit(PredictUnit[Tuple[torch.Tensor, torch.Tensor]]):
         outputs = self.module(inputs)
         assert state.predict_state
         if (
-            state.predict_state.progress.num_steps_completed_in_epoch + 1
+            self.predict_progress.num_steps_completed_in_epoch + 1
             == self.steps_before_stopping
         ):
             state.stop()

--- a/tests/framework/test_state.py
+++ b/tests/framework/test_state.py
@@ -9,8 +9,6 @@ import unittest
 
 from torchtnt.framework.state import _check_loop_condition, PhaseState
 
-from torchtnt.utils.progress import Progress
-
 
 class StateTest(unittest.TestCase):
     def test_check_loop_condition(self) -> None:
@@ -24,18 +22,18 @@ class StateTest(unittest.TestCase):
         with self.assertRaisesRegex(
             ValueError, "Invalid value provided for max_epochs"
         ):
-            PhaseState(progress=Progress(), dataloader=[], max_epochs=-2)
+            PhaseState(dataloader=[], max_epochs=-2)
         with self.assertRaisesRegex(ValueError, "Invalid value provided for max_steps"):
-            PhaseState(progress=Progress(), dataloader=[], max_steps=-2)
+            PhaseState(dataloader=[], max_steps=-2)
         with self.assertRaisesRegex(
             ValueError, "Invalid value provided for max_steps_per_epoch"
         ):
-            PhaseState(progress=Progress(), dataloader=[], max_steps_per_epoch=-2)
+            PhaseState(dataloader=[], max_steps_per_epoch=-2)
         with self.assertRaisesRegex(
             ValueError, "Invalid value provided for evaluate_every_n_steps"
         ):
-            PhaseState(progress=Progress(), dataloader=[], evaluate_every_n_steps=-2)
+            PhaseState(dataloader=[], evaluate_every_n_steps=-2)
         with self.assertRaisesRegex(
             ValueError, "Invalid value provided for evaluate_every_n_epochs"
         ):
-            PhaseState(progress=Progress(), dataloader=[], evaluate_every_n_epochs=-2)
+            PhaseState(dataloader=[], evaluate_every_n_epochs=-2)

--- a/torchtnt/framework/callbacks/garbage_collector.py
+++ b/torchtnt/framework/callbacks/garbage_collector.py
@@ -47,12 +47,11 @@ class GarbageCollector(Callback):
     def on_train_step_end(self, state: State, unit: TTrainUnit) -> None:
         gc.collect(generation=1)
 
-        train_state = none_throws(state.train_state)
-        total_num_steps_completed = train_state.progress.num_steps_completed
+        total_num_steps_completed = unit.train_progress.num_steps_completed
         if state.entry_point == EntryPoint.FIT:
             # if fitting, include the num eval steps completed in the total steps completed
             eval_state = none_throws(state.eval_state)
-            total_num_steps_completed += eval_state.progress.num_steps_completed
+            total_num_steps_completed += unit.eval_progress.num_steps_completed
 
         if total_num_steps_completed % self._step_interval == 0:
             gc.collect()
@@ -68,12 +67,10 @@ class GarbageCollector(Callback):
 
     def on_eval_step_end(self, state: State, unit: TEvalUnit) -> None:
         gc.collect(generation=1)
-        eval_state = none_throws(state.eval_state)
-        total_num_steps_completed = eval_state.progress.num_steps_completed
+        total_num_steps_completed = unit.eval_progress.num_steps_completed
         if state.entry_point == EntryPoint.FIT:
             # if fitting, include the num train steps completed in the total steps completed
-            train_state = none_throws(state.train_state)
-            total_num_steps_completed += train_state.progress.num_steps_completed
+            total_num_steps_completed += unit.train_progress.num_steps_completed
 
         if total_num_steps_completed % self._step_interval == 0:
             gc.collect()
@@ -89,8 +86,7 @@ class GarbageCollector(Callback):
 
     def on_predict_step_end(self, state: State, unit: TPredictUnit) -> None:
         gc.collect(generation=1)
-        predict_state = none_throws(state.predict_state)
-        if predict_state.progress.num_steps_completed % self._step_interval == 0:
+        if unit.predict_progress.num_steps_completed % self._step_interval == 0:
             gc.collect()
 
     def on_predict_end(self, state: State, unit: TPredictUnit) -> None:

--- a/torchtnt/framework/callbacks/lambda_callback.py
+++ b/torchtnt/framework/callbacks/lambda_callback.py
@@ -46,7 +46,7 @@ class Lambda(Callback):
         unit = MyUnit()
 
         def print_on_step_start(state, unit) -> None:
-            print(f'starting eval step {state.eval_state.progress.num_steps_completed}')
+            print(f'starting eval step {unit.eval_progress.num_steps_completed}')
 
 
         lambda_cb = Lambda(

--- a/torchtnt/framework/callbacks/learning_rate_monitor.py
+++ b/torchtnt/framework/callbacks/learning_rate_monitor.py
@@ -6,8 +6,6 @@
 
 from typing import Dict, List, Union
 
-from pyre_extensions import none_throws
-
 from torch.optim.optimizer import Optimizer
 from torchtnt.framework.callback import Callback
 from torchtnt.framework.state import State
@@ -100,9 +98,7 @@ class LearningRateMonitor(Callback):
 
         lr_stats = _extract_lr(unit)
 
-        train_state = none_throws(state.train_state)
-
-        step = train_state.progress.num_steps_completed
+        step = unit.train_progress.num_steps_completed
         _write_stats(self._loggers, lr_stats, step)
 
     def on_train_step_start(self, state: State, unit: TTrainUnit) -> None:
@@ -114,7 +110,5 @@ class LearningRateMonitor(Callback):
 
         lr_stats = _extract_lr(unit)
 
-        train_state = none_throws(state.train_state)
-
-        step = train_state.progress.num_steps_completed
+        step = unit.train_progress.num_steps_completed
         _write_stats(self._loggers, lr_stats, step)

--- a/torchtnt/framework/callbacks/tensorboard_parameter_monitor.py
+++ b/torchtnt/framework/callbacks/tensorboard_parameter_monitor.py
@@ -8,8 +8,6 @@ from typing import Dict, Optional, Union
 
 import torch
 
-from pyre_extensions import none_throws
-
 from torch.utils.tensorboard import SummaryWriter
 from torchtnt.framework.callback import Callback
 from torchtnt.framework.state import State
@@ -49,8 +47,6 @@ class TensorBoardParameterMonitor(Callback):
         if not writer:
             return
 
-        train_state = none_throws(state.train_state)
-
-        step = train_state.progress.num_steps_completed
+        step = unit.train_progress.num_steps_completed
         modules = unit.tracked_modules()
         _write_histogram_parameters(writer, modules, step)

--- a/torchtnt/framework/callbacks/tqdm_progress_bar.py
+++ b/torchtnt/framework/callbacks/tqdm_progress_bar.py
@@ -42,29 +42,27 @@ class TQDMProgressBar(Callback):
             self._train_progress_bar = create_progress_bar(
                 train_state.dataloader,
                 desc="Train Epoch",
-                num_epochs_completed=train_state.progress.num_epochs_completed,
-                num_steps_completed=train_state.progress.num_steps_completed_in_epoch,
+                num_epochs_completed=unit.train_progress.num_epochs_completed,
+                num_steps_completed=unit.train_progress.num_steps_completed_in_epoch,
                 max_steps=train_state.max_steps,
                 max_steps_per_epoch=train_state.max_steps_per_epoch,
             )
 
     def on_train_step_end(self, state: State, unit: TTrainUnit) -> None:
-        train_state = none_throws(state.train_state)
         pbar = self._train_progress_bar
         if pbar is not None:
             update_progress_bar(
                 pbar,
-                train_state.progress.num_steps_completed_in_epoch,
+                unit.train_progress.num_steps_completed_in_epoch,
                 self._refresh_rate,
             )
 
     def on_train_epoch_end(self, state: State, unit: TTrainUnit) -> None:
-        train_state = none_throws(state.train_state)
         pbar = self._train_progress_bar
         if pbar is not None:
             close_progress_bar(
                 pbar,
-                train_state.progress.num_steps_completed_in_epoch,
+                unit.train_progress.num_steps_completed_in_epoch,
                 self._refresh_rate,
             )
 
@@ -74,29 +72,27 @@ class TQDMProgressBar(Callback):
             self._eval_progress_bar = create_progress_bar(
                 eval_state.dataloader,
                 desc="Eval Epoch",
-                num_epochs_completed=eval_state.progress.num_epochs_completed,
-                num_steps_completed=eval_state.progress.num_steps_completed_in_epoch,
+                num_epochs_completed=unit.eval_progress.num_epochs_completed,
+                num_steps_completed=unit.eval_progress.num_steps_completed_in_epoch,
                 max_steps=eval_state.max_steps,
                 max_steps_per_epoch=eval_state.max_steps_per_epoch,
             )
 
     def on_eval_step_end(self, state: State, unit: TEvalUnit) -> None:
-        eval_state = none_throws(state.eval_state)
         pbar = self._eval_progress_bar
         if pbar is not None:
             update_progress_bar(
                 pbar,
-                eval_state.progress.num_steps_completed_in_epoch,
+                unit.eval_progress.num_steps_completed_in_epoch,
                 self._refresh_rate,
             )
 
     def on_eval_epoch_end(self, state: State, unit: TEvalUnit) -> None:
-        eval_state = none_throws(state.eval_state)
         pbar = self._eval_progress_bar
         if pbar is not None and state.eval_state:
             close_progress_bar(
                 pbar,
-                eval_state.progress.num_steps_completed_in_epoch,
+                unit.eval_progress.num_steps_completed_in_epoch,
                 self._refresh_rate,
             )
 
@@ -106,28 +102,26 @@ class TQDMProgressBar(Callback):
             self._predict_progress_bar = create_progress_bar(
                 predict_state.dataloader,
                 desc="Predict Epoch",
-                num_epochs_completed=predict_state.progress.num_epochs_completed,
-                num_steps_completed=predict_state.progress.num_steps_completed,
+                num_epochs_completed=unit.predict_progress.num_epochs_completed,
+                num_steps_completed=unit.predict_progress.num_steps_completed,
                 max_steps=predict_state.max_steps,
                 max_steps_per_epoch=predict_state.max_steps_per_epoch,
             )
 
     def on_predict_step_end(self, state: State, unit: TPredictUnit) -> None:
-        predict_state = none_throws(state.predict_state)
         pbar = self._predict_progress_bar
         if pbar is not None:
             update_progress_bar(
                 pbar,
-                predict_state.progress.num_steps_completed_in_epoch,
+                unit.predict_progress.num_steps_completed_in_epoch,
                 self._refresh_rate,
             )
 
     def on_predict_epoch_end(self, state: State, unit: TPredictUnit) -> None:
-        predict_state = none_throws(state.predict_state)
         pbar = self._predict_progress_bar
         if pbar is not None:
             close_progress_bar(
                 pbar,
-                predict_state.progress.num_steps_completed_in_epoch,
+                unit.predict_progress.num_steps_completed_in_epoch,
                 self._refresh_rate,
             )

--- a/torchtnt/framework/callbacks/train_progress_monitor.py
+++ b/torchtnt/framework/callbacks/train_progress_monitor.py
@@ -6,22 +6,21 @@
 
 from typing import List, Union
 
-from pyre_extensions import none_throws
-
 from torchtnt.framework.callback import Callback
 from torchtnt.framework.state import State
 from torchtnt.framework.unit import TTrainUnit
 from torchtnt.utils.loggers.logger import MetricLogger
+from torchtnt.utils.progress import Progress
 
 
-def _write_training_progress(state: State, loggers: List[MetricLogger]) -> None:
+def _write_training_progress(
+    train_progress: Progress, loggers: List[MetricLogger]
+) -> None:
     if not loggers:
         return
 
-    train_state = none_throws(state.train_state)
-
-    step = train_state.progress.num_steps_completed
-    epoch = train_state.progress.num_epochs_completed
+    step = train_progress.num_steps_completed
+    epoch = train_progress.num_epochs_completed
     for logger in loggers:
         logger.log("Training steps completed vs epochs", step, epoch)
 
@@ -45,7 +44,7 @@ class TrainProgressMonitor(Callback):
         self._loggers: List[MetricLogger] = loggers
 
     def on_train_start(self, state: State, unit: TTrainUnit) -> None:
-        _write_training_progress(state, self._loggers)
+        _write_training_progress(unit.train_progress, self._loggers)
 
     def on_train_epoch_end(self, state: State, unit: TTrainUnit) -> None:
-        _write_training_progress(state, self._loggers)
+        _write_training_progress(unit.train_progress, self._loggers)

--- a/torchtnt/framework/fit.py
+++ b/torchtnt/framework/fit.py
@@ -184,7 +184,7 @@ def _fit_impl(
 
     while not (
         state.should_stop
-        or _is_done(train_state.progress, train_state.max_epochs, train_state.max_steps)
+        or _is_done(unit.train_progress, train_state.max_epochs, train_state.max_steps)
     ):
         _train_epoch_impl(state, unit, callback_handler)
 

--- a/torchtnt/framework/state.py
+++ b/torchtnt/framework/state.py
@@ -13,7 +13,6 @@ import logging
 from enum import auto, Enum
 from typing import Any, Iterable, Optional
 
-from torchtnt.utils.progress import Progress
 from torchtnt.utils.timer import Timer
 
 _logger: logging.Logger = logging.getLogger(__name__)
@@ -69,7 +68,6 @@ class PhaseState:
         self,
         *,
         dataloader: Iterable[Any],
-        progress: Optional[Progress] = None,
         max_epochs: Optional[int] = None,  # used only for train
         max_steps: Optional[int] = None,  # used only for train
         max_steps_per_epoch: Optional[int] = None,
@@ -83,7 +81,6 @@ class PhaseState:
         _check_loop_condition("evaluate_every_n_epochs", evaluate_every_n_epochs)
 
         self._dataloader: Iterable[Any] = dataloader
-        self._progress: Progress = progress or Progress()
         self._max_epochs = max_epochs
         self._max_steps = max_steps
         self._max_steps_per_epoch = max_steps_per_epoch
@@ -96,11 +93,6 @@ class PhaseState:
     def dataloader(self) -> Iterable[Any]:
         """Dataloader defined by the user."""
         return self._dataloader
-
-    @property
-    def progress(self) -> Progress:
-        """An instance of :class:`~torchtnt.framework.Progress` which contains information about the current progress of the loop."""
-        return self._progress
 
     @property
     def max_epochs(self) -> Optional[int]:

--- a/torchtnt/framework/utils.py
+++ b/torchtnt/framework/utils.py
@@ -25,8 +25,7 @@ if is_torch_version_geq_2_0():
     from torch.distributed._composable_state import _get_module_state
     from torch.distributed.fsdp._common_utils import _FSDPState
 
-from pyre_extensions import none_throws
-from torchtnt.framework.state import ActivePhase, EntryPoint, State
+from torchtnt.framework.state import State
 from torchtnt.framework.unit import AppStateMixin
 from torchtnt.utils.lr_scheduler import TLRScheduler
 from torchtnt.utils.progress import Progress
@@ -231,17 +230,3 @@ def _find_optimizers_for_module(
         if all(module_param in optimizer_params for module_param in module_params):
             optimizer_list.append((optim_name, optimizer))
     return optimizer_list
-
-
-def get_current_progress(state: State) -> Progress:
-    """
-    If state's entry point is fit, returns train progress. During fit, we want to return training progress even during eval, so that metrics can be compared easily across train and eval.
-    Otherwise, checks the active phase, and returns the corresponding progress class.
-    """
-    if state.entry_point == EntryPoint.FIT or state.active_phase == ActivePhase.TRAIN:
-        return none_throws(state.train_state).progress
-
-    if state.active_phase == ActivePhase.EVALUATE:
-        return none_throws(state.eval_state).progress
-    else:
-        return none_throws(state.predict_state).progress


### PR DESCRIPTION
Summary:
1. Remove `state` arg since this isn't necessary anymore for restoring from a snapshot
2. Remove `restore_train_dataloader` and replace it with passing the train_dataloader directly

Differential Revision: D47405345

