### PR TITLE
Replace auto_timing arg with timer

### DIFF
--- a/examples/auto_unit_example.py
+++ b/examples/auto_unit_example.py
@@ -21,6 +21,7 @@ from torchtnt.framework import AutoUnit, fit, State
 from torchtnt.framework.state import EntryPoint
 from torchtnt.utils import init_from_env, seed, TLRScheduler
 from torchtnt.utils.loggers import TensorBoardLogger
+from torchtnt.utils.timer import Timer
 
 _logger: logging.Logger = logging.getLogger(__name__)
 logging.basicConfig(level=logging.INFO)
@@ -174,6 +175,7 @@ def main(args: Namespace) -> None:
         train_dataloader=train_dataloader,
         eval_dataloader=eval_dataloader,
         max_epochs=args.max_epochs,
+        timer=Timer(),
     )
 
 

--- a/tests/framework/test_auto_unit.py
+++ b/tests/framework/test_auto_unit.py
@@ -44,6 +44,7 @@ from torchtnt.utils.device import copy_data_to_device
 from torchtnt.utils.env import init_from_env
 from torchtnt.utils.lr_scheduler import TLRScheduler
 from torchtnt.utils.test_utils import get_pet_launch_config
+from torchtnt.utils.timer import Timer
 
 
 class TestAutoUnit(unittest.TestCase):
@@ -837,7 +838,7 @@ class TestAutoUnit(unittest.TestCase):
             dataloader,
             max_steps_per_epoch=max_steps_per_epoch,
             max_epochs=max_epochs,
-            auto_timing=True,
+            timer=Timer(),
         )
 
     def test_auto_unit_timing_eval(self) -> None:
@@ -857,7 +858,7 @@ class TestAutoUnit(unittest.TestCase):
             TimingAutoUnit(module=my_module),
             dataloader,
             max_steps_per_epoch=max_steps_per_epoch,
-            auto_timing=True,
+            timer=Timer(),
         )
 
     @unittest.skipUnless(
@@ -928,7 +929,7 @@ class TestAutoUnit(unittest.TestCase):
             TimingAutoPredictUnit(module=my_module),
             predict_dl,
             max_steps_per_epoch=1,
-            auto_timing=True,
+            timer=Timer(),
         )
 
     @patch("torch.autograd.set_detect_anomaly")

--- a/tests/framework/test_callback_handler.py
+++ b/tests/framework/test_callback_handler.py
@@ -105,119 +105,71 @@ class CallbackHandlerTest(unittest.TestCase):
 
         cb_handler.on_exception(state, unit, ValueError("test"))
         self.assertIn("on_exception", called_hooks)
-        self.assertIn("DummyCallback.on_exception", timer.recorded_durations.keys())
 
         cb_handler.on_train_start(state, unit)
         self.assertIn("on_train_start", called_hooks)
-        self.assertIn("DummyCallback.on_train_start", timer.recorded_durations.keys())
 
         cb_handler.on_train_epoch_start(state, unit)
         self.assertIn("on_train_epoch_start", called_hooks)
-        self.assertIn(
-            "DummyCallback.on_train_epoch_start", timer.recorded_durations.keys()
-        )
 
         cb_handler.on_train_step_start(state, unit)
         self.assertIn("on_train_step_start", called_hooks)
-        self.assertIn(
-            "DummyCallback.on_train_step_start", timer.recorded_durations.keys()
-        )
 
         cb_handler.on_train_step_end(state, unit)
         self.assertIn("on_train_step_end", called_hooks)
-        self.assertIn(
-            "DummyCallback.on_train_step_end", timer.recorded_durations.keys()
-        )
 
         cb_handler.on_train_step_end(state, unit)
         self.assertIn("on_train_step_end", called_hooks)
-        self.assertIn(
-            "DummyCallback.on_train_step_end", timer.recorded_durations.keys()
-        )
 
         cb_handler.on_train_epoch_end(state, unit)
         self.assertIn("on_train_epoch_end", called_hooks)
-        self.assertIn(
-            "DummyCallback.on_train_epoch_end", timer.recorded_durations.keys()
-        )
 
         cb_handler.on_train_end(state, unit)
         self.assertIn("on_train_end", called_hooks)
-        self.assertIn("DummyCallback.on_train_end", timer.recorded_durations.keys())
 
         unit = MagicMock(spec=TEvalUnit)
         cb_handler.on_eval_start(state, unit)
         self.assertIn("on_eval_start", called_hooks)
-        self.assertIn("DummyCallback.on_eval_start", timer.recorded_durations.keys())
 
         cb_handler.on_eval_epoch_start(state, unit)
         self.assertIn("on_eval_epoch_start", called_hooks)
-        self.assertIn(
-            "DummyCallback.on_eval_epoch_start", timer.recorded_durations.keys()
-        )
 
         cb_handler.on_eval_step_start(state, unit)
         self.assertIn("on_eval_step_start", called_hooks)
-        self.assertIn(
-            "DummyCallback.on_eval_step_start", timer.recorded_durations.keys()
-        )
 
         cb_handler.on_eval_step_end(state, unit)
         self.assertIn("on_eval_step_end", called_hooks)
-        self.assertIn("DummyCallback.on_eval_step_end", timer.recorded_durations.keys())
 
         cb_handler.on_eval_step_end(state, unit)
         self.assertIn("on_eval_step_end", called_hooks)
