### PR TITLE
add precision util module

### DIFF
--- a/tests/utils/test_precision.py
+++ b/tests/utils/test_precision.py
@@ -1,0 +1,34 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+import unittest
+
+import torch
+
+from torchtnt.utils.precision import convert_precision_str_to_dtype
+
+
+class PrecisionTest(unittest.TestCase):
+    def test_convert_precision_str_to_dtype_success(self) -> None:
+        for (precision_str, expected_dtype) in [
+            ("fp16", torch.float16),
+            ("bf16", torch.bfloat16),
+            ("fp32", None),
+        ]:
+            with self.subTest(
+                precision_str=precision_str, expected_dtype=expected_dtype
+            ):
+                self.assertEqual(
+                    convert_precision_str_to_dtype(precision_str), expected_dtype
+                )
+
+    def test_convert_precision_str_to_dtype_throws(self) -> None:
+        with self.assertRaisesRegex(
+            ValueError,
+            "Precision foo not supported. Please use one of .*",
+        ):
+            convert_precision_str_to_dtype("foo")

--- a/torchtnt/utils/__init__.py
+++ b/torchtnt/utils/__init__.py
@@ -44,6 +44,7 @@ from .oom import (
     is_out_of_memory_error,
     log_memory_snapshot,
 )
+from .precision import convert_precision_str_to_dtype
 from .prepare_module import DDPStrategy, FSDPStrategy, prepare_ddp, prepare_fsdp
 from .progress import Progress
 from .rank_zero_log import (
@@ -103,6 +104,7 @@ __all__ = [
     "is_out_of_cuda_memory",
     "is_out_of_memory_error",
     "log_memory_snapshot",
+    "convert_precision_str_to_dtype",
     "DDPStrategy",
     "FSDPStrategy",
     "prepare_ddp",

--- a/torchtnt/utils/precision.py
+++ b/torchtnt/utils/precision.py
@@ -1,0 +1,34 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+from typing import Mapping, Optional
+
+import torch
+
+_DTYPE_STRING_TO_DTYPE_MAPPING: Mapping[str, Optional[torch.dtype]] = {
+    "fp16": torch.float16,
+    "bf16": torch.bfloat16,
+    "fp32": None,
+}
+
+
+def convert_precision_str_to_dtype(precision: str) -> Optional[torch.dtype]:
+    """
+    Converts precision as a string to a torch.dtype
+
+    Args:
+        precision: string containing the precision
+
+    Raises:
+        ValueError if an invalid precision string is passed.
+
+    """
+    if precision not in _DTYPE_STRING_TO_DTYPE_MAPPING:
+        raise ValueError(
+            f"Precision {precision} not supported. Please use one of {list(_DTYPE_STRING_TO_DTYPE_MAPPING.keys())}"
+        )
+    return _DTYPE_STRING_TO_DTYPE_MAPPING[precision]


### PR DESCRIPTION
Summary:
# Context
We want to add `mixed_precision` to `FSDPStrategy` dataclass, and stop populating the `FSDPStrategy` with whatever `precision` the user has passed to the `AutoUnit`'s constructor. See attached task for more details

# This diff
Before making the above change, extracting `convert_precision_str_to_dtype` to a precision util module, instead of copy-pasting everywhere in users's code

# What’s next
Introduce `mixed_precision` to `FSDPStrategy`

Differential Revision: D48273660

