### PR TITLE
move ModuleSummary + FLOPS tools from eval to tnt

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,6 +1,6 @@
 parameterized
 pytest
 pytest-cov
-torcheval-nightly
 torchsnapshot-nightly
 pyre-check
+torchvision

--- a/tests/framework/test_auto_unit.py
+++ b/tests/framework/test_auto_unit.py
@@ -391,7 +391,7 @@ class TestAutoUnit(unittest.TestCase):
         my_compile_params = TorchCompileParams(backend="foo")
 
         self.failUnlessRaises(
-            RuntimeError,
+            Exception,
             DummyAutoUnit,
             **{
                 "module": my_module,

--- a/tests/utils/test_flops.py
+++ b/tests/utils/test_flops.py
@@ -1,0 +1,188 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+import unittest
+
+import torch
+import torchvision.models as models
+from torchtnt.utils.flops import FlopTensorDispatchMode
+
+
+class ModuleSummaryTest(unittest.TestCase):
+    def test_torch_operations(self) -> None:
+        """Make sure FLOPs calculation works for a single operations."""
+
+        class TestModule(torch.nn.Module):
+            def __init__(self) -> None:
+                super().__init__()
+
+            def forward(self, x: torch.Tensor) -> torch.Tensor:
+                bmm_mat = torch.randn(10, 5, 7)
+                mm_mat = torch.randn(7, 3)
+                return x.bmm(bmm_mat).matmul(mm_mat)
+
+        test_module = TestModule()
+        with FlopTensorDispatchMode(test_module) as ftdm:
+            inp = torch.randn(10, 4, 5)
+            res = test_module(inp)
+
+            self.assertEqual(res.shape[0], 10)
+            self.assertEqual(res.shape[1], 4)
+            self.assertEqual(res.shape[2], 3)
+
+            self.assertEqual(
+                ftdm.flop_counts[""].get("bmm.default", 0)
+                + ftdm.flop_counts[""].get("bmm", 0),
+                1400,
+            )
+            self.assertEqual(
+                ftdm.flop_counts[""].get("mm.default", 0)
+                + ftdm.flop_counts[""].get("mm", 0),
+                840,
+            )
+
+            inp = torch.randn(10, 4, 5)
+            inp = torch.autograd.Variable(inp, requires_grad=True)
+
+            ftdm.reset()
+            res = test_module(inp)
+            res.mean().backward()
+
+            self.assertEqual(res.shape[0], 10)
+            self.assertEqual(res.shape[1], 4)
+            self.assertEqual(res.shape[2], 3)
+
+            self.assertEqual(
+                ftdm.flop_counts[""].get("bmm.default", 0)
+                + ftdm.flop_counts[""].get("bmm", 0),
+                2800,
+            )
+            self.assertEqual(
+                ftdm.flop_counts[""].get("mm.default", 0)
+                + ftdm.flop_counts[""].get("mm", 0),
+                1680,
+            )
+
+    def test_torch_linear_layer(self) -> None:
+        """Make sure FLOPs calculation works for a module consists of linear layers."""
+        lnn = torch.nn.Sequential(
+            torch.nn.Sequential(torch.nn.Linear(10, 70), torch.nn.Linear(70, 5)),
+            torch.nn.Linear(5, 1),
+        )
+        inp = torch.randn(1, 10)
+
+        with FlopTensorDispatchMode(lnn) as ftdm:
+            self.assertEqual(len(ftdm._all_hooks), 8)
+
+            res = lnn(inp)
+            self.assertEqual(
+                ftdm.flop_counts[""].get("addmm.default", 0)
+                + ftdm.flop_counts[""].get("addmm", 0),
+                1055,
+            )
+            self.assertEqual(
+                ftdm.flop_counts["0"].get("addmm.default", 0)
+                + ftdm.flop_counts["0"].get("addmm", 0),
+                1050,
+            )
+            self.assertEqual(
+                ftdm.flop_counts["0.0"].get("addmm.default", 0)
+                + ftdm.flop_counts["0.0"].get("addmm", 0),
+                700,
+            )
+            self.assertEqual(
+                ftdm.flop_counts["0.1"].get("addmm.default", 0)
+                + ftdm.flop_counts["0.1"].get("addmm", 0),
+                350,
+            )
+            self.assertEqual(
+                ftdm.flop_counts["1"].get("addmm.default", 0)
+                + ftdm.flop_counts["1"].get("addmm", 0),
+                5,
+            )
+            ftdm.reset()
+            res.backward()
+            self.assertEqual(
+                ftdm.flop_counts[""].get("mm.default", 0)
+                + ftdm.flop_counts[""].get("mm", 0),
+                1410,
+            )
+            self.assertEqual(
+                ftdm.flop_counts["0"].get("mm.default", 0)
+                + ftdm.flop_counts["0"].get("mm", 0),
+                1400,
+            )
+            self.assertEqual(
+                ftdm.flop_counts["0.0"].get("mm.default", 0)
+                + ftdm.flop_counts["0.0"].get("mm", 0),
+                700,
+            )
+            self.assertEqual(
+                ftdm.flop_counts["0.1"].get("mm.default", 0)
+                + ftdm.flop_counts["0.1"].get("mm", 0),
+                700,
+            )
+            self.assertEqual(
+                ftdm.flop_counts["1"].get("mm.default", 0)
+                + ftdm.flop_counts["1"].get("mm", 0),
+                10,
+            )
+
+    def test_torch_pretrained_module(self) -> None:
+        """Make sure FLOPs calculation works for a resnet18."""
+        # pyre-fixme[16]: Module `models` has no attribute `resnet18`.
+        mod = models.resnet18()
+        inp = torch.randn(1, 3, 224, 224)
+        with FlopTensorDispatchMode(mod) as ftdm:
+            # Hooks should be 2 * number of modules minus 2 (2 for the model itself)
+            self.assertEqual(len(ftdm._all_hooks), 2 * len(list(mod.modules())) - 2)
+            res = mod(inp)
+
+            self.assertEqual(
+                ftdm.flop_counts[""].get("convolution.default", 0)
+                + ftdm.flop_counts[""].get("convolution", 0),
+                1813561344,
+            )
+            self.assertEqual(
+                ftdm.flop_counts[""].get("addmm.default", 0)
+                + ftdm.flop_counts[""].get("addmm", 0),
+                512000,
+            )
+            self.assertEqual(
+                ftdm.flop_counts["conv1"].get("convolution.default", 0)
+                + ftdm.flop_counts["conv1"].get("convolution", 0),
+                118013952,
+            )
+            self.assertEqual(
+                ftdm.flop_counts["fc"].get("addmm.default", 0)
+                + ftdm.flop_counts["fc"].get("addmm", 0),
+                512000,
+            )
+
+            ftdm.reset()
+            res.mean().backward()
+
+            self.assertEqual(
+                ftdm.flop_counts[""].get("convolution_backward.default", 0)
+                + ftdm.flop_counts[""].get("convolution_backward", 0),
+                3509108736,
+            )
+            self.assertEqual(
+                ftdm.flop_counts[""].get("mm.default", 0)
+                + ftdm.flop_counts[""].get("mm", 0),
+                1024000,
+            )
+            self.assertEqual(
+                ftdm.flop_counts["layer1"].get("convolution_backward.default", 0)
+                + ftdm.flop_counts["layer1"].get("convolution_backward", 0),
+                924844032,
+            )
+            self.assertEqual(
+                ftdm.flop_counts["fc"].get("mm.default", 0)
+                + ftdm.flop_counts["fc"].get("mm", 0),
+                1024000,
+            )

--- a/tests/utils/test_module_summary.py
+++ b/tests/utils/test_module_summary.py
@@ -1,0 +1,359 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+import unittest
+from typing import Any, Dict, Optional, Tuple
+
+import torch
+import torchvision.models as models
+from torchtnt.utils.module_summary import (
+    _get_human_readable_count,
+    get_module_summary,
+    ModuleSummary,
+    prune_module_summary,
+)
+
+
+def get_summary_and_prune(
+    model: torch.nn.Module,
+    *,
+    max_depth: int,
+    # pyre-ignore
+    module_args: Optional[Tuple[Any, ...]] = None,
+    module_kwargs: Optional[Dict[str, Any]] = None,
+) -> ModuleSummary:
+    """Utility function to get module summary and then prune it"""
+    module_summary = get_module_summary(
+        model, module_args=module_args, module_kwargs=module_kwargs
+    )
+    prune_module_summary(module_summary, max_depth=max_depth)
+    return module_summary
+
+
+class ModuleSummaryTest(unittest.TestCase):
+
+    maxDiff = 10000
+
+    def _test_module_summary_text(self, ms1: str, ms2: str) -> None:
+        # utility method to make testing summary method text more robust to terminal differences
+        for l1, l2 in zip(ms1.strip().split("\n"), ms2.strip().split("\n")):
+            self.assertEqual(l1.strip(), l2.strip())
+
+    def test_module_summary_layer(self) -> None:
+        """Make sure ModuleSummary works for a single layer."""
+        model = torch.nn.Conv2d(3, 8, 3)
+        ms1 = get_module_summary(model)
+        ms2 = get_module_summary(model, module_args=(torch.randn(1, 3, 8, 8),))
+
+        self.assertEqual(ms1.module_name, "")
+        self.assertEqual(ms1.module_type, "Conv2d")
+        self.assertEqual(ms1.num_parameters, 224)
+        self.assertEqual(ms1.num_trainable_parameters, 224)
+        self.assertEqual(ms1.size_bytes, 224 * 4)
+        self.assertEqual(ms1.submodule_summaries, {})
+        self.assertFalse(ms1.has_uninitialized_param)
+
+        self.assertEqual(ms1.module_name, ms2.module_name)
+        self.assertEqual(ms1.module_type, ms2.module_type)
+        self.assertEqual(ms1.num_parameters, ms2.num_parameters)
+        self.assertEqual(ms1.num_trainable_parameters, ms2.num_trainable_parameters)
+        self.assertEqual(ms1.size_bytes, ms2.size_bytes)
+        self.assertEqual(ms1.submodule_summaries, ms2.submodule_summaries)
+
+        self.assertEqual(ms2.flops_forward, 7776)
+        self.assertEqual(ms2.flops_backward, 7776)
+
+        self.assertEqual(ms1.in_size, "?")
+        self.assertEqual(ms1.out_size, "?")
+        self.assertEqual(ms2.in_size, [1, 3, 8, 8])
+        self.assertEqual(ms2.out_size, [1, 8, 6, 6])
+
+    def test_activation_size(self) -> None:
+        """Make sure activation size is correct for more complex module"""
+
+        class TestModule(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.hidden = torch.nn.Linear(10, 5)
+                self.relu = torch.nn.ReLU()
+                self.out = torch.nn.Linear(5, 3)
+                self.softmax = torch.nn.Softmax(dim=3)
+
+            def forward(self, x):
+                x = self.hidden(x)
+                x = self.relu(x)
+                x = self.out(x)
+                x = self.softmax(x)
+                return x
+
+        model = TestModule()
+        ms = get_module_summary(model, (torch.randn(1, 3, 10, 10),))
+        self.assertEqual(ms.module_name, "")
+        self.assertEqual(ms.in_size, [1, 3, 10, 10])
+        self.assertEqual(ms.out_size, [1, 3, 10, 3])
+        self.assertEqual(ms.module_type, "TestModule")
+
+        ms_hidden = ms.submodule_summaries["hidden"]
+        self.assertEqual(ms_hidden.module_name, "hidden")
+        self.assertEqual(ms_hidden.in_size, [1, 3, 10, 10])
+        self.assertEqual(ms_hidden.out_size, [1, 3, 10, 5])
+        self.assertEqual(ms_hidden.module_type, "Linear")
+
+        ms_relu = ms.submodule_summaries["relu"]
+        self.assertEqual(ms_relu.module_name, "relu")
+        self.assertEqual(ms_relu.in_size, [1, 3, 10, 5])
+        self.assertEqual(ms_relu.out_size, [1, 3, 10, 5])
+        self.assertEqual(ms_relu.module_type, "ReLU")
+
+        ms_out = ms.submodule_summaries["out"]
+        self.assertEqual(ms_out.module_name, "out")
+        self.assertEqual(ms_out.in_size, [1, 3, 10, 5])
+        self.assertEqual(ms_out.out_size, [1, 3, 10, 3])
+        self.assertEqual(ms_out.module_type, "Linear")
+
+        ms_softmax = ms.submodule_summaries["softmax"]
+        self.assertEqual(ms_softmax.module_name, "softmax")
+        self.assertEqual(ms_softmax.in_size, [1, 3, 10, 3])
+        self.assertEqual(ms_softmax.out_size, [1, 3, 10, 3])
+        self.assertEqual(ms_softmax.module_type, "Softmax")
+
+    def test_invalid_max_depth(self) -> None:
+        """Test for ValueError when providing bad max_depth"""
+        model = torch.nn.Conv2d(3, 8, 3)
+        summary = get_module_summary(model)
+        with self.assertRaisesRegex(ValueError, "Got -2."):
+            prune_module_summary(summary, max_depth=-2)
+        with self.assertRaisesRegex(ValueError, "Got 0."):
+            prune_module_summary(summary, max_depth=0)
+
+    def test_lazy_tensor(self) -> None:
+        """Check for warning when passing in a lazy weight Tensor"""
+        model = torch.nn.LazyLinear(10)
+        ms = get_module_summary(model)
+        with self.assertWarns(Warning):
+            ms.num_parameters
+        with self.assertWarns(Warning):
+            ms.num_trainable_parameters
+        self.assertTrue(ms.has_uninitialized_param)
+
+    def test_lazy_tensor_flops(self) -> None:
+        """Check for warnings when passing in a lazy weight Tensor
+        Even when asking for flops calculation."""
+        model = torch.nn.LazyLinear(10)
+        ms = get_module_summary(model, module_args=(torch.randn(1, 10),))
+        with self.assertWarns(Warning):
+            ms.num_parameters
+        with self.assertWarns(Warning):
+            ms.num_trainable_parameters
+        self.assertTrue(ms.has_uninitialized_param)
+        self.assertEqual(ms.flops_backward, "?")
+        self.assertEqual(ms.flops_forward, "?")
+
+    def test_resnet_max_depth(self) -> None:
+        """Test the behavior of max_depth on a layered model like ResNet"""
+        pretrained_model = models.resnet.resnet18(pretrained=True)
+
+        # max_depth = None
+        ms1 = get_module_summary(pretrained_model)
+
+        self.assertEqual(len(ms1.submodule_summaries), 10)
+        self.assertEqual(len(ms1.submodule_summaries["layer2"].submodule_summaries), 2)
+        self.assertEqual(
+            len(
+                ms1.submodule_summaries["layer2"]
+                .submodule_summaries["layer2.0"]
+                .submodule_summaries
+            ),
+            6,
+        )
+
+        ms2 = get_summary_and_prune(pretrained_model, max_depth=1)
+        self.assertEqual(len(ms2.submodule_summaries), 0)
+        self.assertNotIn("layer2", ms2.submodule_summaries)
+
+        ms3 = get_summary_and_prune(pretrained_model, max_depth=2)
+        self.assertEqual(len(ms3.submodule_summaries), 10)
+        self.assertEqual(len(ms1.submodule_summaries["layer2"].submodule_summaries), 2)
+        self.assertNotIn(
+            "layer2.0", ms3.submodule_summaries["layer2"].submodule_summaries
+        )
+        inp = torch.randn(1, 3, 224, 224)
+        ms4 = get_summary_and_prune(pretrained_model, max_depth=2, module_args=(inp,))
+
+        self.assertEqual(len(ms4.submodule_summaries), 10)
+        self.assertEqual(ms4.flops_forward, 1814073344)
+        self.assertEqual(ms4.flops_backward, 3510132736)
+        self.assertEqual(ms4.submodule_summaries["layer2"].flops_forward, 411041792)
+        self.assertEqual(ms4.submodule_summaries["layer2"].flops_backward, 822083584)
+
+        # These should stay constant for all max_depth values
+        ms_list = [ms1, ms2, ms3, ms4]
+        for ms in ms_list:
+            self.assertEqual(ms.module_name, "")
+            self.assertEqual(ms.module_type, "ResNet")
+            self.assertEqual(ms.num_parameters, 11689512)
+            self.assertEqual(ms.num_trainable_parameters, 11689512)
+            self.assertFalse(ms.has_uninitialized_param)
+
+    def test_module_summary_layer_print(self) -> None:
+        model = torch.nn.Conv2d(3, 8, 3)
+        ms1 = get_module_summary(model)
+
+        summary_table = """
+Name | Type   | # Parameters | # Trainable Parameters | Size (bytes) | Contains Uninitialized Parameters?
+---------------------------------------------------------------------------------------------------------
+     | Conv2d | 224          | 224                    | 896          | No
+"""
+        self._test_module_summary_text(summary_table, str(ms1))
+
+    def test_alexnet_print(self) -> None:
+        pretrained_model = models.alexnet(pretrained=True)
+        ms1 = get_summary_and_prune(pretrained_model, max_depth=1)
+        ms2 = get_summary_and_prune(pretrained_model, max_depth=2)
+        ms3 = get_summary_and_prune(pretrained_model, max_depth=3)
+        ms4 = get_module_summary(pretrained_model)
+
+        summary_table1 = """
+Name | Type    | # Parameters | # Trainable Parameters | Size (bytes) | Contains Uninitialized Parameters?
+----------------------------------------------------------------------------------------------------------
+     | AlexNet | 61.1 M       | 61.1 M                 | 244 M        | No
+"""
+        summary_table2 = """
+Name       | Type              | # Parameters | # Trainable Parameters | Size (bytes) | Contains Uninitialized Parameters?
+--------------------------------------------------------------------------------------------------------------------------
+           | AlexNet           | 61.1 M       | 61.1 M                 | 244 M        | No
+features   | Sequential        | 2.5 M        | 2.5 M                  | 9.9 M        | No
+avgpool    | AdaptiveAvgPool2d | 0            | 0                      | 0            | No
+classifier | Sequential        | 58.6 M       | 58.6 M                 | 234 M        | No
+"""
+
+        self._test_module_summary_text(summary_table1, str(ms1))
+        self._test_module_summary_text(summary_table2, str(ms2))
+        self.assertEqual(str(ms3), str(ms4))
+
+    def test_alexnet_with_input_tensor(self) -> None:
+        pretrained_model = models.alexnet(pretrained=True)
+        inp = torch.randn(1, 3, 224, 224)
+        ms1 = get_summary_and_prune(pretrained_model, max_depth=1, module_args=(inp,))
+        ms2 = get_summary_and_prune(pretrained_model, max_depth=2, module_args=(inp,))
+
+        self.assertEqual(ms1.module_type, "AlexNet")
+        self.assertEqual(ms1.num_parameters, 61100840)
+        self.assertFalse(ms1.has_uninitialized_param)
+        self.assertEqual(ms1.flops_forward, 714188480)
+        self.assertEqual(ms1.flops_backward, 1358100160)
+        self.assertEqual(ms1.in_size, [1, 3, 224, 224])
+        self.assertEqual(ms1.out_size, [1, 1000])
+
+        ms_features = ms2.submodule_summaries["features"]
+        self.assertEqual(ms_features.module_type, "Sequential")
+        self.assertFalse(ms_features.has_uninitialized_param)
+        self.assertEqual(ms_features.flops_forward, 655566528)
+        self.assertEqual(ms_features.flops_backward, 1240856256)
+        self.assertEqual(ms_features.in_size, [1, 3, 224, 224])
+        self.assertEqual(ms_features.out_size, [1, 256, 6, 6])
+
+        ms_avgpool = ms2.submodule_summaries["avgpool"]
+        self.assertEqual(ms_avgpool.module_type, "AdaptiveAvgPool2d")
+        self.assertFalse(ms_avgpool.has_uninitialized_param)
+        self.assertEqual(ms_avgpool.flops_forward, 0)
+        self.assertEqual(ms_avgpool.flops_backward, 0)
+        self.assertEqual(ms_avgpool.in_size, [1, 256, 6, 6])
+        self.assertEqual(ms_avgpool.out_size, [1, 256, 6, 6])
+
+        ms_classifier = ms2.submodule_summaries["classifier"]
+        self.assertEqual(ms_classifier.module_type, "Sequential")
+        self.assertFalse(ms_classifier.has_uninitialized_param)
+        self.assertEqual(ms_classifier.flops_forward, 58621952)
+        self.assertEqual(ms_classifier.flops_backward, 117243904)
+        self.assertEqual(ms_classifier.in_size, [1, 9216])
+        self.assertEqual(ms_classifier.out_size, [1, 1000])
+
+    def test_get_human_readable_count(self) -> None:
+        with self.assertRaisesRegex(ValueError, "received -1"):
+            _get_human_readable_count(-1)
+        with self.assertRaisesRegex(TypeError, "received <class 'float'>"):
+            # pyre-fixme[6]: For 1st param expected `int` but got `float`.
+            _get_human_readable_count(0.1)
+        self.assertEqual(_get_human_readable_count(1), "1  ")
+        self.assertEqual(_get_human_readable_count(123), "123  ")
+        self.assertEqual(_get_human_readable_count(1234), "1.2 K")
+        self.assertEqual(_get_human_readable_count(1254), "1.3 K")
+        self.assertEqual(_get_human_readable_count(1960), "2.0 K")
+        self.assertEqual(_get_human_readable_count(int(1e4)), "10.0 K")
+        self.assertEqual(_get_human_readable_count(int(1e6)), "1.0 M")
+        self.assertEqual(_get_human_readable_count(int(1e9)), "1.0 B")
+        self.assertEqual(_get_human_readable_count(int(1e12)), "1.0 T")
+        self.assertEqual(_get_human_readable_count(int(1e15)), "1,000 T")
+
+    def test_module_summary_multiple_inputs(self) -> None:
+        class SimpleConv(torch.nn.Module):
+            def __init__(self):
+                super(SimpleConv, self).__init__()
+                self.features = torch.nn.Sequential(
+                    torch.nn.Conv2d(1, 1, kernel_size=3, stride=1, padding=1),
+                    torch.nn.ReLU(inplace=True),
+                )
+                self.offset = 1
+
+            def forward(self, x, y, offset=1):
+                self.offset = offset
+                x1 = self.features(x)
+                x2 = self.features(y)
+                x = torch.cat((x1, x2), 1)
+                return x
+
+        model = SimpleConv()
+        x = torch.randn(1, 1, 224, 224)
+        y = torch.randn(1, 1, 224, 224)
+
+        ms1 = get_summary_and_prune(model, max_depth=3, module_args=(x, y))
+
+        self.assertEqual(ms1.module_type, "SimpleConv")
+        self.assertEqual(ms1.num_parameters, 10)
+        self.assertFalse(ms1.has_uninitialized_param)
+        self.assertEqual(ms1.in_size, [[1, 1, 224, 224], [1, 1, 224, 224]])
+        self.assertEqual(ms1.out_size, [1, 2, 224, 224])
+
+        ms_features = ms1.submodule_summaries["features"]
+        self.assertEqual(ms_features.module_type, "Sequential")
+        self.assertFalse(ms_features.has_uninitialized_param)
+        self.assertEqual(ms_features.in_size, [1, 1, 224, 224])
+        self.assertEqual(ms_features.out_size, [1, 1, 224, 224])
+
+        ms_avgpool = ms1.submodule_summaries["features"].submodule_summaries[
+            "features.0"
+        ]
+        self.assertEqual(ms_avgpool.module_type, "Conv2d")
+        self.assertFalse(ms_avgpool.has_uninitialized_param)
+        self.assertEqual(ms_avgpool.in_size, [1, 1, 224, 224])
+        self.assertEqual(ms_avgpool.out_size, [1, 1, 224, 224])
+
+        ms_classifier = ms1.submodule_summaries["features"].submodule_summaries[
+            "features.1"
+        ]
+        self.assertEqual(ms_classifier.module_type, "ReLU")
+        self.assertFalse(ms_classifier.has_uninitialized_param)
+        self.assertEqual(ms_classifier.flops_forward, 0)
+        self.assertEqual(ms_classifier.flops_backward, 0)
+        self.assertEqual(ms_classifier.in_size, [1, 1, 224, 224])
+        self.assertEqual(ms_classifier.out_size, [1, 1, 224, 224])
+
+    def test_forward_elapsed_time(self) -> None:
+        pretrained_model = models.alexnet(pretrained=True)
+        inp = torch.randn(1, 3, 224, 224)
+        ms1 = get_summary_and_prune(pretrained_model, module_args=(inp,), max_depth=4)
+        stack = [ms1] + [
+            ms1.submodule_summaries[key] for key in ms1.submodule_summaries
+        ]
+        # check all submodule summaries have been timed
+        for ms in stack:
+            self.assertNotEqual(ms.forward_elapsed_time_ms, "?")
+            self.assertGreater(float(ms.forward_elapsed_time_ms), 0)
+            stack.extend(
+                [ms.submodule_summaries[key] for key in ms.submodule_summaries]
+            )

--- a/torchtnt/framework/auto_unit.py
+++ b/torchtnt/framework/auto_unit.py
@@ -212,8 +212,14 @@ class AutoPredictUnit(PredictUnit[TPredictData]):
         else:
             module = module.to(self.device)
         if torch_compile_params:
-            # use in-place compile to avoid altering the state_dict keys
-            module.compile(**asdict(torch_compile_params))
+            try:
+                # use in-place compile to avoid altering the state_dict keys
+                module.compile(**asdict(torch_compile_params))
+            except AttributeError:
+                rank_zero_warn(
+                    "Please install pytorch nightlies to use in-place compile to avoid altering the state_dict keys when checkpointing."
+                )
+                torch.compile(module, **asdict(torch_compile_params))
         self.module: torch.nn.Module = module
 
         # cuda stream to use for moving data to device
@@ -471,8 +477,14 @@ class AutoUnit(
                 self.compute_loss,
                 **asdict(torch_compile_params),
             )
-            # use in-place compile to avoid altering the state_dict keys
-            module.compile(**asdict(torch_compile_params))
+            try:
+                # use in-place compile to avoid altering the state_dict keys
+                module.compile(**asdict(torch_compile_params))
+            except AttributeError:
+                rank_zero_warn(
+                    "Please install pytorch nightlies to use in-place compile to avoid altering the state_dict keys when checkpointing."
+                )
+                torch.compile(module, **asdict(torch_compile_params))
 
         self.module: torch.nn.Module = module
 

--- a/torchtnt/framework/callbacks/module_summary.py
+++ b/torchtnt/framework/callbacks/module_summary.py
@@ -6,21 +6,15 @@
 
 from typing import Any, Callable, Dict, List, MutableMapping, Optional, Tuple
 
-try:
-    from torcheval.tools import (
-        get_module_summary,
-        get_summary_table,
-        ModuleSummary as ModuleSummaryObj,
-        prune_module_summary,
-    )
-
-    _TORCHEVAL_AVAILABLE = True
-except Exception:
-    _TORCHEVAL_AVAILABLE = False
-
 from torchtnt.framework.callback import Callback
 from torchtnt.framework.state import EntryPoint, State
 from torchtnt.framework.unit import AppStateMixin, TEvalUnit, TPredictUnit, TTrainUnit
+from torchtnt.utils.module_summary import (
+    get_module_summary,
+    get_summary_table,
+    ModuleSummary as ModuleSummaryObj,
+    prune_module_summary,
+)
 from torchtnt.utils.rank_zero_log import rank_zero_info
 
 
@@ -31,7 +25,7 @@ def _log_module_summary_tables(module_summaries: List[ModuleSummaryObj]) -> None
 
 class ModuleSummary(Callback):
     """
-    A callback which generates and logs a summary of the modules using `TorchEval <https://pytorch.org/torcheval/>`_.
+    A callback which generates and logs a summary of the modules.
 
     Args:
         max_depth: The maximum depth of module summaries to keep.
@@ -54,12 +48,6 @@ class ModuleSummary(Callback):
             MutableMapping[str, Tuple[Tuple[Any, ...], Dict[str, Any]]]
         ] = None,
     ) -> None:
-        if not _TORCHEVAL_AVAILABLE:
-            raise RuntimeError(
-                "ModuleSummary support requires torcheval. "
-                "Please make sure ``torcheval`` is installed. "
-                "Installation: https://github.com/pytorch/torcheval#installing-torcheval"
-            )
         self._max_depth = max_depth
         self._process_fn = process_fn
         self._module_inputs = module_inputs

--- a/torchtnt/utils/__init__.py
+++ b/torchtnt/utils/__init__.py
@@ -26,10 +26,17 @@ from .distributed import (
 )
 from .early_stop_checker import EarlyStopChecker
 from .env import init_from_env, seed
+from .flops import FlopTensorDispatchMode
 from .fsspec import get_filesystem
 from .lr_scheduler import TLRScheduler
 from .memory import get_tensor_size_bytes_map, measure_rss_deltas, RSSProfiler
 from .misc import days_to_secs, transfer_batch_norm_stats, transfer_weights
+from .module_summary import (
+    get_module_summary,
+    get_summary_table,
+    ModuleSummary,
+    prune_module_summary,
+)
 from .oom import (
     attach_oom_observer,
     is_out_of_cpu_memory,
@@ -85,6 +92,7 @@ __all__ = [
     "EarlyStopChecker",
     "init_from_env",
     "seed",
+    "FlopTensorDispatchMode",
     "get_filesystem",
     "get_tensor_size_bytes_map",
     "measure_rss_deltas",
@@ -111,6 +119,10 @@ __all__ = [
     "get_timer_summary",
     "transfer_batch_norm_stats",
     "transfer_weights",
+    "get_module_summary",
+    "get_summary_table",
+    "ModuleSummary",
+    "prune_module_summary",
     "Timer",
     "create_progress_bar",
     "close_progress_bar",

--- a/torchtnt/utils/flops.py
+++ b/torchtnt/utils/flops.py
@@ -1,0 +1,335 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# Flop count implementation based on
+# https://dev-discuss.pytorch.org/t/the-ideal-pytorch-flop-counter-with-torch-dispatch/505
+
+import logging
+import operator
+from collections import defaultdict
+from functools import reduce
+from numbers import Number
+from typing import Any, Callable, DefaultDict, Dict, List, Tuple
+
+import torch
+from torch.utils._python_dispatch import TorchDispatchMode
+from torch.utils._pytree import PyTree, tree_map
+
+aten: torch._ops._OpNamespace = torch.ops.aten
+
+
+# pyre-ignore [2] we don't care the type in outputs
+def _matmul_flop_jit(inputs: Tuple[torch.Tensor], outputs: Tuple[Any]) -> Number:
+    """
+    Count flops for matmul.
+    """
+    # Inputs should be a list of length 2.
+    # Inputs contains the shapes of two matrices.
+    input_shapes = [v.shape for v in inputs]
+    assert len(input_shapes) == 2, input_shapes
+    assert input_shapes[0][-1] == input_shapes[1][-2], input_shapes
+    flop = inputs[0].numel() * input_shapes[-1][-1]
+    return flop
+
+
+# pyre-ignore [2] we don't care the type in outputs
+def _addmm_flop_jit(inputs: Tuple[torch.Tensor], outputs: Tuple[Any]) -> Number:
+    """
+    Count flops for fully connected layers.
+    """
+    # Count flop for nn.Linear
+    # inputs is a list of length 3.
+    input_shapes = [v.shape for v in inputs[1:3]]
+    # input_shapes[0]: [batch size, input feature dimension]
+    # input_shapes[1]: [batch size, output feature dimension]
+    assert len(input_shapes[0]) == 2, input_shapes[0]
+    assert len(input_shapes[1]) == 2, input_shapes[1]
+    batch_size, input_dim = input_shapes[0]
+    output_dim = input_shapes[1][1]
+    flops = batch_size * input_dim * output_dim
+    return flops
+
+
+# pyre-ignore [2] we don't care the type in outputs
+def _bmm_flop_jit(inputs: Tuple[torch.Tensor], outputs: Tuple[Any]) -> Number:
+    """
+    Count flops for the bmm operation.
+    """
+    # Inputs should be a list of length 2.
+    # Inputs contains the shapes of two tensor.
+    assert len(inputs) == 2, len(inputs)
+    input_shapes = [v.shape for v in inputs]
+    n, c, t = input_shapes[0]
+    d = input_shapes[-1][-1]
+    flop = n * c * t * d
+    return flop
+
+
+def _conv_flop_count(
+    x_shape: List[int],
+    w_shape: List[int],
+    out_shape: List[int],
+    transposed: bool = False,
+) -> Number:
+    """
+    Count flops for convolution. Note only multiplication is
+    counted. Computation for addition and bias is ignored.
+    Flops for a transposed convolution are calculated as
+    flops = (x_shape[2:] * prod(w_shape) * batch_size).
+    Args:
+        x_shape (list(int)): The input shape before convolution.
+        w_shape (list(int)): The filter shape.
+        out_shape (list(int)): The output shape after convolution.
+        transposed (bool): is the convolution transposed
+    Returns:
+        int: the number of flops
+    """
+    batch_size = x_shape[0]
+    conv_shape = (x_shape if transposed else out_shape)[2:]
+    flop = (
+        batch_size
+        * reduce(operator.mul, w_shape, 1)
+        * reduce(operator.mul, conv_shape, 1)
+    )
+    return flop
+
+
+def _conv_flop_jit(
+    inputs: Tuple[Any],  # pyre-ignore [2] the inputs can be union of Tensor/bool/Tuple
+    outputs: Tuple[torch.Tensor],
+) -> Number:
+    """
+    Count flops for convolution.
+    """
+    x: torch.Tensor = inputs[0]
+    w: torch.Tensor = inputs[1]
+    x_shape, w_shape, out_shape = (x.shape, w.shape, outputs[0].shape)
+    transposed: bool = inputs[6]
+
+    return _conv_flop_count(
+        list(x_shape), list(w_shape), list(out_shape), transposed=transposed
+    )
+
+
+def _transpose_shape(shape: torch.Size) -> List[int]:
+    return [shape[1], shape[0]] + list(shape[2:])
+
+
+# pyre-ignore [2] the inputs can be union of Tensor/bool/Tuple & we don't care about outputs
+def _conv_backward_flop_jit(inputs: Tuple[Any], outputs: Tuple[Any]) -> Number:
+    grad_out_shape, x_shape, w_shape = [i.shape for i in inputs[:3]]
+    output_mask = inputs[-1]
+    fwd_transposed = inputs[7]
+    flop_count: Number = 0
+
+    if output_mask[0]:
+        grad_input_shape = outputs[0].shape
+        # pyre-ignore [58] this is actually sum of Number and Number
+        flop_count = flop_count + _conv_flop_count(
+            grad_out_shape, w_shape, grad_input_shape, not fwd_transposed
+        )
+    if output_mask[1]:
+        grad_weight_shape = outputs[1].shape
+        flop_count += _conv_flop_count(
+            list(_transpose_shape(x_shape)),
+            list(grad_out_shape),
+            list(grad_weight_shape),
+            fwd_transposed,
+        )
+
+    return flop_count
+
+
+# pyre-ignore [5]
+flop_mapping: Dict[Callable[..., Any], Callable[[Tuple[Any], Tuple[Any]], Number]] = {
+    aten.mm: _matmul_flop_jit,
+    aten.matmul: _matmul_flop_jit,
+    aten.addmm: _addmm_flop_jit,
+    aten.bmm: _bmm_flop_jit,
+    aten.convolution: _conv_flop_jit,
+    aten._convolution: _conv_flop_jit,
+    aten.convolution_backward: _conv_backward_flop_jit,
+    # Add their default to make sure they can be mapped.
+    aten.mm.default: _matmul_flop_jit,
+    aten.matmul.default: _matmul_flop_jit,
+    aten.addmm.default: _addmm_flop_jit,
+    aten.bmm.default: _bmm_flop_jit,
+    aten.convolution.default: _conv_flop_jit,
+    aten._convolution.default: _conv_flop_jit,
+    aten.convolution_backward.default: _conv_backward_flop_jit,
+}
+
+
+# pyre-ignore [2, 3] it can be Tuple of anything.
+def _normalize_tuple(x: Any) -> Tuple[Any]:
+    if not isinstance(x, tuple):
+        return (x,)
+    return x
+
+
+class FlopTensorDispatchMode(TorchDispatchMode):
+    """
+    A context manager to measure flops of a module. Requires PyTorch 1.13+.
+
+    Flop count implementation based on
+    https://dev-discuss.pytorch.org/t/the-ideal-pytorch-flop-counter-with-torch-dispatch/505
+
+    Examples::
+
+        >>> import copy
+        >>> import torch
+        >>> import torchvision.models as models
+        >>> from torcheval.tools.flops import FlopTensorDispatchMode
+
+        >>> module = models.resnet18()
+        >>> module_input = torch.randn(1, 3, 224, 224)
+        >>> with FlopTensorDispatchMode(module) as ftdm:
+        >>>     # count forward flops
+        >>>     res = module(module_input).mean()
+        >>>     flops_forward = copy.deepcopy(ftdm.flop_counts)
+
+        >>>     # reset count before counting backward flops
+        >>>     ftdm.reset()
+        >>>     res.backward()
+        >>>     flops_backward = copy.deepcopy(ftdm.flop_counts)
+
+    """
+
+    def __init__(self, module: torch.nn.Module) -> None:
+        """
+        Initializes a FlopTensorDispatchMode context manager object.
+
+        Args:
+            module: The module to count flops on.
+        """
+        self._all_hooks: List[torch.utils.hooks.RemovableHandle] = []
+        self._instrument_module(module, "")
+
+        self.flop_counts: DefaultDict[str, DefaultDict[str, int]] = defaultdict(
+            lambda: defaultdict(int)
+        )
+        self._parents: List[str] = [""]
+
+    # pyre-ignore
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        for hook_handle in self._all_hooks:
+            hook_handle.remove()
+        super().__exit__(exc_type, exc_val, exc_tb)
+
+    def __torch_dispatch__(
+        self,
+        func: Callable[..., Any],  # pyre-ignore [2] func can be any func
+        types: Tuple[Any],  # pyre-ignore [2]
+        args=(),  # pyre-ignore [2]
+        kwargs=None,  # pyre-ignore [2]
+    ) -> PyTree:
+        rs = func(*args, **kwargs)
+        outs = _normalize_tuple(rs)
+
+        if func in flop_mapping:
+            flop_count = flop_mapping[func](args, outs)
+            for par in self._parents:
+                # pyre-ignore [58]
+                self.flop_counts[par][func.__name__] += flop_count
+        else:
+            logging.debug(f"{func} is not yet supported in FLOPs calculation.")
+
+        return rs
+
+    # pyre-ignore [3]
+    def _create_backwards_push(self, name: str) -> Callable[..., Any]:
+        class PushState(torch.autograd.Function):
+            @staticmethod
+            def forward(ctx, *args):
+                args = tree_map(
+                    lambda x: x.clone() if isinstance(x, torch.Tensor) else x, args
+                )
+                if len(args) == 1:
+                    return args[0]
+                return args
+
+            @staticmethod
+            def backward(ctx, *grad_outs):
+                parents = self._parents
+                parents.append(name)
+                return grad_outs
+
+        # Pyre does not support analyzing classes nested in functions.
+        # But this class can't be lifted out of the function as it is a static class
+        # using a function parameter.
+        return PushState.apply
+
+    # pyre-ignore [3]
+    def _create_backwards_pop(self, name: str) -> Callable[..., Any]:
+        class PopState(torch.autograd.Function):
+            @staticmethod
+            def forward(ctx, *args):
+                args = tree_map(
+                    lambda x: x.clone() if isinstance(x, torch.Tensor) else x, args
+                )
+                if len(args) == 1:
+                    return args[0]
+                return args
+
+            @staticmethod
+            def backward(ctx, *grad_outs):
+                parents = self._parents
+                assert parents[-1] == name
+                parents.pop()
+                return grad_outs
+
+        # Pyre does not support analyzing classes nested in functions.
+        # But this class can't be lifted out of the function as it is a static class
+        # using a function parameter.
+        return PopState.apply
+
+    # pyre-ignore [3] Return a callable function
+    def _enter_module(self, name: str) -> Callable[..., Any]:
+        # pyre-ignore [2, 3]
+        def f(module: torch.nn.Module, inputs: Tuple[Any]):
+            parents = self._parents
+            parents.append(name)
+            inputs = _normalize_tuple(inputs)
+            out = self._create_backwards_pop(name)(*inputs)
+            return out
+
+        return f
+
+    # pyre-ignore [3] Return a callable function
+    def _exit_module(self, name: str) -> Callable[..., Any]:
+        # pyre-ignore [2, 3]
+        def f(module: torch.nn.Module, inputs: Tuple[Any], outputs: Tuple[Any]):
+            parents = self._parents
+            assert parents[-1] == name
+            parents.pop()
+            outputs = _normalize_tuple(outputs)
+            return self._create_backwards_push(name)(*outputs)
+
+        return f
+
+    def _instrument_module(
+        self,
+        mod: torch.nn.Module,
+        par_name: str,
+    ) -> None:
+        for name, module in dict(mod.named_children()).items():
+            formatted_name = name
+            if par_name != "":
+                formatted_name = f"{par_name}.{name}"
+            self._all_hooks.append(
+                module.register_forward_pre_hook(self._enter_module(formatted_name))
+            )
+            self._all_hooks.append(
+                module.register_forward_hook(self._exit_module(formatted_name))
+            )
+            self._instrument_module(module, formatted_name)
+
+    def reset(self) -> None:
+        """
+        Resets current flop count.
+        """
+        self._parents = [""]
+        self.flop_counts.clear()

--- a/torchtnt/utils/module_summary.py
+++ b/torchtnt/utils/module_summary.py
@@ -1,0 +1,757 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+import copy
+import math
+import warnings
+from collections import defaultdict, deque
+from dataclasses import dataclass, field
+from enum import Enum
+from time import perf_counter
+from typing import (
+    Any,
+    Callable,
+    DefaultDict,
+    Deque,
+    Dict,
+    List,
+    MutableMapping,
+    Optional,
+    Tuple,
+    Union,
+)
+
+import torch
+from torch.nn.parameter import UninitializedParameter
+from torch.utils._pytree import PyTree, tree_flatten
+from torch.utils.hooks import RemovableHandle
+
+from torchtnt.utils.version import is_torch_version_geq_1_13
+from typing_extensions import Literal
+
+_ATTRIB_TO_COL_HEADER = {
+    "module_name": "Name",
+    "module_type": "Type",
+    "num_parameters": "# Parameters",
+    "num_trainable_parameters": "# Trainable Parameters",
+    "size_bytes": "Size (bytes)",
+    "has_uninitialized_param": "Contains Uninitialized Parameters?",
+    "flops_forward": "Forward FLOPs",
+    "flops_backward": "Backward FLOPs",
+    "in_size": "In size",
+    "out_size": "Out size",
+    "forward_elapsed_time_ms": "Forward Elapsed Times (ms)",
+}  # Attribute: column header (in table)
+_ATTRIBS: List[str] = list(_ATTRIB_TO_COL_HEADER.keys())
+_FLOP_ATTRIBS: List[str] = ["flops_forward", "flops_backward"]
+
+
+_PARAMETER_NUM_UNITS = [" ", "K", "M", "B", "T"]
+_PARAMETER_FLOPS_UNITS = [" ", "k", "M", "G", "T", "P", "E", "Z", "Y"]
+
+TUnknown = Literal["?"]
+_UNKNOWN_SIZE: TUnknown = "?"
+
+
+@dataclass
+class _ModuleSummaryData:
+    # mapping to store forward flops
+    flops_forward: Optional[DefaultDict[str, DefaultDict[str, int]]] = None
+    # mapping to store backward flops
+    flops_backward: Optional[DefaultDict[str, DefaultDict[str, int]]] = None
+    # mapping from module name to activation size tuple (in_size, out_size)
+    activation_sizes: Dict[
+        str, Tuple[Union[TUnknown, List[int]], Union[TUnknown, List[int]]]
+    ] = field(default_factory=dict)
+    # mapping from module name to elapsed time in ms
+    forward_elapsed_times_ms: Dict[str, float] = field(default_factory=dict)
+
+
+class ModuleSummary:
+    """
+    Summary of module and its submodules. It collects the following information:
+
+    - Name
+    - Type
+    - Number of parameters
+    - Number of trainable parameters
+    - Estimated size in bytes
+    - Whether this module contains uninitialized parameters
+    - FLOPs for forward ("?" meaning not calculated)
+    - FLOPs for backward ("?" meaning not calculated)
+    - Input shape ("?" meaning not calculated)
+    - Output shape ("?" meaning not calculated)
+    - Forward elapsed time in ms ("?" meaning not calculated)
+    """
+
+    def __init__(self) -> None:
+        self._module_name: str = ""
+        self._module_type: str = ""
+        self._num_parameters: int = 0
+        self._num_trainable_parameters: int = 0
+        self._size_bytes: int = 0
+        self._submodule_summaries: Dict[str, "ModuleSummary"] = {}
+        self._has_uninitialized_param: bool = False
+        self._flops_forward: Union[TUnknown, int] = _UNKNOWN_SIZE
+        self._flops_backward: Union[TUnknown, int] = _UNKNOWN_SIZE
+        self._flops_forward_detail: Dict[str, int] = {}
+        self._flops_backward_detail: Dict[str, int] = {}
+        self._in_size: Union[TUnknown, List[int]] = _UNKNOWN_SIZE
+        self._out_size: Union[TUnknown, List[int]] = _UNKNOWN_SIZE
+        self._forward_time_elapsed_ms: Union[TUnknown, float] = _UNKNOWN_SIZE
+
+    @property
+    def submodule_summaries(self) -> Dict[str, "ModuleSummary"]:
+        """
+        A Dict with the names of submodules as keys and corresponding :class:`~ModuleSummary`
+        objects as values. These can be traversed for visualization.
+        """
+        return self._submodule_summaries
+
+    @property
+    def module_name(self) -> str:
+        """Returns the name of this module"""
+        return self._module_name
+
+    @property
+    def module_type(self) -> str:
+        """Returns the type of this module."""
+        return self._module_type
+
+    @property
+    def num_parameters(self) -> int:
+        """Returns the total number of parameters in this module."""
+        if self.has_uninitialized_param:
+            warnings.warn(
+                "A layer with UninitializedParameter was found. "
+                "Thus, the total number of parameters detected may be inaccurate."
+            )
+        return self._num_parameters
+
+    @property
+    def num_trainable_parameters(self) -> int:
+        """
+        Returns the total number of trainable parameters (requires_grad=True)
+        in this module.
+        """
+        if self.has_uninitialized_param:
+            warnings.warn(
+                "A layer with UninitializedParameter was found. "
+                "Thus, the total number of parameters detected may be inaccurate."
+            )
+        return self._num_trainable_parameters
+
+    @property
+    def flops_forward(self) -> Union[int, TUnknown]:
+        """Returns the total FLOPs for forward calculation using this module."""
+        if self.has_uninitialized_param:
+            warnings.warn(
+                "A layer with UninitializedParameter was found. "
+                "Thus, the total number of FLOPs detected may be inaccurate."
+            )
+        return self._flops_forward
+
+    @property
+    def flops_backward(self) -> Union[int, TUnknown]:
+        """Returns the total FLOPs for backward calculation using this module."""
+        if self.has_uninitialized_param:
+            warnings.warn(
+                "A layer with UninitializedParameter was found. "
+                "Thus, the total number of FLOPs detected may be inaccurate."
+            )
+        return self._flops_backward
+
+    @property
+    def in_size(self) -> Union[TUnknown, List[int]]:
+        """Returns the input size of the module"""
+        return self._in_size
+
+    @property
+    def out_size(self) -> Union[TUnknown, List[int]]:
+        """Returns the output size of the module"""
+        return self._out_size
+
+    @property
+    def forward_elapsed_time_ms(self) -> Union[TUnknown, float]:
+        """Returns the forward time of the module in ms."""
+        return self._forward_time_elapsed_ms
+
+    @property
+    def size_bytes(self) -> int:
+        """Returns the total estimated size in bytes of a module."""
+        if self.has_uninitialized_param:
+            warnings.warn(
+                "A layer with UninitializedParameter was found. "
+                "Thus, the total byte sizes detected may be inaccurate."
+            )
+        return self._size_bytes
+
+    @property
+    def has_uninitialized_param(self) -> bool:
+        """Returns if a parameter in this module is uninitialized"""
+        return self._has_uninitialized_param
+
+    def __repr__(self) -> str:
+        return str(self)
+
+    def __str__(self) -> str:
+        return get_summary_table(self)
+
+
+def _clean_flops(flop: DefaultDict[str, DefaultDict[str, int]], N: int) -> None:
+    for _, sub_flop in flop.items():
+        for opr in sub_flop:
+            sub_flop[opr] = sub_flop[opr] // N
+
+
+def _get_module_flops_and_activation_sizes(
+    module: torch.nn.Module,
+    # pyre-ignore
+    module_args: Optional[Tuple[Any, ...]] = None,
+    # pyre-ignore
+    module_kwargs: Optional[MutableMapping[str, Any]] = None,
+) -> _ModuleSummaryData:
+    # a mapping from module name to activation size tuple (in_size, out_size)
+    activation_sizes: Dict[
+        str, Tuple[Union[TUnknown, List[int]], Union[TUnknown, List[int]]]
+    ] = {}
+    # place activation size hooks on all modules + submodules
+    activation_size_handles = _register_hooks(
+        module, [(_activation_size_hook(activation_sizes), _HookType.FORWARD_HOOK)]
+    )
+
+    forward_timer_mapping: Dict[str, float] = {}
+    forward_elapsed_times_sec: Dict[str, float] = {}
+    forward_elapsed_time_handles = _register_hooks(
+        module,
+        [
+            (_forward_time_pre_hook(forward_timer_mapping), _HookType.FORWARD_PRE_HOOK),
+            (
+                _forward_time_hook(forward_timer_mapping, forward_elapsed_times_sec),
+                _HookType.FORWARD_HOOK,
+            ),
+        ],
+    )
+
+    module.zero_grad()
+
+    module_args = module_args or ()
+    module_kwargs = module_kwargs or {}
+    flops_forward = None
+    flops_backward = None
+    if not is_torch_version_geq_1_13():
+        warnings.warn(
+            "Please install PyTorch 1.13 or higher to compute FLOPs: https://pytorch.org/get-started/locally/"
+        )
+        module(*module_args, **module_kwargs)
+        # detach activation size hook handles
+        for hook_handle in activation_size_handles:
+            hook_handle.remove()
+    else:
+        from torchtnt.utils.flops import FlopTensorDispatchMode
+
+        with FlopTensorDispatchMode(module) as ftdm:
+            # Count for forward flops (+ compute activation sizes)
+            res = module(*module_args, **module_kwargs)
+
+            # detach activation size hook handles
+            for hook_handle in activation_size_handles:
+                hook_handle.remove()
+
+            flops_forward = copy.deepcopy(ftdm.flop_counts)
+            if isinstance(res, torch.Tensor):
+                # Count for backward flops
+                ftdm.reset()
+                res.mean().backward()
+                flops_backward = copy.deepcopy(ftdm.flop_counts)
+            else:
+                warnings.warn(
+                    "Backward FLOPs are only computed if module foward returns a tensor."
+                )
+
+    # remove forward time elapsed handles
+    for hook_handle in forward_elapsed_time_handles:
+        hook_handle.remove()
+
+    # convert module timings to ms
+    forward_time_elapsed_ms = {}
+    for module_name in forward_elapsed_times_sec:
+        forward_time_elapsed_ms[module_name] = (
+            forward_elapsed_times_sec[module_name] / 1000.0
+        )
+
+    # Reverting all the changes:
+    module.zero_grad()
+    module_summary_data = _ModuleSummaryData(
+        flops_forward, flops_backward, activation_sizes, forward_time_elapsed_ms
+    )
+    # TODO: Reverting BN: We also need to save status of BN running mean/var before running and revert those.
+    return module_summary_data
+
+
+def _has_uninitialized_param(module: torch.nn.Module) -> bool:
+    for param in module.parameters():
+        if isinstance(param, UninitializedParameter):
+            return True
+    return False
+
+
+def _has_tensor(item: Optional[PyTree]) -> bool:
+    flattened_list, _ = tree_flatten(item)
+    for ele in flattened_list:
+        if isinstance(ele, torch.Tensor):
+            return True
+    return False
+
+
+def get_module_summary(
+    module: torch.nn.Module,
+    # pyre-ignore
+    module_args: Optional[Tuple[Any, ...]] = None,
+    # pyre-ignore
+    module_kwargs: Optional[MutableMapping[str, Any]] = None,
+) -> ModuleSummary:
+    """
+    Generate a :class:`~ModuleSummary` object, then assign its values and generate submodule tree.
+
+    Args:
+        module: The module to be summarized.
+        module_args: A tuple of arguments for the module to run and calculate FLOPs and activation sizes.
+        module_kwargs: Any kwarg arguments to be passed into the module's forward function.
+
+            Note:
+              To calculate FLOPs, you must use PyTorch 1.13 or greater.
+
+            Note:
+              If module contains any lazy submodule, we will NOT calculate FLOPs.
+
+            Note:
+              Currently only modules that output a single tensor are supported.
+              TODO: to support more flexible output for module.
+
+    """
+
+    module_summary_data = _ModuleSummaryData()
+    has_uninitialized_param = _has_uninitialized_param(module)
+    if not has_uninitialized_param:
+        has_tensor_in_args = _has_tensor(module_args)
+        has_tensor_in_kwargs = _has_tensor(module_kwargs)
+        if has_tensor_in_kwargs:
+            warnings.warn(
+                "A tensor in module_kwargs was found. This may lead to an inaccurately computed activation size, as keyword arguments are not passed into forward hooks for modules. "
+                "For best results, please input tensors though module_args."
+            )
+        if has_tensor_in_args or has_tensor_in_kwargs:
+            module_summary_data = _get_module_flops_and_activation_sizes(
+                module, module_args, module_kwargs
+            )
+
+    return _generate_module_summary(module, "", module_summary_data)
+
+
+def _generate_module_summary(
+    module: torch.nn.Module, module_name: str, module_summary_data: _ModuleSummaryData
+) -> ModuleSummary:
+    """
+    Recursively generate and populate metrics for ModelSummary.
+    """
+    module_summary = ModuleSummary()
+    module_summary._module_name = module_name
+    module_summary._module_type = str(module.__class__.__name__)
+
+    for name, submodule in module.named_children():
+
+        formatted_name = f"{module_name}.{name}" if module_name != "" else name
+
+        submodule_summary = _generate_module_summary(
+            submodule, formatted_name, module_summary_data
+        )
+
+        # Add results from submodule summary
+        module_summary._submodule_summaries[formatted_name] = submodule_summary
+        module_summary._has_uninitialized_param = (
+            module_summary._has_uninitialized_param
+            or submodule_summary._has_uninitialized_param
+        )
+        module_summary._num_parameters += submodule_summary._num_parameters
+        module_summary._num_trainable_parameters += (
+            submodule_summary._num_trainable_parameters
+        )
+        module_summary._size_bytes += submodule_summary._size_bytes
+
+    for param in module.parameters(recurse=False):
+        if isinstance(param, UninitializedParameter):
+            module_summary._has_uninitialized_param = True
+        else:
+            numel = param.numel()
+            module_summary._num_parameters += numel
+            module_summary._size_bytes += numel * param.element_size()
+            if param.requires_grad:
+                module_summary._num_trainable_parameters += numel
+
+    for buf in module.buffers(recurse=False):
+        module_summary._size_bytes += buf.numel() * buf.element_size()
+
+    flops_forward = module_summary_data.flops_forward
+    flops_backward = module_summary_data.flops_backward
+    activation_sizes = module_summary_data.activation_sizes
+    forward_elapsed_times_ms = module_summary_data.forward_elapsed_times_ms
+
+    # Calculate flops forward/backward.
+    if flops_forward is not None:
+        module_summary._flops_forward_detail = dict(flops_forward[module_name])
+        module_summary._flops_forward = sum(
+            [v for k, v in flops_forward[module_name].items()]
+        )
+    if flops_backward is not None:
+        module_summary._flops_backward_detail = dict(flops_backward[module_name])
+        module_summary._flops_backward = sum(
+            [v for k, v in flops_backward[module_name].items()]
+        )
+
+    # set activation sizes
+    if module_name in activation_sizes:
+        in_size, out_size = activation_sizes[module_name]
+        module_summary._in_size = in_size
+        module_summary._out_size = out_size
+
+    # set forward elasped times
+    if module_name in forward_elapsed_times_ms:
+        module_summary._forward_time_elapsed_ms = forward_elapsed_times_ms[module_name]
+
+    return module_summary
+
+
+def get_summary_table(
+    module_summary: ModuleSummary, human_readable_nums: bool = True
+) -> str:
+    """
+    Generates a string summary_table, tabularizing the information in module_summary.
+
+    Args:
+        module_summary: module_summary to be printed/tabularized
+        human_readable_nums: set to False for exact (e.g. 1234 vs 1.2 K)
+    """
+    stop_attr: List[str] = []
+    # Unpack attributes
+    if module_summary.flops_forward == _UNKNOWN_SIZE:
+        stop_attr.append("flops_forward")
+    if module_summary.flops_backward == _UNKNOWN_SIZE:
+        stop_attr.append("flops_backward")
+    if module_summary.in_size == _UNKNOWN_SIZE:
+        stop_attr.append("in_size")
+    if module_summary.out_size == _UNKNOWN_SIZE:
+        stop_attr.append("out_size")
+    if module_summary.forward_elapsed_time_ms == _UNKNOWN_SIZE:
+        stop_attr.append("forward_elapsed_time_ms")
+    unpacked_attribs, col_widths = defaultdict(list), defaultdict(int)
+    _unpack_attributes(
+        {"root": module_summary},
+        unpacked_attribs,
+        col_widths,
+        human_readable_nums,
+        stop_attr,
+    )
+
+    # Generate formatted summary_table string
+    s = "{:{}}"  # inner {}: col_width
+    use_attribs = [attr for attr in _ATTRIBS if attr not in stop_attr]
+    n_rows, n_cols = len(unpacked_attribs[use_attribs[0]]), len(use_attribs)
+    total_width = sum(col_widths.values()) + 3 * (n_cols - 1)
+
+    header = [
+        s.format(col_header, col_width)
+        for col_header, col_width in zip(
+            [_ATTRIB_TO_COL_HEADER[attr] for attr in use_attribs], col_widths.values()
+        )
+    ]
+    summary_table = " | ".join(header) + "\n" + "-" * total_width + "\n"
+
+    for i in range(n_rows):
+        row = []
+        for attrib in use_attribs:
+            row.append(unpacked_attribs[attrib][i])
+            row = [
+                s.format(r, col_width) for r, col_width in zip(row, col_widths.values())
+            ]
+        summary_table += " | ".join(row) + "\n"
+    # Add disclaims for FLOPs:
+    if "flops_forward" not in stop_attr or "flops_backward" not in stop_attr:
+        from torchtnt.utils.flops import flop_mapping
+
+        used_operators = "|".join(
+            [
+                f"`{j.__name__}`"
+                for j in flop_mapping.keys()
+                if not j.__name__.endswith(".default")
+            ]
+        )
+        summary_table += (
+            f"Remark for FLOPs calculation: (1) Only operators {used_operators} are included. "
+            + "To add more operators supported in FLOPs calculation, "
+            + "please contribute to torcheval/tools/flops.py. "
+            + "(2) The calculation related to additional loss function is not included. "
+            + "For forward, we calculated FLOPs based on `loss = model(input_data).mean()`. "
+            + "For backward, we calculated FLOPs based on `loss.backward()`. \n"
+        )
+    return summary_table
+
+
+def prune_module_summary(module_summary: ModuleSummary, *, max_depth: int) -> None:
+    """
+    Prune the module summaries that are deeper than max_depth in the module
+    summary tree. The ModuleSummary object is prunned inplace.
+
+    Args:
+        module_summary: Root module summary to prune.
+        max_depth: The maximum depth of module summaries to keep.
+
+    Raises:
+        ValueError:
+            If `max_depth` is an int less than 1
+    """
+    if max_depth < 1:
+        raise ValueError(f"`max_depth` must be an int greater than 0. Got {max_depth}.")
+    if max_depth == 1:
+        module_summary._submodule_summaries = {}
+        return
+
+    for submodule_summary in module_summary._submodule_summaries.values():
+        prune_module_summary(submodule_summary, max_depth=max_depth - 1)
+
+
+def _unpack_attributes(
+    module_summaries: Dict[str, ModuleSummary],
+    unpacked_attribs: Dict[str, List[str]],
+    col_widths: Dict[str, int],
+    human_readable_nums: bool = True,
+    stop_attr: Optional[List[str]] = None,
+) -> None:
+    """
+    Unpack/flatten recursive module_summaries into table columns and store in unpacked_attribs.
+    Also, populate col_widths (with max column width).
+
+    Args:
+        module_summaries: dict of module summaries
+        unpacked_attribs: collects unpacked/flattened columns
+        col_widths: tracks max table width for each column
+        human_readable_nums: human readable nums (e.g. 1.2 K for 1234)
+        stop_attr: a list of attributes that we stop from adding to the table,
+        i.e. exclude from _ATTRIBS
+    """
+
+    if not module_summaries:
+        return
+
+    for module_summary in module_summaries.values():
+        for attrib in _ATTRIBS:
+            if stop_attr is not None and attrib in stop_attr:
+                continue
+
+            # Convert attribute value to string appropriately
+            attrib_val = getattr(module_summary, attrib)
+            if isinstance(attrib_val, bool):
+                attrib_val = "Yes" if attrib_val else "No"
+            elif isinstance(attrib_val, int) and attrib in _FLOP_ATTRIBS:
+                if attrib_val < 0:
+                    attrib_val = ""
+                else:
+                    attrib_val = (
+                        _get_human_readable_count(
+                            attrib_val, labels=_PARAMETER_FLOPS_UNITS
+                        )
+                        if human_readable_nums
+                        else str(attrib_val)
+                    )
+            elif isinstance(attrib_val, int):
+                attrib_val = (
+                    _get_human_readable_count(attrib_val)
+                    if human_readable_nums
+                    else str(attrib_val)
+                )
+            elif isinstance(attrib_val, float):
+                attrib_val = f"{attrib_val:.10f}"
+            elif isinstance(attrib_val, list):
+                attrib_val = str(attrib_val)
+            elif attrib_val is None:
+                attrib_val = ""
+
+            # Store converted attribute value, track max column width
+            unpacked_attribs[attrib].append(attrib_val)
+            col_widths[attrib] = max(
+                len(_ATTRIB_TO_COL_HEADER[attrib]),
+                len(attrib_val),
+                col_widths[attrib],
+            )
+        # Recurse
+        _unpack_attributes(
+            module_summary.submodule_summaries,
+            unpacked_attribs,
+            col_widths,
+            human_readable_nums,
+            stop_attr,
+        )
+
+
+def _get_human_readable_count(number: int, labels: Optional[List[str]] = None) -> str:
+    """Abbreviates an integer number with K, M, B, T for thousands, millions, billions and trillions, respectively.
+    Examples:
+        >>> _get_human_readable_count(123)
+        '123  '
+        >>> _get_human_readable_count(1234)  # (one thousand)
+        '1.2 K'
+        >>> _get_human_readable_count(int(2e6))   # (two million)
+        '2.0 M'
+        >>> _get_human_readable_count(int(3e9))   # (three billion)
+        '3.0 B'
+        >>> _get_human_readable_count(int(3e9), labels=[" ", "K", "M", "G", "T"])  # (Using units for FLOPs, 3 G)
+        '3.0 G'
+        >>> _get_human_readable_count(int(4e14))  # (four hundred trillion)
+        '400 T'
+        >>> _get_human_readable_count(int(5e15))  # (more than trillion)
+        '5,000 T'
+    Args:
+        number: a positive integer number
+        labels: a list of units that we want to use per 10^3 digits. Defaults to [" ", "K", "M", "B", "T"]
+    Return:
+        A string formatted according to the pattern described above.
+    Raises:
+        ValueError:
+            If `number` is less than 0
+        TypeError:
+            If `number` is not an int
+    """
+    # logic does not work for floats (e.g. number=0.5)
+    if not isinstance(number, int):
+        raise TypeError(f"Input type must be int, but received {type(number)}")
+    if number < 0:
+        raise ValueError(f"Input value must be greater than 0, received {number}")
+    labels = labels or _PARAMETER_NUM_UNITS
+    if len(labels) <= 0:
+        raise ValueError(
+            f"Input labels must be a list with at least one string, received {labels}"
+        )
+
+    num_digits = int(math.floor(math.log10(number)) + 1 if number > 0 else 1)
+    num_groups = int(math.ceil(num_digits / 3))
+    num_groups = min(num_groups, len(labels))  # don't abbreviate beyond trillions
+    shift = -3 * (num_groups - 1)
+    number = number * (10**shift)
+    index = num_groups - 1
+    if index < 1 or number >= 100:
+        return f"{int(number):,d} {labels[index]}"
+
+    return f"{number:,.1f} {labels[index]}"
+
+
+def _parse_batch_shape(batch: torch.Tensor) -> Union[TUnknown, List[int]]:
+    if hasattr(batch, "shape"):
+        return list(batch.shape)
+
+    if isinstance(batch, (list, tuple)):
+        shape = [_parse_batch_shape(el) for el in batch]
+        return shape
+
+    return _UNKNOWN_SIZE
+
+
+class _HookType(Enum):
+    FORWARD_PRE_HOOK = 1
+    FORWARD_HOOK = 2
+    BACKWARD_PRE_HOOK = 3
+    BACKWARD_HOOK = 4
+
+
+def _activation_size_hook(
+    activation_sizes: Dict[
+        str, Tuple[Union[TUnknown, List[int]], Union[TUnknown, List[int]]]
+    ],
+    # pyre-ignore: Invalid type parameters [24]
+) -> Callable[[str], Callable]:
+    # pyre-ignore: Missing parameter annotation [2]
+    def intermediate_hook(
+        module_name: str,
+    ) -> Callable[[torch.nn.Module, Any, Any], None]:
+        # pyre-ignore
+        def hook(_: torch.nn.Module, inp: Any, out: Any) -> None:
+            if len(inp) == 1:
+                inp = inp[0]
+            in_size = _parse_batch_shape(inp)
+            out_size = _parse_batch_shape(out)
+            activation_sizes[module_name] = (in_size, out_size)
+
+        return hook
+
+    return intermediate_hook
+
+
+def _forward_time_pre_hook(
+    timer_mapping: Dict[str, float]
+    # pyre-ignore: Invalid type parameters [24]
+) -> Callable[[str], Callable]:
+    # pyre-ignore: Missing parameter annotation [2]
+    def intermediate_hook(
+        module_name: str,
+    ) -> Callable[[torch.nn.Module, Any], None]:
+        def hook(_module: torch.nn.Module, _inp: Any) -> None:
+            timer_mapping[module_name] = perf_counter()
+
+        return hook
+
+    return intermediate_hook
+
+
+def _forward_time_hook(
+    timer_mapping: Dict[str, float],
+    elapsed_times: Dict[str, float],
+    # pyre-ignore: Invalid type parameters [24]
+) -> Callable[[str], Callable]:
+    # pyre-ignore: Missing parameter annotation [2]
+    def intermediate_hook(
+        module_name: str,
+    ) -> Callable[[torch.nn.Module, Any, Any], None]:
+        def hook(_module: torch.nn.Module, _inp: Any, _out: Any) -> None:
+            if torch.cuda.is_available():
+                torch.cuda.synchronize()
+            elapsed_times[module_name] = perf_counter() - timer_mapping[module_name]
+
+        return hook
+
+    return intermediate_hook
+
+
+def _register_hooks(
+    module: torch.nn.Module,
+    # pyre-ignore: Invalid type parameters [24]
+    hooks: List[Tuple[Callable, _HookType]],
+) -> List[RemovableHandle]:
+    """
+    Handles recursive hook attachment to module and its submodules, and passes the module name to each hook function.
+    """
+    removable_handle_list: List[RemovableHandle] = []
+    if not isinstance(module, torch.jit.ScriptModule):
+        queue: Deque[Tuple[str, torch.nn.Module]] = deque([("", module)])
+        while len(queue) > 0:
+            module_name, mod = queue.pop()
+
+            # register hook
+            for hook, hook_type in hooks:
+                if hook_type == _HookType.FORWARD_PRE_HOOK:
+                    handle = mod.register_forward_pre_hook(hook(module_name))
+                elif hook_type == _HookType.FORWARD_HOOK:
+                    handle = mod.register_forward_hook(hook(module_name))
+                elif hook_type == _HookType.BACKWARD_PRE_HOOK:
+                    handle = mod.register_full_backward_pre_hook(hook(module_name))
+                else:
+                    handle = mod.register_full_backward_hook(hook(module_name))
+                removable_handle_list.append(handle)
+
+            for name, submodule in mod.named_children():
+                formatted_name = f"{module_name}.{name}" if module_name != "" else name
+                queue.append((formatted_name, submodule))
+    else:
+        warnings.warn("Registering hooks on torch.jit.ScriptModule is not supported.")
+    return removable_handle_list


### PR DESCRIPTION
Summary: Move `flops`, `ModuleSummary` utilities to TNT, and removed reference to flops in quickstart jupyter notebook

Differential Revision: D47735567