-        self.assertIn("DummyCallback.on_eval_step_end", timer.recorded_durations.keys())
 
         cb_handler.on_eval_epoch_end(state, unit)
         self.assertIn("on_eval_epoch_end", called_hooks)
-        self.assertIn(
-            "DummyCallback.on_eval_epoch_end", timer.recorded_durations.keys()
-        )
 
         cb_handler.on_eval_end(state, unit)
         self.assertIn("on_eval_end", called_hooks)
-        self.assertIn("DummyCallback.on_eval_end", timer.recorded_durations.keys())
 
         unit = MagicMock(spec=TPredictUnit)
         cb_handler.on_predict_start(state, unit)
         self.assertIn("on_predict_start", called_hooks)
-        self.assertIn("DummyCallback.on_predict_start", timer.recorded_durations.keys())
 
         cb_handler.on_predict_epoch_start(state, unit)
         self.assertIn("on_predict_epoch_start", called_hooks)
-        self.assertIn(
-            "DummyCallback.on_predict_epoch_start", timer.recorded_durations.keys()
-        )
 
         cb_handler.on_predict_step_start(state, unit)
         self.assertIn("on_predict_step_start", called_hooks)
-        self.assertIn(
-            "DummyCallback.on_predict_step_start", timer.recorded_durations.keys()
-        )
 
         cb_handler.on_predict_step_end(state, unit)
         self.assertIn("on_predict_step_end", called_hooks)
-        self.assertIn(
-            "DummyCallback.on_predict_step_end", timer.recorded_durations.keys()
-        )
 
         cb_handler.on_predict_step_end(state, unit)
         self.assertIn("on_predict_step_end", called_hooks)
-        self.assertIn(
-            "DummyCallback.on_predict_step_end", timer.recorded_durations.keys()
-        )
 
         cb_handler.on_predict_epoch_end(state, unit)
         self.assertIn("on_predict_epoch_end", called_hooks)
-        self.assertIn(
-            "DummyCallback.on_predict_epoch_end", timer.recorded_durations.keys()
-        )
 
         cb_handler.on_predict_end(state, unit)
         self.assertIn("on_predict_end", called_hooks)
-        self.assertIn("DummyCallback.on_predict_end", timer.recorded_durations.keys())
 
     def test_get_implemented_callback_mapping(self) -> None:
         callbacks = []

--- a/tests/framework/test_evaluate.py
+++ b/tests/framework/test_evaluate.py
@@ -15,6 +15,7 @@ from torchtnt.framework._test_utils import DummyEvalUnit, generate_random_datalo
 from torchtnt.framework.evaluate import evaluate
 from torchtnt.framework.state import State
 from torchtnt.framework.unit import EvalUnit
+from torchtnt.utils.timer import Timer
 
 
 class EvaluateTest(unittest.TestCase):
@@ -146,9 +147,9 @@ class EvaluateTest(unittest.TestCase):
         self.assertEqual(callback_mock.on_eval_epoch_end.call_count, 1)
         self.assertEqual(callback_mock.on_eval_end.call_count, 1)
 
-    def test_evaluate_auto_timing(self) -> None:
+    def test_evaluate_timing(self) -> None:
         """
-        Test auto timing in evaluate
+        Test timing in evaluate
         """
 
         input_dim = 2
@@ -157,13 +158,14 @@ class EvaluateTest(unittest.TestCase):
         max_steps_per_epoch = 2
 
         dataloader = generate_random_dataloader(dataset_len, input_dim, batch_size)
-
+        timer = Timer()
         evaluate(
-            TimingEvalUnit(input_dim=input_dim),
+            DummyEvalUnit(input_dim=input_dim),
             dataloader,
             max_steps_per_epoch=max_steps_per_epoch,
-            auto_timing=True,
+            timer=timer,
         )
+        self.assertTrue("evaluate.next(data_iter)" in timer.recorded_durations.keys())
 
 
 class StopEvalUnit(EvalUnit[Tuple[torch.Tensor, torch.Tensor]]):
@@ -196,26 +198,3 @@ class StopEvalUnit(EvalUnit[Tuple[torch.Tensor, torch.Tensor]]):
 
 
 Batch = Tuple[torch.Tensor, torch.Tensor]
-
-
-class TimingEvalUnit(EvalUnit[Batch]):
-    def __init__(self, input_dim: int) -> None:
-        super().__init__()
-        # initialize module, loss_fn, & optimizer
-        self.module = nn.Linear(input_dim, 2)
-
-    def eval_step(self, state: State, data: Batch) -> torch.Tensor:
-        inputs, _ = data
-        outputs = self.module(inputs)
-
-        if self.eval_progress.num_steps_completed == 1:
-            tc = unittest.TestCase()
-            for k in (
-                "TimingEvalUnit.on_eval_start",
-                "TimingEvalUnit.on_eval_epoch_start",
-                "evaluate.next(data_iter)",
-                "TimingEvalUnit.eval_step",
-            ):
-                tc.assertTrue(k in state.timer.recorded_durations.keys())
-
-        return outputs

