### PR TITLE
Remove auto-timing of hooks + add timing for logic in callbacks

### DIFF
--- a/tests/framework/test_callback_handler.py
+++ b/tests/framework/test_callback_handler.py
@@ -105,119 +105,71 @@ class CallbackHandlerTest(unittest.TestCase):
 
         cb_handler.on_exception(state, unit, ValueError("test"))
         self.assertIn("on_exception", called_hooks)
-        self.assertIn("DummyCallback.on_exception", timer.recorded_durations.keys())
 
         cb_handler.on_train_start(state, unit)
         self.assertIn("on_train_start", called_hooks)
-        self.assertIn("DummyCallback.on_train_start", timer.recorded_durations.keys())
 
         cb_handler.on_train_epoch_start(state, unit)
         self.assertIn("on_train_epoch_start", called_hooks)
-        self.assertIn(
-            "DummyCallback.on_train_epoch_start", timer.recorded_durations.keys()
-        )
 
         cb_handler.on_train_step_start(state, unit)
         self.assertIn("on_train_step_start", called_hooks)
-        self.assertIn(
-            "DummyCallback.on_train_step_start", timer.recorded_durations.keys()
-        )
 
         cb_handler.on_train_step_end(state, unit)
         self.assertIn("on_train_step_end", called_hooks)
-        self.assertIn(
-            "DummyCallback.on_train_step_end", timer.recorded_durations.keys()
-        )
 
         cb_handler.on_train_step_end(state, unit)
         self.assertIn("on_train_step_end", called_hooks)
-        self.assertIn(
-            "DummyCallback.on_train_step_end", timer.recorded_durations.keys()
-        )
 
         cb_handler.on_train_epoch_end(state, unit)
         self.assertIn("on_train_epoch_end", called_hooks)
-        self.assertIn(
-            "DummyCallback.on_train_epoch_end", timer.recorded_durations.keys()
-        )
 
         cb_handler.on_train_end(state, unit)
         self.assertIn("on_train_end", called_hooks)
-        self.assertIn("DummyCallback.on_train_end", timer.recorded_durations.keys())
 
         unit = MagicMock(spec=TEvalUnit)
         cb_handler.on_eval_start(state, unit)
         self.assertIn("on_eval_start", called_hooks)
-        self.assertIn("DummyCallback.on_eval_start", timer.recorded_durations.keys())
 
         cb_handler.on_eval_epoch_start(state, unit)
         self.assertIn("on_eval_epoch_start", called_hooks)
-        self.assertIn(
-            "DummyCallback.on_eval_epoch_start", timer.recorded_durations.keys()
-        )
 
         cb_handler.on_eval_step_start(state, unit)
         self.assertIn("on_eval_step_start", called_hooks)
-        self.assertIn(
-            "DummyCallback.on_eval_step_start", timer.recorded_durations.keys()
-        )
 
         cb_handler.on_eval_step_end(state, unit)
         self.assertIn("on_eval_step_end", called_hooks)
-        self.assertIn("DummyCallback.on_eval_step_end", timer.recorded_durations.keys())
 
         cb_handler.on_eval_step_end(state, unit)
         self.assertIn("on_eval_step_end", called_hooks)
-        self.assertIn("DummyCallback.on_eval_step_end", timer.recorded_durations.keys())
 
         cb_handler.on_eval_epoch_end(state, unit)
         self.assertIn("on_eval_epoch_end", called_hooks)
-        self.assertIn(
-            "DummyCallback.on_eval_epoch_end", timer.recorded_durations.keys()
-        )
 
         cb_handler.on_eval_end(state, unit)
         self.assertIn("on_eval_end", called_hooks)
-        self.assertIn("DummyCallback.on_eval_end", timer.recorded_durations.keys())
 
         unit = MagicMock(spec=TPredictUnit)
         cb_handler.on_predict_start(state, unit)
         self.assertIn("on_predict_start", called_hooks)
-        self.assertIn("DummyCallback.on_predict_start", timer.recorded_durations.keys())
 
         cb_handler.on_predict_epoch_start(state, unit)
         self.assertIn("on_predict_epoch_start", called_hooks)
-        self.assertIn(
-            "DummyCallback.on_predict_epoch_start", timer.recorded_durations.keys()
-        )
 
         cb_handler.on_predict_step_start(state, unit)
         self.assertIn("on_predict_step_start", called_hooks)
-        self.assertIn(
-            "DummyCallback.on_predict_step_start", timer.recorded_durations.keys()
-        )
 
         cb_handler.on_predict_step_end(state, unit)
         self.assertIn("on_predict_step_end", called_hooks)
