### PR TITLE
touch up prepare_module

### DIFF
--- a/tests/framework/test_auto_unit.py
+++ b/tests/framework/test_auto_unit.py
@@ -25,12 +25,7 @@ from torchtnt.framework._test_utils import (
     get_dummy_train_state,
 )
 
-from torchtnt.framework.auto_unit import (
-    AutoPredictUnit,
-    AutoUnit,
-    DDPStrategy,
-    FSDPStrategy,
-)
+from torchtnt.framework.auto_unit import AutoPredictUnit, AutoUnit
 from torchtnt.framework.evaluate import evaluate
 from torchtnt.framework.predict import predict
 from torchtnt.framework.state import State
@@ -39,7 +34,12 @@ from torchtnt.framework.unit import TPredictData
 from torchtnt.utils.device import copy_data_to_device
 from torchtnt.utils.env import init_from_env
 from torchtnt.utils.lr_scheduler import TLRScheduler
-from torchtnt.utils.prepare_module import SWAParams, TorchCompileParams
+from torchtnt.utils.prepare_module import (
+    DDPStrategy,
+    FSDPStrategy,
+    SWAParams,
+    TorchCompileParams,
+)
 from torchtnt.utils.test_utils import spawn_multi_process
 from torchtnt.utils.timer import Timer
 

--- a/tests/utils/test_prepare_module.py
+++ b/tests/utils/test_prepare_module.py
@@ -373,3 +373,16 @@ class PrepareModelTest(unittest.TestCase):
                 device=init_from_env(),
                 torch_compile_params=TorchCompileParams(backend="foo"),
             )
+
+    def test_prepare_module_incompatible_FSDP_torchcompile_params(self) -> None:
+        """
+        verify error is thrown when FSDP's use_orig_params and torch compile is enabled
+        """
+
+        with self.assertRaises(RuntimeError):
+            prepare_module(
+                module=torch.nn.Linear(2, 2),
+                device=init_from_env(),
+                strategy=FSDPStrategy(use_orig_params=False),
+                torch_compile_params=TorchCompileParams(),
+            )


### PR DESCRIPTION
Summary: Makes AutoPredictUnit use `prepare_module` and adds runtime error instead if incompatible torch compile + fsdp parameters are discovered (see D47473960)

Differential Revision: D48751758

