### PR TITLE
Fix test_module_summary_retrieve_module_summaries_module_inputs on GPU

### DIFF
--- a/tests/framework/callbacks/test_module_summary.py
+++ b/tests/framework/callbacks/test_module_summary.py
@@ -110,7 +110,7 @@ class ModuleSummaryTest(unittest.TestCase):
             module=my_module,
         )
 
-        module_inputs = {"module": ((torch.rand(2, 2),), {})}
+        module_inputs = {"module": ((torch.rand(2, 2, device=auto_unit.device),), {})}
         module_summary_callback = ModuleSummary(module_inputs=module_inputs)
         summaries = module_summary_callback._retrieve_module_summaries(auto_unit)
 


### PR DESCRIPTION
Summary: Need to create module_inputs on the correct device

Reviewed By: ananthsub

Differential Revision: D47675228

