### PR TITLE
update references to torcheval tools

### DIFF
--- a/torchtnt/utils/flops.py
+++ b/torchtnt/utils/flops.py
@@ -182,7 +182,7 @@ class FlopTensorDispatchMode(TorchDispatchMode):
         >>> import copy
         >>> import torch
         >>> import torchvision.models as models
-        >>> from torcheval.tools.flops import FlopTensorDispatchMode
+        >>> from torchtnt.utils.flops import FlopTensorDispatchMode
 
         >>> module = models.resnet18()
         >>> module_input = torch.randn(1, 3, 224, 224)


### PR DESCRIPTION
Summary: forgot to remove torcheval tools from docs and in TNT docstring from D47735567

Reviewed By: bobakfb, ananthsub

Differential Revision: D48573263