-        self.assertIn(
-            "DummyCallback.on_predict_step_end", timer.recorded_durations.keys()
-        )
 
         cb_handler.on_predict_step_end(state, unit)
         self.assertIn("on_predict_step_end", called_hooks)
-        self.assertIn(
-            "DummyCallback.on_predict_step_end", timer.recorded_durations.keys()
-        )
 
         cb_handler.on_predict_epoch_end(state, unit)
         self.assertIn("on_predict_epoch_end", called_hooks)
-        self.assertIn(
-            "DummyCallback.on_predict_epoch_end", timer.recorded_durations.keys()
-        )
 
         cb_handler.on_predict_end(state, unit)
         self.assertIn("on_predict_end", called_hooks)
-        self.assertIn("DummyCallback.on_predict_end", timer.recorded_durations.keys())
 
     def test_get_implemented_callback_mapping(self) -> None:
         callbacks = []

--- a/tests/framework/test_evaluate.py
+++ b/tests/framework/test_evaluate.py
@@ -208,14 +208,9 @@ class TimingEvalUnit(EvalUnit[Batch]):
         inputs, _ = data
         outputs = self.module(inputs)
 
-        if self.eval_progress.num_steps_completed == 1:
-            tc = unittest.TestCase()
-            for k in (
-                "TimingEvalUnit.on_eval_start",
-                "TimingEvalUnit.on_eval_epoch_start",
-                "evaluate.next(data_iter)",
-                "TimingEvalUnit.eval_step",
-            ):
-                tc.assertTrue(k in state.timer.recorded_durations.keys())
+        tc = unittest.TestCase()
+        tc.assertTrue(
+            "evaluate.next(data_iter)" in state.timer.recorded_durations.keys()
+        )
 
         return outputs

--- a/tests/framework/test_fit.py
+++ b/tests/framework/test_fit.py
@@ -337,15 +337,12 @@ class TimingFitUnit(TrainUnit[Batch], EvalUnit[Batch]):
     def train_step(self, state: State, data: Batch) -> torch.Tensor:
         inputs, _ = data
         outputs = self.module(inputs)
-
         tc = unittest.TestCase()
-        for k in (
-            "TimingFitUnit.on_train_start",
-            "TimingFitUnit.on_train_epoch_start",
-        ):
-            tc.assertTrue(k in state.timer.recorded_durations.keys())
-
+        tc.assertTrue("train.next(data_iter)" in state.timer.recorded_durations.keys())
         return outputs
 
     def eval_step(self, state: State, data: Batch) -> None:
-        pass
+        tc = unittest.TestCase()
+        tc.assertTrue(
+            "evaluate.next(data_iter)" in state.timer.recorded_durations.keys()
+        )

--- a/tests/framework/test_predict.py
+++ b/tests/framework/test_predict.py
@@ -218,12 +218,8 @@ class TimingPredictUnit(PredictUnit[Batch]):
 
         if self.predict_progress.num_steps_completed == 1:
             tc = unittest.TestCase()
-            for k in (
-                "TimingPredictUnit.on_predict_start",
-                "TimingPredictUnit.on_predict_epoch_start",
-                "predict.next(data_iter)",
-                "TimingPredictUnit.predict_step",
-            ):
-                tc.assertTrue(k in state.timer.recorded_durations.keys())
+            tc.assertTrue(
+                "predict.next(data_iter)" in state.timer.recorded_durations.keys()
+            )
 
         return outputs

--- a/tests/framework/test_train.py
+++ b/tests/framework/test_train.py
@@ -266,14 +266,7 @@ class TimingTrainUnit(TrainUnit[Batch]):
         inputs, _ = data
         outputs = self.module(inputs)
 
-        if self.train_progress.num_steps_completed == 1:
-            tc = unittest.TestCase()
-            for k in (
-                "TimingTrainUnit.on_train_start",
-                "TimingTrainUnit.on_train_epoch_start",
-                "train.next(data_iter)",
-                "TimingTrainUnit.train_step",
-            ):
-                tc.assertTrue(k in state.timer.recorded_durations.keys())
+        tc = unittest.TestCase()
+        tc.assertTrue("train.next(data_iter)" in state.timer.recorded_durations.keys())
 
         return outputs

--- a/tests/framework/test_utils.py
+++ b/tests/framework/test_utils.py
@@ -214,14 +214,6 @@ class UtilsTest(unittest.TestCase):
         self.assertTrue("b" in state.timer.recorded_durations.keys())
         mock_record_function.assert_called_with("b")
 