--- a/tests/framework/test_utils.py
+++ b/tests/framework/test_utils.py
@@ -31,7 +31,6 @@ from torchtnt.framework.utils import (
     _construct_tracked_optimizers_and_schedulers,
     _find_optimizers_for_module,
     _FSDPOptimizerWrapper,
-    _get_timing_context,
     _is_done,
     _is_epoch_done,
     _is_fsdp_module,
@@ -39,6 +38,7 @@ from torchtnt.framework.utils import (
     _reset_module_training_mode,
     _set_module_training_mode,
     _step_requires_iterator,
+    get_timing_context,
 )
 from torchtnt.utils.env import init_from_env
 from torchtnt.utils.lr_scheduler import TLRScheduler
@@ -202,25 +202,17 @@ class UtilsTest(unittest.TestCase):
         state = MagicMock()
         state.timer = None
 
-        ctx = _get_timing_context(state, "a")
+        ctx = get_timing_context(state, "a")
         with ctx:
             time.sleep(1)
         mock_record_function.assert_called_with("a")
 
         state.timer = Timer()
-        ctx = _get_timing_context(state, "b")
+        ctx = get_timing_context(state, "b")
         with ctx:
             time.sleep(1)
         self.assertTrue("b" in state.timer.recorded_durations.keys())
         mock_record_function.assert_called_with("b")
-
-        state.timer = Timer()
-        ctx = _get_timing_context(state, "c", skip_timer=True)
-        with ctx:
-            time.sleep(1)
-        # "c" should not be in the recorded_durations because we set skip_timer to True
-        self.assertFalse("c" in state.timer.recorded_durations.keys())
-        mock_record_function.assert_called_with("c")
 
     def test_find_optimizers_for_module(self) -> None:
         module1 = torch.nn.Linear(10, 10)

--- a/torchtnt/framework/_callback_handler.py
+++ b/torchtnt/framework/_callback_handler.py
@@ -12,7 +12,6 @@ from unittest.mock import Mock
 from torchtnt.framework.callback import Callback
 from torchtnt.framework.state import State
 from torchtnt.framework.unit import TEvalUnit, TPredictUnit, TTrainUnit
-from torchtnt.framework.utils import _get_timing_context
 
 logger: logging.Logger = logging.getLogger(__name__)
 
@@ -109,131 +108,112 @@ class CallbackHandler:
         fn_name = "on_exception"
         callbacks = self._callbacks.get(fn_name, [])
         for cb in callbacks:
-            with _get_timing_context(state, f"{cb.name}.{fn_name}"):
-                cb.on_exception(state, unit, exc)
+            cb.on_exception(state, unit, exc)
 
     def on_train_start(self, state: State, unit: TTrainUnit) -> None:
         fn_name = "on_train_start"
         callbacks = self._callbacks.get(fn_name, [])
         for cb in callbacks:
-            with _get_timing_context(state, f"{cb.name}.{fn_name}"):
-                cb.on_train_start(state, unit)
+            cb.on_train_start(state, unit)
 
     def on_train_epoch_start(self, state: State, unit: TTrainUnit) -> None:
         fn_name = "on_train_epoch_start"
         callbacks = self._callbacks.get(fn_name, [])
         for cb in callbacks:
-            with _get_timing_context(state, f"{cb.name}.{fn_name}"):
-                cb.on_train_epoch_start(state, unit)
+            cb.on_train_epoch_start(state, unit)
 
     def on_train_step_start(self, state: State, unit: TTrainUnit) -> None:
         fn_name = "on_train_step_start"
         callbacks = self._callbacks.get(fn_name, [])
         for cb in callbacks:
-            with _get_timing_context(state, f"{cb.name}.{fn_name}"):
-                cb.on_train_step_start(state, unit)
+            cb.on_train_step_start(state, unit)
 
     def on_train_step_end(self, state: State, unit: TTrainUnit) -> None:
         fn_name = "on_train_step_end"
         callbacks = self._callbacks.get(fn_name, [])
         for cb in callbacks:
-            with _get_timing_context(state, f"{cb.name}.{fn_name}"):
-                cb.on_train_step_end(state, unit)
+            cb.on_train_step_end(state, unit)
 
     def on_train_epoch_end(self, state: State, unit: TTrainUnit) -> None:
         fn_name = "on_train_epoch_end"
         callbacks = self._callbacks.get(fn_name, [])
         for cb in callbacks:
-            with _get_timing_context(state, f"{cb.name}.{fn_name}"):
-                cb.on_train_epoch_end(state, unit)
+            cb.on_train_epoch_end(state, unit)
 
     def on_train_end(self, state: State, unit: TTrainUnit) -> None:
         fn_name = "on_train_end"
         callbacks = self._callbacks.get(fn_name, [])
         for cb in callbacks:
-            with _get_timing_context(state, f"{cb.name}.{fn_name}"):
-                cb.on_train_end(state, unit)
+            cb.on_train_end(state, unit)
 
     def on_eval_start(self, state: State, unit: TEvalUnit) -> None:
         fn_name = "on_eval_start"
         callbacks = self._callbacks.get(fn_name, [])
         for cb in callbacks:
-            with _get_timing_context(state, f"{cb.name}.{fn_name}"):
-                cb.on_eval_start(state, unit)
+            cb.on_eval_start(state, unit)
 
     def on_eval_epoch_start(self, state: State, unit: TEvalUnit) -> None:
         fn_name = "on_eval_epoch_start"
         callbacks = self._callbacks.get(fn_name, [])
         for cb in callbacks:
-            with _get_timing_context(state, f"{cb.name}.{fn_name}"):
-                cb.on_eval_epoch_start(state, unit)
+            cb.on_eval_epoch_start(state, unit)
 
     def on_eval_step_start(self, state: State, unit: TEvalUnit) -> None:
         fn_name = "on_eval_step_start"
         callbacks = self._callbacks.get(fn_name, [])
         for cb in callbacks:
-            with _get_timing_context(state, f"{cb.name}.{fn_name}"):
-                cb.on_eval_step_start(state, unit)
+            cb.on_eval_step_start(state, unit)
 
     def on_eval_step_end(self, state: State, unit: TEvalUnit) -> None:
         fn_name = "on_eval_step_end"
         callbacks = self._callbacks.get(fn_name, [])
         for cb in callbacks:
-            with _get_timing_context(state, f"{cb.name}.{fn_name}"):
-                cb.on_eval_step_end(state, unit)
+            cb.on_eval_step_end(state, unit)
 
     def on_eval_epoch_end(self, state: State, unit: TEvalUnit) -> None:
         fn_name = "on_eval_epoch_end"
         callbacks = self._callbacks.get(fn_name, [])
         for cb in callbacks:
-            with _get_timing_context(state, f"{cb.name}.{fn_name}"):
-                cb.on_eval_epoch_end(state, unit)
+            cb.on_eval_epoch_end(state, unit)
 
     def on_eval_end(self, state: State, unit: TEvalUnit) -> None:
         fn_name = "on_eval_end"
         callbacks = self._callbacks.get(fn_name, [])
         for cb in callbacks:
-            with _get_timing_context(state, f"{cb.name}.{fn_name}"):
-                cb.on_eval_end(state, unit)
+            cb.on_eval_end(state, unit)
 
     def on_predict_start(self, state: State, unit: TPredictUnit) -> None:
         fn_name = "on_predict_start"
         callbacks = self._callbacks.get(fn_name, [])
         for cb in callbacks:
-            with _get_timing_context(state, f"{cb.name}.{fn_name}"):
-                cb.on_predict_start(state, unit)
+            cb.on_predict_start(state, unit)
 
     def on_predict_epoch_start(self, state: State, unit: TPredictUnit) -> None:
         fn_name = "on_predict_epoch_start"
         callbacks = self._callbacks.get(fn_name, [])
         for cb in callbacks:
-            with _get_timing_context(state, f"{cb.name}.{fn_name}"):
-                cb.on_predict_epoch_start(state, unit)
+            cb.on_predict_epoch_start(state, unit)
 
     def on_predict_step_start(self, state: State, unit: TPredictUnit) -> None:
         fn_name = "on_predict_step_start"
         callbacks = self._callbacks.get(fn_name, [])
         for cb in callbacks:
-            with _get_timing_context(state, f"{cb.name}.{fn_name}"):
-                cb.on_predict_step_start(state, unit)
+            cb.on_predict_step_start(state, unit)
 
     def on_predict_step_end(self, state: State, unit: TPredictUnit) -> None:
         fn_name = "on_predict_step_end"
         callbacks = self._callbacks.get(fn_name, [])
         for cb in callbacks:
-            with _get_timing_context(state, f"{cb.name}.{fn_name}"):
-                cb.on_predict_step_end(state, unit)
+            cb.on_predict_step_end(state, unit)
 
     def on_predict_epoch_end(self, state: State, unit: TPredictUnit) -> None:
         fn_name = "on_predict_epoch_end"
         callbacks = self._callbacks.get(fn_name, [])
         for cb in callbacks:
-            with _get_timing_context(state, f"{cb.name}.{fn_name}"):
-                cb.on_predict_epoch_end(state, unit)
+            cb.on_predict_epoch_end(state, unit)
 
     def on_predict_end(self, state: State, unit: TPredictUnit) -> None:
         fn_name = "on_predict_end"
         callbacks = self._callbacks.get(fn_name, [])
         for cb in callbacks:
-            with _get_timing_context(state, f"{cb.name}.{fn_name}"):
-                cb.on_predict_end(state, unit)
+            cb.on_predict_end(state, unit)

--- a/torchtnt/framework/auto_unit.py
+++ b/torchtnt/framework/auto_unit.py
@@ -27,7 +27,7 @@ from torch.nn.parallel import DistributedDataParallel as DDP
 from torch.optim.swa_utils import AveragedModel, SWALR
 from torchtnt.framework.state import ActivePhase, EntryPoint, State
 from torchtnt.framework.unit import EvalUnit, PredictUnit, TPredictData, TrainUnit
-from torchtnt.framework.utils import _get_timing_context, _is_fsdp_module
+from torchtnt.framework.utils import _is_fsdp_module, get_timing_context
 from torchtnt.utils.device import copy_data_to_device, record_data_in_stream
 from torchtnt.utils.env import init_from_env
 from torchtnt.utils.lr_scheduler import TLRScheduler
@@ -240,14 +240,11 @@ class AutoPredictUnit(PredictUnit[TPredictData]):
         )
 
         with self.maybe_autocast_precision, maybe_detect_anomaly:
