### PR TITLE
tb train iteration time logger

### DIFF
--- a/docs/source/framework/callbacks.rst
+++ b/docs/source/framework/callbacks.rst
@@ -27,6 +27,7 @@ We offer several pre-written callbacks which are ready to be used out of the box
     PyTorchProfiler
     SystemResourcesMonitor
     TensorBoardParameterMonitor
+    IterationTimeLogger
     TorchSnapshotSaver
     TQDMProgressBar
     TrainProgressMonitor

--- a/tests/framework/callbacks/test_iteration_time_logger.py
+++ b/tests/framework/callbacks/test_iteration_time_logger.py
@@ -1,0 +1,55 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+import unittest
+from unittest.mock import MagicMock
+
+from torch.utils.tensorboard import SummaryWriter
+from torchtnt.framework._test_utils import DummyTrainUnit, generate_random_dataloader
+from torchtnt.framework.callbacks.iteration_time_logger import IterationTimeLogger
+
+from torchtnt.framework.state import State
+from torchtnt.framework.train import train
+from torchtnt.utils.loggers import TensorBoardLogger
+
+
+class IterationTimeLoggerTest(unittest.TestCase):
+    def test_iteration_time_logger_test_on_train_step_end(self) -> None:
+        logger = MagicMock(spec=TensorBoardLogger)
+        logger.writer = MagicMock(spec=SummaryWriter)
+        state = MagicMock(spec=State)
+        state.train_state.iteration_timer.recorded_durations = {
+            "train_iteration_time": [1, 3, 5, 7, 9]
+        }
+
+        my_unit = DummyTrainUnit(input_dim=2)
+        my_unit.train_progress.increment_step()
+        my_unit.train_progress.increment_step()
+        callback = IterationTimeLogger(logger=logger, moving_avg_window=4)
+        callback.on_train_step_end(state, my_unit)
+
+        logger.writer.add_scalar.assert_called_with(
+            "Train Iteration Time (seconds)",
+            6,  # the average of the last 4 numbers is 6
+            2,  # after incrementing twice, step should be 2
+        )
+
+    def test_with_train_epoch(self) -> None:
+        """
+        Test IterationTimeLogger callback with train entry point
+        """
+
+        my_unit = DummyTrainUnit(input_dim=2)
+        logger = MagicMock(spec=TensorBoardLogger)
+        logger.writer = MagicMock(spec=SummaryWriter)
+        callback = IterationTimeLogger(logger, moving_avg_window=1, log_every_n_steps=3)
+        dataloader = generate_random_dataloader(
+            num_samples=12, input_dim=2, batch_size=2
+        )
+        train(my_unit, dataloader, max_epochs=2, callbacks=[callback])
+        # 2 epochs, 6 iterations each, logging every third step
+        self.assertEqual(logger.writer.add_scalar.call_count, 4)

--- a/torchtnt/framework/callbacks/iteration_time_logger.py
+++ b/torchtnt/framework/callbacks/iteration_time_logger.py
@@ -1,0 +1,65 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+
+from typing import Union
+
+from pyre_extensions import none_throws
+from torch.utils.tensorboard import SummaryWriter
+
+from torchtnt.framework.callback import Callback
+from torchtnt.framework.state import PhaseState, State
+from torchtnt.framework.unit import TTrainUnit
+from torchtnt.utils.distributed import get_global_rank
+from torchtnt.utils.loggers.tensorboard import TensorBoardLogger
+
+
+class IterationTimeLogger(Callback):
+    """
+    A callback which logs iteration times as scalars to TensorBoard.
+
+    Args:
+        logger: Either a :class:`torchtnt.loggers.tensorboard.TensorBoardLogger`
+            or a :class:`torch.utils.tensorboard.SummaryWriter` instance.
+        moving_avg_window: an optional int to control the moving average window
+        log_every_n_steps: an optional int to control the log frequency
+    """
+
+    def __init__(
+        self,
+        logger: Union[TensorBoardLogger, SummaryWriter],
+        moving_avg_window: int = 1,
+        log_every_n_steps: int = 1,
+    ) -> None:
+        if isinstance(logger, TensorBoardLogger):
+            logger = logger.writer
+        self._writer: SummaryWriter = none_throws(
+            logger, "TensorBoardLogger.writer should not be None"
+        )
+        self.moving_avg_window = moving_avg_window
+        self.log_every_n_steps = log_every_n_steps
+
+    def on_train_step_end(self, state: State, unit: TTrainUnit) -> None:
+        if get_global_rank() != 0:  # only write from the main rank
+            return
+
+        step_logging_for = unit.train_progress.num_steps_completed
+        if step_logging_for % self.log_every_n_steps != 0:
+            return
+
+        train_state: PhaseState = none_throws(state.train_state)
+        train_iteration_time_list = none_throws(
+            train_state.iteration_timer
+        ).recorded_durations.get("train_iteration_time", [])
+        if len(train_iteration_time_list) == 0:
+            return
+
+        last_n_values = train_iteration_time_list[-self.moving_avg_window :]
+        self._writer.add_scalar(
+            "Train Iteration Time (seconds)",
+            sum(last_n_values) / len(last_n_values),
+            step_logging_for,
+        )


### PR DESCRIPTION
Summary: Adding a callback to allow logging train_iteration_time to be logged to TB

Differential Revision: D48911142


