### PR TITLE
remove pyre-ignore-all

### DIFF
--- a/torchtnt/framework/auto_unit.py
+++ b/torchtnt/framework/auto_unit.py
@@ -4,9 +4,6 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
-# ignore errors due to `Any` type
-# pyre-ignore-all-errors[2]
-# pyre-ignore-all-errors[3]
 
 import contextlib
 from abc import ABCMeta, abstractmethod
@@ -48,6 +45,8 @@ TData = TypeVar("TData")
 
 
 class _ConfigureOptimizersCaller(ABCMeta):
+    # pyre-fixme[3]: Return type must be annotated.
+    # pyre-fixme[2]: Parameter must be annotated.
     def __call__(self, *args, **kwargs):
         x = super().__call__(*args, **kwargs)
         x.optimizer = None
@@ -180,6 +179,7 @@ class AutoPredictUnit(PredictUnit[TPredictData]):
 
         self.detect_anomaly = detect_anomaly
 
+    # pyre-fixme[3]: Return annotation cannot be `Any`.
     def predict_step(self, state: State, data: Iterator[TPredictData]) -> Any:
         batch = self._get_next_batch(state, data)
 
@@ -200,7 +200,12 @@ class AutoPredictUnit(PredictUnit[TPredictData]):
         return outputs
 
     def on_predict_step_end(
-        self, state: State, data: TPredictData, step: int, outputs: Any
+        self,
+        state: State,
+        data: TPredictData,
+        step: int,
+        # pyre-fixme[2]: Parameter annotation cannot be `Any`.
+        outputs: Any,
     ) -> None:
         """
         This will be called at the end of every ``predict_step`` before returning. The user can implement this method with code to update and log their metrics,
@@ -437,6 +442,7 @@ class AutoUnit(
         ...
 
     @abstractmethod
+    # pyre-fixme[3]: Return annotation cannot contain `Any`.
     def compute_loss(self, state: State, data: TData) -> Tuple[torch.Tensor, Any]:
         """
         The user should implement this method with their loss computation. This will be called every ``train_step``/``eval_step``.
