### PR TITLE
In TorchSnapshotSaver log a warning if dataloader is passed in but a corresponding entry isn't found in the manifest

### DIFF
--- a/torchtnt/framework/callbacks/torchsnapshot_saver.py
+++ b/torchtnt/framework/callbacks/torchsnapshot_saver.py
@@ -252,6 +252,9 @@ class TorchSnapshotSaver(Callback):
                 if _TRAIN_DL_STATE_KEY in key:
                     app_state[_TRAIN_DL_STATE_KEY] = train_dataloader
                     break
+            rank_zero_warn(
+                "train_dataloader was passed to `restore` but no train dataloader exists in the Snapshot"
+            )
 
         snapshot.restore(app_state)
         rank_zero_info(f"Restored snapshot from path: {path}", logger=logger)


### PR DESCRIPTION
Summary: Also added a unit test for saving/restoring dataloader state

Differential Revision: D48080602

