### PR TITLE
Make get_timing_context a public function

### DIFF
--- a/tests/framework/test_utils.py
+++ b/tests/framework/test_utils.py
@@ -31,7 +31,6 @@ from torchtnt.framework.utils import (
     _construct_tracked_optimizers_and_schedulers,
     _find_optimizers_for_module,
     _FSDPOptimizerWrapper,
-    _get_timing_context,
     _is_done,
     _is_epoch_done,
     _is_fsdp_module,
@@ -39,6 +38,7 @@ from torchtnt.framework.utils import (
     _reset_module_training_mode,
     _set_module_training_mode,
     _step_requires_iterator,
+    get_timing_context,
 )
 from torchtnt.utils.env import init_from_env
 from torchtnt.utils.lr_scheduler import TLRScheduler
@@ -202,20 +202,20 @@ class UtilsTest(unittest.TestCase):
         state = MagicMock()
         state.timer = None
 
-        ctx = _get_timing_context(state, "a")
+        ctx = get_timing_context(state, "a")
         with ctx:
             time.sleep(1)
         mock_record_function.assert_called_with("a")
 
         state.timer = Timer()
-        ctx = _get_timing_context(state, "b")
+        ctx = get_timing_context(state, "b")
         with ctx:
             time.sleep(1)
         self.assertTrue("b" in state.timer.recorded_durations.keys())
         mock_record_function.assert_called_with("b")
 
         state.timer = Timer()
-        ctx = _get_timing_context(state, "c", skip_timer=True)
+        ctx = get_timing_context(state, "c", skip_timer=True)
         with ctx:
             time.sleep(1)
         # "c" should not be in the recorded_durations because we set skip_timer to True

--- a/torchtnt/framework/_callback_handler.py
+++ b/torchtnt/framework/_callback_handler.py
@@ -12,7 +12,7 @@ from unittest.mock import Mock
 from torchtnt.framework.callback import Callback
 from torchtnt.framework.state import State
 from torchtnt.framework.unit import TEvalUnit, TPredictUnit, TTrainUnit
-from torchtnt.framework.utils import _get_timing_context
+from torchtnt.framework.utils import get_timing_context
 
 logger: logging.Logger = logging.getLogger(__name__)
 
@@ -109,131 +109,131 @@ class CallbackHandler:
         fn_name = "on_exception"
         callbacks = self._callbacks.get(fn_name, [])
         for cb in callbacks:
-            with _get_timing_context(state, f"{cb.name}.{fn_name}"):
+            with get_timing_context(state, f"{cb.name}.{fn_name}"):
                 cb.on_exception(state, unit, exc)
 
     def on_train_start(self, state: State, unit: TTrainUnit) -> None:
         fn_name = "on_train_start"
         callbacks = self._callbacks.get(fn_name, [])
         for cb in callbacks:
-            with _get_timing_context(state, f"{cb.name}.{fn_name}"):
+            with get_timing_context(state, f"{cb.name}.{fn_name}"):
                 cb.on_train_start(state, unit)
 
     def on_train_epoch_start(self, state: State, unit: TTrainUnit) -> None:
         fn_name = "on_train_epoch_start"
         callbacks = self._callbacks.get(fn_name, [])
         for cb in callbacks:
-            with _get_timing_context(state, f"{cb.name}.{fn_name}"):
+            with get_timing_context(state, f"{cb.name}.{fn_name}"):
                 cb.on_train_epoch_start(state, unit)
 
     def on_train_step_start(self, state: State, unit: TTrainUnit) -> None:
         fn_name = "on_train_step_start"
         callbacks = self._callbacks.get(fn_name, [])
         for cb in callbacks:
-            with _get_timing_context(state, f"{cb.name}.{fn_name}"):
+            with get_timing_context(state, f"{cb.name}.{fn_name}"):
                 cb.on_train_step_start(state, unit)
 
     def on_train_step_end(self, state: State, unit: TTrainUnit) -> None:
         fn_name = "on_train_step_end"
         callbacks = self._callbacks.get(fn_name, [])
         for cb in callbacks:
-            with _get_timing_context(state, f"{cb.name}.{fn_name}"):
+            with get_timing_context(state, f"{cb.name}.{fn_name}"):
                 cb.on_train_step_end(state, unit)
 
     def on_train_epoch_end(self, state: State, unit: TTrainUnit) -> None:
         fn_name = "on_train_epoch_end"
         callbacks = self._callbacks.get(fn_name, [])
         for cb in callbacks:
-            with _get_timing_context(state, f"{cb.name}.{fn_name}"):
+            with get_timing_context(state, f"{cb.name}.{fn_name}"):
                 cb.on_train_epoch_end(state, unit)
 
     def on_train_end(self, state: State, unit: TTrainUnit) -> None:
         fn_name = "on_train_end"
         callbacks = self._callbacks.get(fn_name, [])
         for cb in callbacks:
-            with _get_timing_context(state, f"{cb.name}.{fn_name}"):
+            with get_timing_context(state, f"{cb.name}.{fn_name}"):
                 cb.on_train_end(state, unit)
 
     def on_eval_start(self, state: State, unit: TEvalUnit) -> None:
         fn_name = "on_eval_start"
         callbacks = self._callbacks.get(fn_name, [])
         for cb in callbacks:
-            with _get_timing_context(state, f"{cb.name}.{fn_name}"):
+            with get_timing_context(state, f"{cb.name}.{fn_name}"):
                 cb.on_eval_start(state, unit)
 
     def on_eval_epoch_start(self, state: State, unit: TEvalUnit) -> None:
         fn_name = "on_eval_epoch_start"
         callbacks = self._callbacks.get(fn_name, [])
         for cb in callbacks:
-            with _get_timing_context(state, f"{cb.name}.{fn_name}"):
+            with get_timing_context(state, f"{cb.name}.{fn_name}"):
                 cb.on_eval_epoch_start(state, unit)
 
     def on_eval_step_start(self, state: State, unit: TEvalUnit) -> None:
         fn_name = "on_eval_step_start"
         callbacks = self._callbacks.get(fn_name, [])
         for cb in callbacks:
-            with _get_timing_context(state, f"{cb.name}.{fn_name}"):
+            with get_timing_context(state, f"{cb.name}.{fn_name}"):
                 cb.on_eval_step_start(state, unit)
 
     def on_eval_step_end(self, state: State, unit: TEvalUnit) -> None:
         fn_name = "on_eval_step_end"
         callbacks = self._callbacks.get(fn_name, [])
         for cb in callbacks:
-            with _get_timing_context(state, f"{cb.name}.{fn_name}"):
+            with get_timing_context(state, f"{cb.name}.{fn_name}"):
                 cb.on_eval_step_end(state, unit)
 
     def on_eval_epoch_end(self, state: State, unit: TEvalUnit) -> None:
         fn_name = "on_eval_epoch_end"
         callbacks = self._callbacks.get(fn_name, [])
         for cb in callbacks:
-            with _get_timing_context(state, f"{cb.name}.{fn_name}"):
+            with get_timing_context(state, f"{cb.name}.{fn_name}"):
                 cb.on_eval_epoch_end(state, unit)
 
     def on_eval_end(self, state: State, unit: TEvalUnit) -> None:
         fn_name = "on_eval_end"
         callbacks = self._callbacks.get(fn_name, [])
         for cb in callbacks:
-            with _get_timing_context(state, f"{cb.name}.{fn_name}"):
+            with get_timing_context(state, f"{cb.name}.{fn_name}"):
                 cb.on_eval_end(state, unit)
 
     def on_predict_start(self, state: State, unit: TPredictUnit) -> None:
         fn_name = "on_predict_start"
         callbacks = self._callbacks.get(fn_name, [])
         for cb in callbacks:
-            with _get_timing_context(state, f"{cb.name}.{fn_name}"):
+            with get_timing_context(state, f"{cb.name}.{fn_name}"):
                 cb.on_predict_start(state, unit)
 
     def on_predict_epoch_start(self, state: State, unit: TPredictUnit) -> None:
         fn_name = "on_predict_epoch_start"
         callbacks = self._callbacks.get(fn_name, [])
         for cb in callbacks:
-            with _get_timing_context(state, f"{cb.name}.{fn_name}"):
+            with get_timing_context(state, f"{cb.name}.{fn_name}"):
                 cb.on_predict_epoch_start(state, unit)
 
     def on_predict_step_start(self, state: State, unit: TPredictUnit) -> None:
         fn_name = "on_predict_step_start"
         callbacks = self._callbacks.get(fn_name, [])
         for cb in callbacks:
-            with _get_timing_context(state, f"{cb.name}.{fn_name}"):
+            with get_timing_context(state, f"{cb.name}.{fn_name}"):
                 cb.on_predict_step_start(state, unit)
 
     def on_predict_step_end(self, state: State, unit: TPredictUnit) -> None:
         fn_name = "on_predict_step_end"
         callbacks = self._callbacks.get(fn_name, [])
         for cb in callbacks:
-            with _get_timing_context(state, f"{cb.name}.{fn_name}"):
+            with get_timing_context(state, f"{cb.name}.{fn_name}"):
                 cb.on_predict_step_end(state, unit)
 
     def on_predict_epoch_end(self, state: State, unit: TPredictUnit) -> None:
         fn_name = "on_predict_epoch_end"
         callbacks = self._callbacks.get(fn_name, [])
         for cb in callbacks:
-            with _get_timing_context(state, f"{cb.name}.{fn_name}"):
+            with get_timing_context(state, f"{cb.name}.{fn_name}"):
                 cb.on_predict_epoch_end(state, unit)
 
     def on_predict_end(self, state: State, unit: TPredictUnit) -> None:
         fn_name = "on_predict_end"
         callbacks = self._callbacks.get(fn_name, [])
         for cb in callbacks:
-            with _get_timing_context(state, f"{cb.name}.{fn_name}"):
+            with get_timing_context(state, f"{cb.name}.{fn_name}"):
                 cb.on_predict_end(state, unit)

--- a/torchtnt/framework/evaluate.py
+++ b/torchtnt/framework/evaluate.py
@@ -16,11 +16,11 @@ from torchtnt.framework.callback import Callback
 from torchtnt.framework.state import ActivePhase, EntryPoint, PhaseState, State
 from torchtnt.framework.unit import TEvalData, TEvalUnit
 from torchtnt.framework.utils import (
-    _get_timing_context,
     _is_epoch_done,
     _reset_module_training_mode,
     _set_module_training_mode,
     _step_requires_iterator,
+    get_timing_context,
     log_api_usage,
 )
 from torchtnt.utils.timer import get_timer_summary, Timer
@@ -120,20 +120,20 @@ def _evaluate_impl(
     tracked_modules = eval_unit.tracked_modules()
     prior_module_train_states = _set_module_training_mode(tracked_modules, False)
 
-    with _get_timing_context(state, f"{eval_unit.__class__.__name__}.on_eval_start"):
+    with get_timing_context(state, f"{eval_unit.__class__.__name__}.on_eval_start"):
         eval_unit.on_eval_start(state)
     callback_handler.on_eval_start(state, eval_unit)
 
     # Conditionally run this to avoid running this multiple times
     # in the case of resuming from a checkpoint mid-epoch
     if eval_unit.eval_progress.num_steps_completed_in_epoch == 0:
-        with _get_timing_context(
+        with get_timing_context(
             state, f"{eval_unit.__class__.__name__}.on_eval_epoch_start"
         ):
             eval_unit.on_eval_epoch_start(state)
         callback_handler.on_eval_epoch_start(state, eval_unit)
 
-    with _get_timing_context(state, "evaluate.iter(dataloader)"):
+    with get_timing_context(state, "evaluate.iter(dataloader)"):
         data_iter = iter(eval_state.dataloader)
     step_input = data_iter
 
@@ -152,10 +152,10 @@ def _evaluate_impl(
         try:
             if not pass_data_iter_to_step:
                 # get the next batch from the data iterator
-                with _get_timing_context(state, "evaluate.next(data_iter)"):
+                with get_timing_context(state, "evaluate.next(data_iter)"):
                     step_input = next(data_iter)
             callback_handler.on_eval_step_start(state, eval_unit)
-            with _get_timing_context(
+            with get_timing_context(
                 state,
                 f"{eval_unit.__class__.__name__}.eval_step",
                 skip_timer=is_auto_unit,
@@ -182,13 +182,11 @@ def _evaluate_impl(
     # set progress counters for the next epoch
     eval_unit.eval_progress.increment_epoch()
 
-    with _get_timing_context(
-        state, f"{eval_unit.__class__.__name__}.on_eval_epoch_end"
-    ):
+    with get_timing_context(state, f"{eval_unit.__class__.__name__}.on_eval_epoch_end"):
         eval_unit.on_eval_epoch_end(state)
     callback_handler.on_eval_epoch_end(state, eval_unit)
 
-    with _get_timing_context(state, f"{eval_unit.__class__.__name__}.on_eval_end"):
+    with get_timing_context(state, f"{eval_unit.__class__.__name__}.on_eval_end"):
         eval_unit.on_eval_end(state)
     callback_handler.on_eval_end(state, eval_unit)
 

--- a/torchtnt/framework/utils.py
+++ b/torchtnt/framework/utils.py
@@ -92,8 +92,14 @@ def _reset_module_training_mode(
 
 @contextmanager
 # pyre-fixme[3]: Return type must be annotated.
-def _get_timing_context(state: State, event_name: str, skip_timer: bool = False):
-    """Returns a context manager that records an event to a :class:`~torchtnt.utils.timer.Timer` and to PyTorch Profiler."""
+def get_timing_context(state: State, event_name: str, skip_timer: bool = False):
+    """
+    Returns a context manager that records an event to a :class:`~torchtnt.utils.timer.Timer` and to PyTorch Profiler.
+
+    Args:
+        state: an instance of :class:`~torchtnt.framework.State`
+        event_name: string identifier to use for timing
+    """
     timer_context = (
         state.timer.time(event_name)
         if state.timer and not skip_timer


### PR DESCRIPTION
Summary: This will allow users to call this function directly to time their code when using the framework

Differential Revision: D47658498