@@ -531,6 +537,7 @@ class AutoUnit(
 
         return batch
 
+    # pyre-fixme[3]: Return annotation cannot contain `Any`.
     def train_step(
         self, state: State, data: Iterator[TData]
     ) -> Tuple[torch.Tensor, Any]:
@@ -659,7 +666,13 @@ class AutoUnit(
         return loss, outputs
 
     def on_train_step_end(
-        self, state: State, data: TData, step: int, loss: torch.Tensor, outputs: Any
+        self,
+        state: State,
+        data: TData,
+        step: int,
+        loss: torch.Tensor,
+        # pyre-fixme[2]: Parameter annotation cannot be `Any`.
+        outputs: Any,
     ) -> None:
         """
         This will be called at the end of every ``train_step`` before returning. The user can implement this method with code to update and log their metrics,
@@ -715,6 +728,7 @@ class AutoUnit(
             ):
                 transfer_batch_norm_stats(swa_model, self.module)
 
+    # pyre-fixme[3]: Return annotation cannot contain `Any`.
     def eval_step(self, state: State, data: TData) -> Tuple[torch.Tensor, Any]:
         with get_timing_context(
             state, f"{self.__class__.__name__}.move_data_to_device"
@@ -735,7 +749,13 @@ class AutoUnit(
         return loss, outputs
 
     def on_eval_step_end(
-        self, state: State, data: TData, step: int, loss: torch.Tensor, outputs: Any
+        self,
+        state: State,
+        data: TData,
+        step: int,
+        loss: torch.Tensor,
+        # pyre-fixme[2]: Parameter annotation cannot be `Any`.
+        outputs: Any,
     ) -> None:
         """
         This will be called at the end of every ``eval_step`` before returning. The user can implement this method with code to update and log their metrics,

--- a/torchtnt/framework/state.py
+++ b/torchtnt/framework/state.py
@@ -5,9 +5,6 @@
 # LICENSE file in the root directory of this source tree.
 
 # ignore errors due to `Any` type
-# pyre-ignore-all-errors[2]
-# pyre-ignore-all-errors[3]
-# pyre-ignore-all-errors[4]
 
 import logging
 from enum import auto, Enum
@@ -67,6 +64,7 @@ class PhaseState:
     def __init__(
         self,
         *,
+        # pyre-fixme[2]: Parameter annotation cannot contain `Any`.
         dataloader: Iterable[Any],
         max_epochs: Optional[int] = None,  # used only for train
         max_steps: Optional[int] = None,  # used only for train
@@ -80,6 +78,7 @@ class PhaseState:
         _check_loop_condition("evaluate_every_n_steps", evaluate_every_n_steps)
         _check_loop_condition("evaluate_every_n_epochs", evaluate_every_n_epochs)
 
+        # pyre-fixme[4]: Attribute annotation cannot contain `Any`.
         self._dataloader: Iterable[Any] = dataloader
         self._max_epochs = max_epochs
         self._max_steps = max_steps
@@ -87,12 +86,14 @@ class PhaseState:
         self._evaluate_every_n_steps = evaluate_every_n_steps
         self._evaluate_every_n_epochs = evaluate_every_n_epochs
 
+        # pyre-fixme[4]: Attribute annotation cannot be `Any`.
         self._step_output: Any = None
         self._iteration_timer = BoundedTimer(
             cuda_sync=False, lower_bound=1_000, upper_bound=5_000
         )
 
     @property
+    # pyre-fixme[3]: Return annotation cannot contain `Any`.
     def dataloader(self) -> Iterable[Any]:
         """Dataloader defined by the user."""
         return self._dataloader
@@ -123,6 +124,7 @@ class PhaseState:
         return self._evaluate_every_n_epochs
 
     @property
+    # pyre-fixme[3]: Return annotation cannot be `Any`.
     def step_output(self) -> Any:
         """Output of the last step."""
         return self._step_output

--- a/torchtnt/framework/unit.py
+++ b/torchtnt/framework/unit.py
@@ -4,9 +4,6 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
-# Disable `Any` type errors
-# pyre-ignore-all-errors[2]
-# pyre-ignore-all-errors[3]
 
 from abc import ABC, abstractmethod
 from typing import Any, Dict, Generic, TypeVar
@@ -77,6 +74,7 @@ class AppStateMixin:
     def tracked_misc_statefuls(self) -> Dict[str, Any]:
         return self._misc_statefuls
 
+    # pyre-fixme[3]: Return annotation cannot be `Any`.
     def __getattr__(self, name: str) -> Any:
         if "_modules" in self.__dict__:
             _modules = self.__dict__["_modules"]
@@ -104,6 +102,7 @@ class AppStateMixin:
     def _update_attr(
         self,
         name: str,
+        # pyre-fixme[2]: Parameter annotation cannot be `Any`.
         value: Any,
         tracked_objects: Dict[str, Any],
     ) -> None:
@@ -122,6 +121,7 @@ class AppStateMixin:
         )
         tracked_objects[name] = value
 
+    # pyre-fixme[2]: Parameter annotation cannot be `Any`.
     def __setattr__(self, name: str, value: Any) -> None:
         if isinstance(value, torch.nn.Module):
             self._update_attr(name, value, self.__dict__.get("_modules"))
@@ -248,6 +248,7 @@ class TrainUnit(AppStateMixin, _OnExceptionMixin, Generic[TTrainData], ABC):
         pass
 
     @abstractmethod
+    # pyre-fixme[3]: Return annotation cannot be `Any`.
     def train_step(self, state: State, data: TTrainData) -> Any:
         """Core required method for user to implement. This method will be called at each iteration of the
         train dataloader, and can return any data the user wishes.
@@ -328,6 +329,7 @@ class EvalUnit(AppStateMixin, _OnExceptionMixin, Generic[TEvalData], ABC):
         pass
 
     @abstractmethod
+    # pyre-fixme[3]: Return annotation cannot be `Any`.
     def eval_step(self, state: State, data: TEvalData) -> Any:
         """
         Core required method for user to implement. This method will be called at each iteration of the
@@ -415,6 +417,7 @@ class PredictUnit(
         pass
 
     @abstractmethod
+    # pyre-fixme[3]: Return annotation cannot be `Any`.
     def predict_step(self, state: State, data: TPredictData) -> Any:
         """
         Core required method for user to implement. This method will be called at each iteration of the

--- a/torchtnt/utils/distributed.py
+++ b/torchtnt/utils/distributed.py
@@ -5,7 +5,6 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
-# pyre-ignore-all-errors[2]: Parameter must have a type that does not contain `Any`
 
 import os
 import tempfile
@@ -55,11 +54,13 @@ class PGWrapper:
         else:
             dist.barrier(group=self.pg)
 
+    # pyre-fixme[2]: Parameter annotation cannot contain `Any`.
     def broadcast_object_list(self, obj_list: List[Any], src: int = 0) -> None:
         if self.pg is None:
             return
         dist.broadcast_object_list(obj_list, src=src, group=self.pg)
 
+    # pyre-fixme[2]: Parameter annotation cannot contain `Any`.
     def all_gather_object(self, obj_list: List[Any], obj: Any) -> None:
         if self.pg is None:
             obj_list[0] = obj
@@ -68,7 +69,9 @@ class PGWrapper:
 
     def scatter_object_list(
         self,
+        # pyre-fixme[2]: Parameter annotation cannot contain `Any`.
         output_list: List[Any],
+        # pyre-fixme[2]: Parameter annotation cannot contain `Any`.
         input_list: Optional[List[Any]],
         src: int = 0,
     ) -> None:


### PR DESCRIPTION
Summary: Get rid of `pyre-ignore-all-errors` and replace with actual errors per line to give a better reflection on what is annotated

Differential Revision: D48838941

