### PR TITLE
empty cuda cache callback

### DIFF
--- a/tests/framework/callbacks/test_empty_cuda_cache.py
+++ b/tests/framework/callbacks/test_empty_cuda_cache.py
@@ -1,0 +1,55 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+import unittest
+from unittest import mock
+
+from torchtnt.framework._test_utils import DummyFitUnit, generate_random_dataloader
+from torchtnt.framework.callbacks.empty_cuda_cache import EmptyCudaCache
+from torchtnt.framework.fit import fit
+
+
+class EmptyCudaCacheTest(unittest.TestCase):
+    def test_empty_cuda_cache_call_count_fit(self) -> None:
+        """
+        Test EmptyCudaCache callback was called correct number of times (with fit entry point)
+        """
+        input_dim = 2
+        train_dataset_len = 10
+        eval_dataset_len = 6
+        batch_size = 2
+        max_epochs = 2
+        evaluate_every_n_epochs = 1
+        expected_num_total_steps = (
+            train_dataset_len / batch_size * max_epochs
+            + eval_dataset_len / batch_size * max_epochs
+        )
+        step_interval = 4
+
+        my_unit = DummyFitUnit(2)
+        ecc_callback = EmptyCudaCache(step_interval)
+
+        train_dataloader = generate_random_dataloader(
+            train_dataset_len, input_dim, batch_size
+        )
+        eval_dataloader = generate_random_dataloader(
+            eval_dataset_len, input_dim, batch_size
+        )
+
+        expected_num_calls_to_cuda_empty = expected_num_total_steps / step_interval
+        with mock.patch(
+            "torchtnt.framework.callbacks.empty_cuda_cache.torch.cuda.empty_cache"
+        ) as empty_mock:
+            fit(
+                my_unit,
+                train_dataloader=train_dataloader,
+                eval_dataloader=eval_dataloader,
+                max_epochs=max_epochs,
+                evaluate_every_n_epochs=evaluate_every_n_epochs,
+                callbacks=[ecc_callback],
+            )
+            self.assertEqual(empty_mock.call_count, expected_num_calls_to_cuda_empty)

--- a/torchtnt/framework/callbacks/__init__.py
+++ b/torchtnt/framework/callbacks/__init__.py
@@ -5,6 +5,7 @@
 # LICENSE file in the root directory of this source tree.
 
 from .base_csv_writer import BaseCSVWriter
+from .empty_cuda_cache import EmptyCudaCache
 from .garbage_collector import GarbageCollector
 from .lambda_callback import Lambda
 from .learning_rate_monitor import LearningRateMonitor
@@ -18,6 +19,7 @@ from .train_progress_monitor import TrainProgressMonitor
 
 __all__ = [
     "BaseCSVWriter",
+    "EmptyCudaCache",
     "GarbageCollector",
     "Lambda",
     "LearningRateMonitor",

--- a/torchtnt/framework/callbacks/empty_cuda_cache.py
+++ b/torchtnt/framework/callbacks/empty_cuda_cache.py
@@ -1,0 +1,51 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+import torch
+
+from torchtnt.framework.callback import Callback
+from torchtnt.framework.state import EntryPoint, State
+from torchtnt.framework.unit import TEvalUnit, TPredictUnit, TTrainUnit
+
+
+class EmptyCudaCache(Callback):
+    """
+    A callback that performs periodic emptying of cuda cache using `torch.cuda.empty_cache <https://pytorch.org/docs/stable/generated/torch.cuda.empty_cache.html#torch.cuda.empty_cache>_.
+
+    On different ranks, reserved memory and fragmentation might diverge after several iterations.
+    If different ranks trigger de-fragmentation (i.e. cudaFree and redo cudaMalloc later)
+    at different times, there will be different stragglers in different iterations, which will
+    hurt the performance and will get worse with larger clusters. To avoid this, this callback
+    calls empty_cache() at the same cadence across all ranks.
+
+    Args:
+        step_interval: number of steps to run before emptying cuda cache
+    """
+
+    def __init__(self, step_interval: int) -> None:
+        self._step_interval = step_interval
+
+    def on_train_step_end(self, state: State, unit: TTrainUnit) -> None:
+        total_num_steps_completed = unit.train_progress.num_steps_completed
+        if state.entry_point == EntryPoint.FIT:
+            # if fitting, include the num eval steps completed in the total steps completed
+            total_num_steps_completed += unit.eval_progress.num_steps_completed
+
+        if total_num_steps_completed % self._step_interval == 0:
+            torch.cuda.empty_cache()
+
+    def on_eval_step_end(self, state: State, unit: TEvalUnit) -> None:
+        total_num_steps_completed = unit.eval_progress.num_steps_completed
+        if state.entry_point == EntryPoint.FIT:
+            # if fitting, include the num train steps completed in the total steps completed
+            total_num_steps_completed += unit.train_progress.num_steps_completed
+
+        if total_num_steps_completed % self._step_interval == 0:
+            torch.cuda.empty_cache()
+
+    def on_predict_step_end(self, state: State, unit: TPredictUnit) -> None:
+        if unit.predict_progress.num_steps_completed % self._step_interval == 0:
+            torch.cuda.empty_cache()


### PR DESCRIPTION
Summary: Add callback to periodically call `torch.cuda.empty_cache()`

Differential Revision: D48179378

