### PR TITLE
add precision as an argument to FSDP strategy dataclass

### DIFF
--- a/torchtnt/framework/auto_unit.py
+++ b/torchtnt/framework/auto_unit.py
@@ -206,7 +206,6 @@ class AutoPredictUnit(PredictUnit[TPredictData]):
                     module,
                     self.device,
                     strategy,
-                    self.precision,
                 )
         else:
             module = module.to(self.device)
@@ -446,7 +445,7 @@ class AutoUnit(
                 rank_zero_warn(
                     "We recommend setting FSDPStrategy's use_original_params to True when using torch compile."
                 )
-                module = prepare_fsdp(module, self.device, strategy, self.precision)
+                module = prepare_fsdp(module, self.device, strategy)
         else:
             module = module.to(self.device)
 


### PR DESCRIPTION
Summary:
# Context
We want to add `mixed_precision` to `FSDPStrategy` dataclass, and stop populating the `FSDPStrategy` with whatever `precision` the user has passed to the `AutoUnit`'s constructor. See attached task for more details

# This diff
- Add the above.
- Modify from `asdict()` to `__dict__` as the former works recursively, which then throws an exception when `MixedPrecision` becomes a dict
- Adjust users who use `FSDPStrategy` to pass in the `mixed_precision`. Found the right `precision` to use by looking for the `precision` passed in the `AutoUnit` constructor

Reviewed By: JKSenthil

Differential Revision: D48248411

