### PR TITLE
step arg as optional in tensorboard logger

### DIFF
--- a/torchtnt/utils/loggers/tensorboard.py
+++ b/torchtnt/utils/loggers/tensorboard.py
@@ -93,7 +93,7 @@ class TensorBoardLogger(MetricLogger):
 
         Args:
             payload (dict): dictionary of tag name and scalar value
-            step (int, Optional): step value to record
+            step (int): step value to record
         """
 
         if self._writer:
@@ -106,7 +106,7 @@ class TensorBoardLogger(MetricLogger):
         Args:
             name (string): tag name used to group scalars
             data (float/int/Tensor): scalar data to log
-            step (int, optional): step value to record
+            step (int): step value to record
         """
 
         if self._writer:


### PR DESCRIPTION
Summary:
received this error:

```
[0]: > self.tb_logger.log("avg_test_auc", self.total_auc_sum / self.num_eval_steps)
[0]:TypeError: TensorBoardLogger.log() missing 1 required positional argument: 'step'
```

Docstring says it is optional, but it is typed to be enforced

https://www.internalfb.com/code/fbsource/[5c36f61b6704d4472063673bdb28d73e0bb992d7]/fbcode/torchtnt/utils/loggers/tensorboard.py?lines=91-113

changing `step: int` to `step: Optional[int] = None`

Differential Revision: D47921178