-        state.timer = Timer()
-        ctx = get_timing_context(state, "c", skip_timer=True)
-        with ctx:
-            time.sleep(1)
-        # "c" should not be in the recorded_durations because we set skip_timer to True
-        self.assertFalse("c" in state.timer.recorded_durations.keys())
-        mock_record_function.assert_called_with("c")
-
     def test_find_optimizers_for_module(self) -> None:
         module1 = torch.nn.Linear(10, 10)
         module2 = torch.nn.Linear(10, 10)

--- a/tests/framework/test_utils.py
+++ b/tests/framework/test_utils.py
@@ -31,7 +31,6 @@ from torchtnt.framework.utils import (
     _construct_tracked_optimizers_and_schedulers,
     _find_optimizers_for_module,
     _FSDPOptimizerWrapper,
-    _get_timing_context,
     _is_done,
     _is_epoch_done,
     _is_fsdp_module,
@@ -39,6 +38,7 @@ from torchtnt.framework.utils import (
     _reset_module_training_mode,
     _set_module_training_mode,
     _step_requires_iterator,
+    get_timing_context,
 )
 from torchtnt.utils.env import init_from_env
 from torchtnt.utils.lr_scheduler import TLRScheduler
@@ -202,20 +202,20 @@ class UtilsTest(unittest.TestCase):
         state = MagicMock()
         state.timer = None
 
-        ctx = _get_timing_context(state, "a")
+        ctx = get_timing_context(state, "a")
         with ctx:
             time.sleep(1)
         mock_record_function.assert_called_with("a")
 
         state.timer = Timer()
-        ctx = _get_timing_context(state, "b")
+        ctx = get_timing_context(state, "b")
         with ctx:
             time.sleep(1)
         self.assertTrue("b" in state.timer.recorded_durations.keys())
         mock_record_function.assert_called_with("b")
 
         state.timer = Timer()
-        ctx = _get_timing_context(state, "c", skip_timer=True)
+        ctx = get_timing_context(state, "c", skip_timer=True)
         with ctx:
             time.sleep(1)
         # "c" should not be in the recorded_durations because we set skip_timer to True

--- a/torchtnt/framework/_callback_handler.py
+++ b/torchtnt/framework/_callback_handler.py
@@ -12,7 +12,7 @@ from unittest.mock import Mock
 from torchtnt.framework.callback import Callback
 from torchtnt.framework.state import State
 from torchtnt.framework.unit import TEvalUnit, TPredictUnit, TTrainUnit
-from torchtnt.framework.utils import _get_timing_context
+from torchtnt.framework.utils import get_timing_context
 
 logger: logging.Logger = logging.getLogger(__name__)
 
@@ -109,131 +109,131 @@ class CallbackHandler:
         fn_name = "on_exception"
         callbacks = self._callbacks.get(fn_name, [])
         for cb in callbacks:
-            with _get_timing_context(state, f"{cb.name}.{fn_name}"):
+            with get_timing_context(state, f"{cb.name}.{fn_name}"):
                 cb.on_exception(state, unit, exc)
 
     def on_train_start(self, state: State, unit: TTrainUnit) -> None:
         fn_name = "on_train_start"
         callbacks = self._callbacks.get(fn_name, [])
         for cb in callbacks:
-            with _get_timing_context(state, f"{cb.name}.{fn_name}"):
+            with get_timing_context(state, f"{cb.name}.{fn_name}"):
                 cb.on_train_start(state, unit)
 
     def on_train_epoch_start(self, state: State, unit: TTrainUnit) -> None:
         fn_name = "on_train_epoch_start"
         callbacks = self._callbacks.get(fn_name, [])
         for cb in callbacks:
-            with _get_timing_context(state, f"{cb.name}.{fn_name}"):
+            with get_timing_context(state, f"{cb.name}.{fn_name}"):
                 cb.on_train_epoch_start(state, unit)
 
     def on_train_step_start(self, state: State, unit: TTrainUnit) -> None:
         fn_name = "on_train_step_start"
         callbacks = self._callbacks.get(fn_name, [])
         for cb in callbacks:
-            with _get_timing_context(state, f"{cb.name}.{fn_name}"):
+            with get_timing_context(state, f"{cb.name}.{fn_name}"):
                 cb.on_train_step_start(state, unit)
 
     def on_train_step_end(self, state: State, unit: TTrainUnit) -> None:
         fn_name = "on_train_step_end"
         callbacks = self._callbacks.get(fn_name, [])
         for cb in callbacks:
-            with _get_timing_context(state, f"{cb.name}.{fn_name}"):
+            with get_timing_context(state, f"{cb.name}.{fn_name}"):
                 cb.on_train_step_end(state, unit)
 
     def on_train_epoch_end(self, state: State, unit: TTrainUnit) -> None:
         fn_name = "on_train_epoch_end"
         callbacks = self._callbacks.get(fn_name, [])
         for cb in callbacks:
-            with _get_timing_context(state, f"{cb.name}.{fn_name}"):
+            with get_timing_context(state, f"{cb.name}.{fn_name}"):
                 cb.on_train_epoch_end(state, unit)
 
     def on_train_end(self, state: State, unit: TTrainUnit) -> None:
         fn_name = "on_train_end"
         callbacks = self._callbacks.get(fn_name, [])
         for cb in callbacks:
-            with _get_timing_context(state, f"{cb.name}.{fn_name}"):
+            with get_timing_context(state, f"{cb.name}.{fn_name}"):
                 cb.on_train_end(state, unit)
 
     def on_eval_start(self, state: State, unit: TEvalUnit) -> None:
         fn_name = "on_eval_start"
         callbacks = self._callbacks.get(fn_name, [])
         for cb in callbacks:
-            with _get_timing_context(state, f"{cb.name}.{fn_name}"):
+            with get_timing_context(state, f"{cb.name}.{fn_name}"):
                 cb.on_eval_start(state, unit)
 
     def on_eval_epoch_start(self, state: State, unit: TEvalUnit) -> None:
         fn_name = "on_eval_epoch_start"
         callbacks = self._callbacks.get(fn_name, [])
         for cb in callbacks:
-            with _get_timing_context(state, f"{cb.name}.{fn_name}"):
+            with get_timing_context(state, f"{cb.name}.{fn_name}"):
                 cb.on_eval_epoch_start(state, unit)
 
     def on_eval_step_start(self, state: State, unit: TEvalUnit) -> None:
         fn_name = "on_eval_step_start"
         callbacks = self._callbacks.get(fn_name, [])
         for cb in callbacks:
-            with _get_timing_context(state, f"{cb.name}.{fn_name}"):
+            with get_timing_context(state, f"{cb.name}.{fn_name}"):
                 cb.on_eval_step_start(state, unit)
 
     def on_eval_step_end(self, state: State, unit: TEvalUnit) -> None:
         fn_name = "on_eval_step_end"
         callbacks = self._callbacks.get(fn_name, [])
         for cb in callbacks:
-            with _get_timing_context(state, f"{cb.name}.{fn_name}"):
+            with get_timing_context(state, f"{cb.name}.{fn_name}"):
                 cb.on_eval_step_end(state, unit)
 
     def on_eval_epoch_end(self, state: State, unit: TEvalUnit) -> None:
         fn_name = "on_eval_epoch_end"
         callbacks = self._callbacks.get(fn_name, [])
         for cb in callbacks:
-            with _get_timing_context(state, f"{cb.name}.{fn_name}"):
+            with get_timing_context(state, f"{cb.name}.{fn_name}"):
                 cb.on_eval_epoch_end(state, unit)
 
     def on_eval_end(self, state: State, unit: TEvalUnit) -> None:
         fn_name = "on_eval_end"
         callbacks = self._callbacks.get(fn_name, [])
         for cb in callbacks:
-            with _get_timing_context(state, f"{cb.name}.{fn_name}"):
+            with get_timing_context(state, f"{cb.name}.{fn_name}"):
                 cb.on_eval_end(state, unit)
 
     def on_predict_start(self, state: State, unit: TPredictUnit) -> None:
         fn_name = "on_predict_start"
         callbacks = self._callbacks.get(fn_name, [])
         for cb in callbacks:
-            with _get_timing_context(state, f"{cb.name}.{fn_name}"):
+            with get_timing_context(state, f"{cb.name}.{fn_name}"):
                 cb.on_predict_start(state, unit)
 
     def on_predict_epoch_start(self, state: State, unit: TPredictUnit) -> None:
         fn_name = "on_predict_epoch_start"
         callbacks = self._callbacks.get(fn_name, [])
         for cb in callbacks:
-            with _get_timing_context(state, f"{cb.name}.{fn_name}"):
+            with get_timing_context(state, f"{cb.name}.{fn_name}"):
                 cb.on_predict_epoch_start(state, unit)
 
     def on_predict_step_start(self, state: State, unit: TPredictUnit) -> None:
         fn_name = "on_predict_step_start"
         callbacks = self._callbacks.get(fn_name, [])
         for cb in callbacks:
-            with _get_timing_context(state, f"{cb.name}.{fn_name}"):
+            with get_timing_context(state, f"{cb.name}.{fn_name}"):
                 cb.on_predict_step_start(state, unit)
 
     def on_predict_step_end(self, state: State, unit: TPredictUnit) -> None:
         fn_name = "on_predict_step_end"
         callbacks = self._callbacks.get(fn_name, [])
         for cb in callbacks:
-            with _get_timing_context(state, f"{cb.name}.{fn_name}"):
+            with get_timing_context(state, f"{cb.name}.{fn_name}"):
                 cb.on_predict_step_end(state, unit)
 
     def on_predict_epoch_end(self, state: State, unit: TPredictUnit) -> None:
         fn_name = "on_predict_epoch_end"
         callbacks = self._callbacks.get(fn_name, [])
         for cb in callbacks:
-            with _get_timing_context(state, f"{cb.name}.{fn_name}"):
+            with get_timing_context(state, f"{cb.name}.{fn_name}"):
                 cb.on_predict_epoch_end(state, unit)
 
     def on_predict_end(self, state: State, unit: TPredictUnit) -> None:
         fn_name = "on_predict_end"
         callbacks = self._callbacks.get(fn_name, [])
         for cb in callbacks:
-            with _get_timing_context(state, f"{cb.name}.{fn_name}"):
+            with get_timing_context(state, f"{cb.name}.{fn_name}"):
                 cb.on_predict_end(state, unit)

--- a/torchtnt/framework/_callback_handler.py
+++ b/torchtnt/framework/_callback_handler.py
@@ -12,7 +12,6 @@ from unittest.mock import Mock
 from torchtnt.framework.callback import Callback
 from torchtnt.framework.state import State
 from torchtnt.framework.unit import TEvalUnit, TPredictUnit, TTrainUnit
-from torchtnt.framework.utils import get_timing_context
 
 logger: logging.Logger = logging.getLogger(__name__)
 
@@ -109,131 +108,112 @@ class CallbackHandler:
         fn_name = "on_exception"
         callbacks = self._callbacks.get(fn_name, [])
         for cb in callbacks:
-            with get_timing_context(state, f"{cb.name}.{fn_name}"):
-                cb.on_exception(state, unit, exc)
+            cb.on_exception(state, unit, exc)
 
     def on_train_start(self, state: State, unit: TTrainUnit) -> None:
         fn_name = "on_train_start"
         callbacks = self._callbacks.get(fn_name, [])
         for cb in callbacks:
-            with get_timing_context(state, f"{cb.name}.{fn_name}"):
-                cb.on_train_start(state, unit)
+            cb.on_train_start(state, unit)
 
     def on_train_epoch_start(self, state: State, unit: TTrainUnit) -> None:
         fn_name = "on_train_epoch_start"
         callbacks = self._callbacks.get(fn_name, [])
         for cb in callbacks:
-            with get_timing_context(state, f"{cb.name}.{fn_name}"):
-                cb.on_train_epoch_start(state, unit)
+            cb.on_train_epoch_start(state, unit)
 
     def on_train_step_start(self, state: State, unit: TTrainUnit) -> None:
         fn_name = "on_train_step_start"
         callbacks = self._callbacks.get(fn_name, [])
         for cb in callbacks:
-            with get_timing_context(state, f"{cb.name}.{fn_name}"):
-                cb.on_train_step_start(state, unit)
+            cb.on_train_step_start(state, unit)
 
     def on_train_step_end(self, state: State, unit: TTrainUnit) -> None:
         fn_name = "on_train_step_end"
         callbacks = self._callbacks.get(fn_name, [])
         for cb in callbacks:
-            with get_timing_context(state, f"{cb.name}.{fn_name}"):
-                cb.on_train_step_end(state, unit)
+            cb.on_train_step_end(state, unit)
 
     def on_train_epoch_end(self, state: State, unit: TTrainUnit) -> None:
         fn_name = "on_train_epoch_end"
         callbacks = self._callbacks.get(fn_name, [])
         for cb in callbacks:
-            with get_timing_context(state, f"{cb.name}.{fn_name}"):
-                cb.on_train_epoch_end(state, unit)
+            cb.on_train_epoch_end(state, unit)
 
     def on_train_end(self, state: State, unit: TTrainUnit) -> None:
         fn_name = "on_train_end"
         callbacks = self._callbacks.get(fn_name, [])
         for cb in callbacks:
-            with get_timing_context(state, f"{cb.name}.{fn_name}"):
-                cb.on_train_end(state, unit)
+            cb.on_train_end(state, unit)
 
     def on_eval_start(self, state: State, unit: TEvalUnit) -> None:
         fn_name = "on_eval_start"
         callbacks = self._callbacks.get(fn_name, [])
         for cb in callbacks:
-            with get_timing_context(state, f"{cb.name}.{fn_name}"):
-                cb.on_eval_start(state, unit)
+            cb.on_eval_start(state, unit)
 
     def on_eval_epoch_start(self, state: State, unit: TEvalUnit) -> None:
         fn_name = "on_eval_epoch_start"
         callbacks = self._callbacks.get(fn_name, [])
         for cb in callbacks:
-            with get_timing_context(state, f"{cb.name}.{fn_name}"):
-                cb.on_eval_epoch_start(state, unit)
+            cb.on_eval_epoch_start(state, unit)
 
     def on_eval_step_start(self, state: State, unit: TEvalUnit) -> None:
         fn_name = "on_eval_step_start"
         callbacks = self._callbacks.get(fn_name, [])
         for cb in callbacks:
-            with get_timing_context(state, f"{cb.name}.{fn_name}"):
-                cb.on_eval_step_start(state, unit)
+            cb.on_eval_step_start(state, unit)
 
     def on_eval_step_end(self, state: State, unit: TEvalUnit) -> None:
         fn_name = "on_eval_step_end"
         callbacks = self._callbacks.get(fn_name, [])
         for cb in callbacks:
-            with get_timing_context(state, f"{cb.name}.{fn_name}"):
-                cb.on_eval_step_end(state, unit)
+            cb.on_eval_step_end(state, unit)
 
     def on_eval_epoch_end(self, state: State, unit: TEvalUnit) -> None:
         fn_name = "on_eval_epoch_end"
         callbacks = self._callbacks.get(fn_name, [])
         for cb in callbacks:
-            with get_timing_context(state, f"{cb.name}.{fn_name}"):
-                cb.on_eval_epoch_end(state, unit)
+            cb.on_eval_epoch_end(state, unit)
 
     def on_eval_end(self, state: State, unit: TEvalUnit) -> None:
         fn_name = "on_eval_end"
         callbacks = self._callbacks.get(fn_name, [])
         for cb in callbacks:
-            with get_timing_context(state, f"{cb.name}.{fn_name}"):
-                cb.on_eval_end(state, unit)
+            cb.on_eval_end(state, unit)
 
     def on_predict_start(self, state: State, unit: TPredictUnit) -> None:
         fn_name = "on_predict_start"
         callbacks = self._callbacks.get(fn_name, [])
         for cb in callbacks:
-            with get_timing_context(state, f"{cb.name}.{fn_name}"):
-                cb.on_predict_start(state, unit)
+            cb.on_predict_start(state, unit)
 
     def on_predict_epoch_start(self, state: State, unit: TPredictUnit) -> None:
         fn_name = "on_predict_epoch_start"
         callbacks = self._callbacks.get(fn_name, [])
         for cb in callbacks:
-            with get_timing_context(state, f"{cb.name}.{fn_name}"):
-                cb.on_predict_epoch_start(state, unit)
+            cb.on_predict_epoch_start(state, unit)
 
     def on_predict_step_start(self, state: State, unit: TPredictUnit) -> None:
         fn_name = "on_predict_step_start"
         callbacks = self._callbacks.get(fn_name, [])
         for cb in callbacks:
-            with get_timing_context(state, f"{cb.name}.{fn_name}"):
-                cb.on_predict_step_start(state, unit)
+            cb.on_predict_step_start(state, unit)
 
     def on_predict_step_end(self, state: State, unit: TPredictUnit) -> None:
         fn_name = "on_predict_step_end"
         callbacks = self._callbacks.get(fn_name, [])
         for cb in callbacks:
-            with get_timing_context(state, f"{cb.name}.{fn_name}"):
-                cb.on_predict_step_end(state, unit)
+            cb.on_predict_step_end(state, unit)
 
     def on_predict_epoch_end(self, state: State, unit: TPredictUnit) -> None:
         fn_name = "on_predict_epoch_end"
         callbacks = self._callbacks.get(fn_name, [])
         for cb in callbacks:
-            with get_timing_context(state, f"{cb.name}.{fn_name}"):
-                cb.on_predict_epoch_end(state, unit)
+            cb.on_predict_epoch_end(state, unit)
 
     def on_predict_end(self, state: State, unit: TPredictUnit) -> None:
         fn_name = "on_predict_end"
         callbacks = self._callbacks.get(fn_name, [])
         for cb in callbacks:
-            with get_timing_context(state, f"{cb.name}.{fn_name}"):
-                cb.on_predict_end(state, unit)
+            cb.on_predict_end(state, unit)

--- a/torchtnt/framework/auto_unit.py
+++ b/torchtnt/framework/auto_unit.py
@@ -244,10 +244,7 @@ class AutoPredictUnit(PredictUnit[TPredictData]):
                 outputs = self.module(batch)
 
         step = self.predict_progress.num_steps_completed
-        with get_timing_context(
-            state, f"{self.__class__.__name__}.on_predict_step_end"
-        ):
-            self.on_predict_step_end(state, batch, step, outputs)
+        self.on_predict_step_end(state, batch, step, outputs)
         return outputs
 
     def on_predict_step_end(
@@ -741,9 +738,7 @@ class AutoUnit(
                         lr_scheduler.step()
 
         step = self.train_progress.num_steps_completed
-        # users can override this, by default this is a no-op
-        with get_timing_context(state, f"{self.__class__.__name__}.on_train_step_end"):
-            self.on_train_step_end(state, batch, step, loss, outputs)
+        self.on_train_step_end(state, batch, step, loss, outputs)
         return loss, outputs
 
     def on_train_step_end(
@@ -819,9 +814,7 @@ class AutoUnit(
         else:
             step = self.eval_progress.num_steps_completed
 
-        # users can override this, by default this is a no-op
-        with get_timing_context(state, f"{self.__class__.__name__}.on_eval_step_end"):
-            self.on_eval_step_end(state, data, step, loss, outputs)
+        self.on_eval_step_end(state, data, step, loss, outputs)
         return loss, outputs
 
     def on_eval_step_end(

--- a/torchtnt/framework/callbacks/torchsnapshot_saver.py
+++ b/torchtnt/framework/callbacks/torchsnapshot_saver.py
@@ -16,7 +16,7 @@ from torchsnapshot.snapshot import PendingSnapshot, Snapshot
 from torchtnt.framework.callback import Callback
 from torchtnt.framework.state import EntryPoint, State
 from torchtnt.framework.unit import AppStateMixin, TEvalUnit, TPredictUnit, TTrainUnit
-from torchtnt.framework.utils import _construct_tracked_optimizers
+from torchtnt.framework.utils import _construct_tracked_optimizers, get_timing_context
 from torchtnt.utils.distributed import get_global_rank
 from torchtnt.utils.rank_zero_log import rank_zero_info, rank_zero_warn
 from torchtnt.utils.stateful import Stateful
@@ -127,7 +127,10 @@ class TorchSnapshotSaver(Callback):
         snapshot_path = _get_snapshot_save_path(
             self._dirpath, epoch, num_steps_completed
         )
-        self._async_snapshot(snapshot_path, app_state, wait=False)
+        with get_timing_context(
+            state, f"{self.__class__.__name__}.take_async_snapshot"
+        ):
+            self._async_snapshot(snapshot_path, app_state, wait=False)
 
     def on_train_epoch_end(self, state: State, unit: TTrainUnit) -> None:
         epoch = unit.train_progress.num_epochs_completed
@@ -140,7 +143,10 @@ class TorchSnapshotSaver(Callback):
         snapshot_path = _get_snapshot_save_path(
             self._dirpath, epoch, num_steps_completed
         )
-        self._async_snapshot(snapshot_path, app_state, wait=True)
+        with get_timing_context(
+            state, f"{self.__class__.__name__}.take_async_snapshot"
+        ):
+            self._async_snapshot(snapshot_path, app_state, wait=True)
 
     def on_train_end(self, state: State, unit: TTrainUnit) -> None:
         app_state = _get_app_state(state, unit, self._replicated, intra_epoch=False)
@@ -149,8 +155,11 @@ class TorchSnapshotSaver(Callback):
         snapshot_path = _get_snapshot_save_path(
             self._dirpath, epoch, num_steps_completed
         )
-        self._async_snapshot(snapshot_path, app_state, wait=True)
-        self._wait()
+        with get_timing_context(
+            state, f"{self.__class__.__name__}.take_async_snapshot"
+        ):
+            self._async_snapshot(snapshot_path, app_state, wait=True)
+            self._wait()
 
     def on_exception(
         self,

--- a/torchtnt/framework/evaluate.py
+++ b/torchtnt/framework/evaluate.py
@@ -16,11 +16,11 @@ from torchtnt.framework.callback import Callback
 from torchtnt.framework.state import ActivePhase, EntryPoint, PhaseState, State
 from torchtnt.framework.unit import TEvalData, TEvalUnit
 from torchtnt.framework.utils import (
-    _get_timing_context,
     _is_epoch_done,
     _reset_module_training_mode,
     _set_module_training_mode,
     _step_requires_iterator,
+    get_timing_context,
     log_api_usage,
 )
 from torchtnt.utils.timer import get_timer_summary, Timer
@@ -120,20 +120,20 @@ def _evaluate_impl(
     tracked_modules = eval_unit.tracked_modules()
     prior_module_train_states = _set_module_training_mode(tracked_modules, False)
 
-    with _get_timing_context(state, f"{eval_unit.__class__.__name__}.on_eval_start"):
+    with get_timing_context(state, f"{eval_unit.__class__.__name__}.on_eval_start"):
         eval_unit.on_eval_start(state)
     callback_handler.on_eval_start(state, eval_unit)
 
     # Conditionally run this to avoid running this multiple times
     # in the case of resuming from a checkpoint mid-epoch
     if eval_unit.eval_progress.num_steps_completed_in_epoch == 0:
-        with _get_timing_context(
+        with get_timing_context(
             state, f"{eval_unit.__class__.__name__}.on_eval_epoch_start"
         ):
             eval_unit.on_eval_epoch_start(state)
         callback_handler.on_eval_epoch_start(state, eval_unit)
 
-    with _get_timing_context(state, "evaluate.iter(dataloader)"):
+    with get_timing_context(state, "evaluate.iter(dataloader)"):
         data_iter = iter(eval_state.dataloader)
     step_input = data_iter
 
@@ -152,10 +152,10 @@ def _evaluate_impl(
         try:
             if not pass_data_iter_to_step:
                 # get the next batch from the data iterator
-                with _get_timing_context(state, "evaluate.next(data_iter)"):
+                with get_timing_context(state, "evaluate.next(data_iter)"):
                     step_input = next(data_iter)
             callback_handler.on_eval_step_start(state, eval_unit)
-            with _get_timing_context(
+            with get_timing_context(
                 state,
                 f"{eval_unit.__class__.__name__}.eval_step",
                 skip_timer=is_auto_unit,
@@ -182,13 +182,11 @@ def _evaluate_impl(
     # set progress counters for the next epoch
     eval_unit.eval_progress.increment_epoch()
 
-    with _get_timing_context(
-        state, f"{eval_unit.__class__.__name__}.on_eval_epoch_end"
-    ):
+    with get_timing_context(state, f"{eval_unit.__class__.__name__}.on_eval_epoch_end"):
         eval_unit.on_eval_epoch_end(state)
     callback_handler.on_eval_epoch_end(state, eval_unit)
 
-    with _get_timing_context(state, f"{eval_unit.__class__.__name__}.on_eval_end"):
+    with get_timing_context(state, f"{eval_unit.__class__.__name__}.on_eval_end"):
         eval_unit.on_eval_end(state)
     callback_handler.on_eval_end(state, eval_unit)
 

--- a/torchtnt/framework/utils.py
+++ b/torchtnt/framework/utils.py
@@ -92,7 +92,7 @@ def _reset_module_training_mode(
 
 @contextmanager
 # pyre-fixme[3]: Return type must be annotated.
-def get_timing_context(state: State, event_name: str, skip_timer: bool = False):
+def get_timing_context(state: State, event_name: str):
     """
     Returns a context manager that records an event to a :class:`~torchtnt.utils.timer.Timer` and to PyTorch Profiler.
 
@@ -102,7 +102,7 @@ def get_timing_context(state: State, event_name: str, skip_timer: bool = False):
     """
     timer_context = (
         state.timer.time(event_name)
-        if state.timer and not skip_timer
+        if state.timer is not None
         else contextlib.nullcontext()
     )
     profiler_context = record_function(event_name)

--- a/torchtnt/framework/utils.py
+++ b/torchtnt/framework/utils.py
@@ -92,8 +92,14 @@ def _reset_module_training_mode(
 
 @contextmanager
 # pyre-fixme[3]: Return type must be annotated.
-def _get_timing_context(state: State, event_name: str, skip_timer: bool = False):
-    """Returns a context manager that records an event to a :class:`~torchtnt.utils.timer.Timer` and to PyTorch Profiler."""
+def get_timing_context(state: State, event_name: str, skip_timer: bool = False):
+    """
+    Returns a context manager that records an event to a :class:`~torchtnt.utils.timer.Timer` and to PyTorch Profiler.
+
+    Args:
+        state: an instance of :class:`~torchtnt.framework.State`
+        event_name: string identifier to use for timing
+    """
     timer_context = (
         state.timer.time(event_name)
         if state.timer and not skip_timer


### PR DESCRIPTION
Summary:
Users are now expected to time their own code using `state.timer.time()` or `get_timing_context`.

We time the code in the AutoUnit and the built-in callbacks for the user. This gives the user a lot of flexibility to time what they want to time, and makes the timer summaries more informative.

Differential Revision: D47523530

