### PR TITLE
remove redundant pyre-ignore from auto_unit

### DIFF
--- a/torchtnt/framework/auto_unit.py
+++ b/torchtnt/framework/auto_unit.py
@@ -95,8 +95,6 @@ class ActivationCheckpointParams:
     check_fn: Optional[Callable[[torch.nn.Module], bool]]
 
 
-# pyre-ignore: Invalid type parameters [24]
-TSelf = TypeVar("TSelf", bound="AutoUnit")
 TData = TypeVar("TData")
 
 


### PR DESCRIPTION
Summary: `TSelf` isn't using anywhere and has a `pyre-ignore` to suppress `pyre` issues. Remove it with the `pyre-ignore` suppression

Differential Revision: D48289131