-            with _get_timing_context(state, f"{self.__class__.__name__}.forward"):
+            with get_timing_context(state, f"{self.__class__.__name__}.forward"):
                 outputs = self.module(batch)
 
         step = self.predict_progress.num_steps_completed
-        with _get_timing_context(
-            state, f"{self.__class__.__name__}.on_predict_step_end"
-        ):
-            self.on_predict_step_end(state, batch, step, outputs)
+        self.on_predict_step_end(state, batch, step, outputs)
         return outputs
 
     def on_predict_step_end(
@@ -292,7 +289,7 @@ class AutoPredictUnit(PredictUnit[TPredictData]):
             self._prefetched = True
 
         if self._prefetch_stream:
-            with _get_timing_context(state, f"{self.__class__.__name__}.wait_stream"):
+            with get_timing_context(state, f"{self.__class__.__name__}.wait_stream"):
                 # wait on the CUDA stream to complete the host to device copy
                 torch.cuda.current_stream().wait_stream(self._prefetch_stream)
 
@@ -303,7 +300,7 @@ class AutoPredictUnit(PredictUnit[TPredictData]):
             raise StopIteration
 
         if self._prefetch_stream:
-            with _get_timing_context(
+            with get_timing_context(
                 state, f"{self.__class__.__name__}.record_data_in_stream"
             ):
                 # record the batch in the current stream
@@ -319,7 +316,7 @@ class AutoPredictUnit(PredictUnit[TPredictData]):
         """Prefetch the next batch on a separate CUDA stream."""
 
         try:
-            with _get_timing_context(
+            with get_timing_context(
                 state, f"{self.__class__.__name__}.next(data_iter)"
             ):
                 next_batch = next(data_iter)
@@ -332,7 +329,7 @@ class AutoPredictUnit(PredictUnit[TPredictData]):
         )
 
         # if on cpu, self._prefetch_stream is None so the torch.cuda.stream call is a no-op
-        with torch.cuda.stream(self._prefetch_stream), _get_timing_context(
+        with torch.cuda.stream(self._prefetch_stream), get_timing_context(
             state, f"{self.__class__.__name__}.move_data_to_device"
         ):
             self._next_batch = self.move_data_to_device(
@@ -566,7 +563,7 @@ class AutoUnit(
 
         phase = state.active_phase.name.lower()
         try:
-            with _get_timing_context(
+            with get_timing_context(
                 state, f"{self.__class__.__name__}.{phase}.next(data_iter)"
             ):
                 next_batch = next(data_iter)
@@ -584,7 +581,7 @@ class AutoUnit(
         )
 
         # if on cpu, self._prefetch_stream is None so the torch.cuda.stream call is a no-op
-        with torch.cuda.stream(self._prefetch_stream), _get_timing_context(
+        with torch.cuda.stream(self._prefetch_stream), get_timing_context(
             state, f"{self.__class__.__name__}.{phase}.move_data_to_device"
         ):
             self._next_batch = self.move_data_to_device(
@@ -597,7 +594,7 @@ class AutoUnit(
             self._prefetched = True
 
         if self._prefetch_stream:
-            with _get_timing_context(state, f"{self.__class__.__name__}.wait_stream"):
+            with get_timing_context(state, f"{self.__class__.__name__}.wait_stream"):
                 # wait on the CUDA stream to complete the host to device copy
                 torch.cuda.current_stream().wait_stream(self._prefetch_stream)
 
@@ -609,7 +606,7 @@ class AutoUnit(
             raise StopIteration
 
         if self._prefetch_stream:
-            with _get_timing_context(
+            with get_timing_context(
                 state, f"{self.__class__.__name__}.record_data_in_stream"
             ):
                 # record the batch in the current stream
@@ -654,7 +651,7 @@ class AutoUnit(
         grad_scaler = self.grad_scaler
         with maybe_no_sync, maybe_detect_anomaly:
             with self.maybe_autocast_precision:
-                with _get_timing_context(
+                with get_timing_context(
                     state, f"{self.__class__.__name__}.compute_loss"
                 ):
                     # Run the forward pass and compute the loss
@@ -665,10 +662,10 @@ class AutoUnit(
 
             if grad_scaler:
                 scaled_loss = grad_scaler.scale(loss)
-                with _get_timing_context(state, f"{self.__class__.__name__}.backward"):
+                with get_timing_context(state, f"{self.__class__.__name__}.backward"):
                     scaled_loss.backward()
             else:
-                with _get_timing_context(state, f"{self.__class__.__name__}.backward"):
+                with get_timing_context(state, f"{self.__class__.__name__}.backward"):
                     loss.backward()
 
         if should_update_weights:
@@ -677,7 +674,7 @@ class AutoUnit(
             clip_grad_value = self.clip_grad_value
             if grad_scaler and (clip_grad_norm or clip_grad_value):
                 # unscale the gradients of optimizer's assigned params in-place in preparation for gradient clipping
-                with _get_timing_context(
+                with get_timing_context(
                     state, f"{self.__class__.__name__}.grad_unscale"
                 ):
                     grad_scaler.unscale_(self.optimizer)
@@ -686,7 +683,7 @@ class AutoUnit(
             if clip_grad_norm:
                 if _is_fsdp_module(module):
                     if isinstance(module, FSDP):
-                        with _get_timing_context(
+                        with get_timing_context(
                             state, f"{self.__class__.__name__}.clip_grad_norm"
                         ):
                             module.clip_grad_norm_(max_norm=clip_grad_norm)
@@ -695,7 +692,7 @@ class AutoUnit(
                             "Composable FSDP clip_grad_norm is not yet implemented: https://github.com/pytorch/pytorch/issues/97271"
                         )
                 else:
-                    with _get_timing_context(
+                    with get_timing_context(
                         state, f"{self.__class__.__name__}.clip_grad_norm"
                     ):
                         torch.nn.utils.clip_grad_norm_(
@@ -705,7 +702,7 @@ class AutoUnit(
 
             # gradient value clipping
             if clip_grad_value:
-                with _get_timing_context(
+                with get_timing_context(
                     state, f"{self.__class__.__name__}.clip_grad_value"
                 ):
                     torch.nn.utils.clip_grad_value_(
@@ -713,9 +710,7 @@ class AutoUnit(
                         clip_value=clip_grad_value,
                     )
 
-            with _get_timing_context(
-                state, f"{self.__class__.__name__}.optimizer_step"
-            ):
+            with get_timing_context(state, f"{self.__class__.__name__}.optimizer_step"):
                 if grad_scaler:
                     grad_scaler.step(self.optimizer)
                     # update the scale for next iteration
@@ -724,7 +719,7 @@ class AutoUnit(
                     self.optimizer.step()
 
             # sets gradients to zero
-            with _get_timing_context(
+            with get_timing_context(
                 state, f"{self.__class__.__name__}.optimizer_zero_grad"
             ):
                 self.optimizer.zero_grad(set_to_none=True)
@@ -737,15 +732,14 @@ class AutoUnit(
             ):
                 lr_scheduler = self.lr_scheduler
                 if lr_scheduler and self.step_lr_interval == "step":
-                    with _get_timing_context(
+                    with get_timing_context(
                         state, f"{self.__class__.__name__}.lr_scheduler_step"
                     ):
                         lr_scheduler.step()
 
         step = self.train_progress.num_steps_completed
         # users can override this, by default this is a no-op
-        with _get_timing_context(state, f"{self.__class__.__name__}.on_train_step_end"):
-            self.on_train_step_end(state, batch, step, loss, outputs)
+        self.on_train_step_end(state, batch, step, loss, outputs)
         return loss, outputs
 
     def on_train_step_end(
@@ -773,17 +767,17 @@ class AutoUnit(
             and self.swa_params
             and self.train_progress.num_epochs_completed >= self.swa_params.epoch_start
         ):
-            with _get_timing_context(
+            with get_timing_context(
                 state, f"{self.__class__.__name__}.stochastic_weight_avg_update"
             ):
                 self.swa_model.update_parameters(self.module)
-            with _get_timing_context(
+            with get_timing_context(
                 state, f"{self.__class__.__name__}.stochastic_weight_avg_step"
             ):
                 none_throws(self.swa_scheduler).step()
         elif self.lr_scheduler and self.step_lr_interval == "epoch":
             # optionally step lr scheduler
-            with _get_timing_context(
+            with get_timing_context(
                 state, f"{self.__class__.__name__}.lr_scheduler_step"
             ):
                 self.lr_scheduler.step()
@@ -794,26 +788,26 @@ class AutoUnit(
         """
         swa_model = self.swa_model
         if swa_model:
-            with _get_timing_context(
+            with get_timing_context(
                 state,
                 f"{self.__class__.__name__}.stochastic_weight_avg_transfer_weights",
             ):
                 transfer_weights(swa_model, self.module)
-            with _get_timing_context(
+            with get_timing_context(
                 state,
                 f"{self.__class__.__name__}.stochastic_weight_avg_transfer_batch_norm_stats",
             ):
                 transfer_batch_norm_stats(swa_model, self.module)
 
     def eval_step(self, state: State, data: TData) -> Tuple[torch.Tensor, Any]:
-        with _get_timing_context(
+        with get_timing_context(
             state, f"{self.__class__.__name__}.move_data_to_device"
         ):
             data = self.move_data_to_device(state, data, non_blocking=False)
 
         with self.maybe_autocast_precision:
             # users must override this
-            with _get_timing_context(state, f"{self.__class__.__name__}.compute_loss"):
+            with get_timing_context(state, f"{self.__class__.__name__}.compute_loss"):
                 loss, outputs = self.compute_loss(state, data)
 
         if state.entry_point == EntryPoint.FIT:
@@ -822,8 +816,7 @@ class AutoUnit(
             step = self.eval_progress.num_steps_completed
 
         # users can override this, by default this is a no-op
-        with _get_timing_context(state, f"{self.__class__.__name__}.on_eval_step_end"):
-            self.on_eval_step_end(state, data, step, loss, outputs)
+        self.on_eval_step_end(state, data, step, loss, outputs)
         return loss, outputs
 
     def on_eval_step_end(

--- a/torchtnt/framework/callbacks/torchsnapshot_saver.py
+++ b/torchtnt/framework/callbacks/torchsnapshot_saver.py
@@ -16,7 +16,7 @@ from torchsnapshot.snapshot import PendingSnapshot, Snapshot
 from torchtnt.framework.callback import Callback
 from torchtnt.framework.state import EntryPoint, State
 from torchtnt.framework.unit import AppStateMixin, TEvalUnit, TPredictUnit, TTrainUnit
-from torchtnt.framework.utils import _construct_tracked_optimizers
+from torchtnt.framework.utils import _construct_tracked_optimizers, get_timing_context
 from torchtnt.utils.distributed import get_global_rank
 from torchtnt.utils.rank_zero_log import rank_zero_info, rank_zero_warn
 from torchtnt.utils.stateful import Stateful
@@ -127,7 +127,10 @@ class TorchSnapshotSaver(Callback):
         snapshot_path = _get_snapshot_save_path(
             self._dirpath, epoch, num_steps_completed
         )
-        self._async_snapshot(snapshot_path, app_state, wait=False)
+        with get_timing_context(
+            state, f"{self.__class__.__name__}.take_async_snapshot"
+        ):
+            self._async_snapshot(snapshot_path, app_state, wait=False)
 
     def on_train_epoch_end(self, state: State, unit: TTrainUnit) -> None:
         epoch = unit.train_progress.num_epochs_completed
@@ -140,7 +143,10 @@ class TorchSnapshotSaver(Callback):
         snapshot_path = _get_snapshot_save_path(
             self._dirpath, epoch, num_steps_completed
         )
-        self._async_snapshot(snapshot_path, app_state, wait=True)
+        with get_timing_context(
+            state, f"{self.__class__.__name__}.take_async_snapshot"
+        ):
+            self._async_snapshot(snapshot_path, app_state, wait=True)
 
     def on_train_end(self, state: State, unit: TTrainUnit) -> None:
         app_state = _get_app_state(state, unit, self._replicated, intra_epoch=False)
@@ -149,7 +155,10 @@ class TorchSnapshotSaver(Callback):
         snapshot_path = _get_snapshot_save_path(
             self._dirpath, epoch, num_steps_completed
         )
-        self._async_snapshot(snapshot_path, app_state, wait=True)
+        with get_timing_context(
+            state, f"{self.__class__.__name__}.take_async_snapshot"
+        ):
+            self._async_snapshot(snapshot_path, app_state, wait=True)
         self._wait()
 
     def on_exception(

--- a/torchtnt/framework/evaluate.py
+++ b/torchtnt/framework/evaluate.py
@@ -10,17 +10,16 @@ from typing import Iterable, List, Optional
 import torch
 from pyre_extensions import none_throws
 from torchtnt.framework._callback_handler import CallbackHandler
-from torchtnt.framework.auto_unit import AutoUnit
 from torchtnt.framework.callback import Callback
 
 from torchtnt.framework.state import ActivePhase, EntryPoint, PhaseState, State
 from torchtnt.framework.unit import TEvalData, TEvalUnit
 from torchtnt.framework.utils import (
-    _get_timing_context,
     _is_epoch_done,
     _reset_module_training_mode,
     _set_module_training_mode,
     _step_requires_iterator,
+    get_timing_context,
     log_api_usage,
 )
 from torchtnt.utils.timer import get_timer_summary, Timer
@@ -34,7 +33,7 @@ def evaluate(
     *,
     max_steps_per_epoch: Optional[int] = None,
     callbacks: Optional[List[Callback]] = None,
-    auto_timing: bool = False,
+    timer: Optional[Timer] = None,
 ) -> None:
     """
     The ``evaluate`` entry point takes in a :class:`~torchtnt.framework.EvalUnit` object, a train dataloader (any Iterable), optional arguments to modify loop execution,
@@ -45,7 +44,7 @@ def evaluate(
         eval_dataloader: dataloader to be used during evaluation, which can be *any* iterable, including PyTorch DataLoader, DataLoader2, etc.
         max_steps_per_epoch: the max number of steps to run per epoch. None means evaluate until the dataloader is exhausted.
         callbacks: an optional list of :class:`~torchtnt.framework.Callback` s.
-        auto_timing: whether to automatically time the evaluation loop, using the state's timer (enabling auto_timing may degrade performance).
+        timer: an optional Timer which will be used to time key events (using a Timer with CUDA synchronization may degrade performance).
 
 
     Below is an example of calling :py:func:`~torchtnt.framework.evaluate`.
@@ -86,7 +85,7 @@ def evaluate(
             dataloader=eval_dataloader,
             max_steps_per_epoch=max_steps_per_epoch,
         ),
-        timer=None if not auto_timing else Timer(),
+        timer=timer,
     )
     try:
         _evaluate_impl(state, eval_unit, callback_handler)
@@ -120,25 +119,20 @@ def _evaluate_impl(
     tracked_modules = eval_unit.tracked_modules()
     prior_module_train_states = _set_module_training_mode(tracked_modules, False)
 
-    with _get_timing_context(state, f"{eval_unit.__class__.__name__}.on_eval_start"):
-        eval_unit.on_eval_start(state)
+    eval_unit.on_eval_start(state)
     callback_handler.on_eval_start(state, eval_unit)
 
     # Conditionally run this to avoid running this multiple times
     # in the case of resuming from a checkpoint mid-epoch
     if eval_unit.eval_progress.num_steps_completed_in_epoch == 0:
-        with _get_timing_context(
-            state, f"{eval_unit.__class__.__name__}.on_eval_epoch_start"
-        ):
-            eval_unit.on_eval_epoch_start(state)
+        eval_unit.on_eval_epoch_start(state)
         callback_handler.on_eval_epoch_start(state, eval_unit)
 
-    with _get_timing_context(state, "evaluate.iter(dataloader)"):
+    with get_timing_context(state, "evaluate.iter(dataloader)"):
         data_iter = iter(eval_state.dataloader)
     step_input = data_iter
 
     pass_data_iter_to_step = _step_requires_iterator(eval_unit.eval_step)
-    is_auto_unit = isinstance(eval_unit, AutoUnit)
     prev_steps_in_epoch = eval_unit.eval_progress.num_steps_completed_in_epoch
 
     while not (
@@ -152,16 +146,11 @@ def _evaluate_impl(
         try:
             if not pass_data_iter_to_step:
                 # get the next batch from the data iterator
-                with _get_timing_context(state, "evaluate.next(data_iter)"):
+                with get_timing_context(state, "evaluate.next(data_iter)"):
                     step_input = next(data_iter)
+
             callback_handler.on_eval_step_start(state, eval_unit)
-            with _get_timing_context(
-                state,
-                f"{eval_unit.__class__.__name__}.eval_step",
-                skip_timer=is_auto_unit,
-                # skip timer if eval_unit is a subclass of AutoUnit because we have additional timing in the AutoUnit and all timing should be mutually exclusive
-            ):
-                eval_state._step_output = eval_unit.eval_step(state, step_input)
+            eval_state._step_output = eval_unit.eval_step(state, step_input)
 
             eval_unit.eval_progress.increment_step()
             callback_handler.on_eval_step_end(state, eval_unit)
@@ -182,14 +171,10 @@ def _evaluate_impl(
     # set progress counters for the next epoch
     eval_unit.eval_progress.increment_epoch()
 
-    with _get_timing_context(
-        state, f"{eval_unit.__class__.__name__}.on_eval_epoch_end"
-    ):
-        eval_unit.on_eval_epoch_end(state)
+    eval_unit.on_eval_epoch_end(state)
     callback_handler.on_eval_epoch_end(state, eval_unit)
 
-    with _get_timing_context(state, f"{eval_unit.__class__.__name__}.on_eval_end"):
-        eval_unit.on_eval_end(state)
+    eval_unit.on_eval_end(state)
     callback_handler.on_eval_end(state, eval_unit)
 
     # Reset training mode for modules at the end of the epoch

--- a/torchtnt/framework/fit.py
+++ b/torchtnt/framework/fit.py
@@ -36,7 +36,7 @@ def fit(
     evaluate_every_n_steps: Optional[int] = None,
     evaluate_every_n_epochs: Optional[int] = 1,
     callbacks: Optional[List[Callback]] = None,
-    auto_timing: bool = False,
+    timer: Optional[Timer] = None,
 ) -> None:
     """
     The ``fit`` entry point interleaves training and evaluation loops. The ``fit`` entry point takes in an object which subclasses both :class:`~torchtnt.framework.TrainUnit` and :class:`~torchtnt.framework.EvalUnit`, train and eval dataloaders (any Iterables), optional arguments to modify loop execution,
@@ -54,7 +54,7 @@ def fit(
         evaluate_every_n_steps: how often to run the evaluation loop in terms of training steps.
         evaluate_every_n_epochs: how often to run the evaluation loop in terms of training epochs.
         callbacks: an optional list of callbacks.
-        auto_timing: whether to automatically time the training and evaluation loop, using the state's timer (enabling auto_timing may degrade performance).
+        timer: an optional Timer which will be used to time key events (using a Timer with CUDA synchronization may degrade performance).
 
     Below is an example of calling :py:func:`~torchtnt.framework.fit`.
 
@@ -115,7 +115,7 @@ def fit(
             evaluate_every_n_steps=evaluate_every_n_steps,
             evaluate_every_n_epochs=evaluate_every_n_epochs,
         ),
-        timer=None if not auto_timing else Timer(),
+        timer=timer,
     )
 
     logger.info(

--- a/torchtnt/framework/train.py
+++ b/torchtnt/framework/train.py
@@ -158,11 +158,6 @@ def _train_epoch_impl(
     logger.info("Started train epoch")
     state._active_phase = ActivePhase.TRAIN
 
-    # Set all modules to train() mode
-    # access modules made available through AppStateMixin
-    tracked_modules = train_unit.tracked_modules()
-    prior_module_train_states = _set_module_training_mode(tracked_modules, True)
-
     train_state = none_throws(state.train_state)
 
     evaluate_every_n_steps = None
@@ -275,10 +270,5 @@ def _train_epoch_impl(
             callback_handler,
         )
         state._active_phase = ActivePhase.TRAIN
-
-    # Reset training mode for modules at the end of the epoch
-    # This ensures that side-effects made by the loop are reset before
-    # returning back to the user
-    _reset_module_training_mode(tracked_modules, prior_module_train_states)
 
     logger.info("Ended train epoch")

--- a/torchtnt/framework/utils.py
+++ b/torchtnt/framework/utils.py
@@ -92,11 +92,17 @@ def _reset_module_training_mode(
 
 @contextmanager
 # pyre-fixme[3]: Return type must be annotated.
-def _get_timing_context(state: State, event_name: str, skip_timer: bool = False):
-    """Returns a context manager that records an event to a :class:`~torchtnt.utils.timer.Timer` and to PyTorch Profiler."""
+def get_timing_context(state: State, event_name: str):
+    """
+    Returns a context manager that records an event to a :class:`~torchtnt.utils.timer.Timer` and to PyTorch Profiler.
+
+    Args:
+        state: an instance of :class:`~torchtnt.framework.State`
+        event_name: string identifier to use for timing
+    """
     timer_context = (
         state.timer.time(event_name)
-        if state.timer and not skip_timer
+        if state.timer is not None
         else contextlib.nullcontext()
     )
     profiler_context = record_function(event_name)


### PR DESCRIPTION
Summary:
Users are now expected to pass in a Timer themselves, and to time their own code using `state.timer.time()` or `get_timing_context`, which we expose as a public function in this diff.

We time the code in the AutoUnit and the built-in callbacks for the user.

Differential Revision: D47523530

