### PR TITLE
Raise when torch.compile + FSDP use_orig_params=False

### DIFF
--- a/torchtnt/framework/auto_unit.py
+++ b/torchtnt/framework/auto_unit.py
@@ -132,7 +132,6 @@ class AutoPredictUnit(PredictUnit[TPredictData]):
             strategy=strategy,
             torch_compile_params=torch_compile_params,
         )
-        self.module: torch.nn.Module = module
 
         # cuda stream to use for moving data to device
         self._prefetch_stream: Optional[torch.cuda.streams.Stream] = (


### PR DESCRIPTION
Summary:
use_orig_params=True for FSDP is required when using torch compile, so
raise instead of warning here.

also, the code in prepare_module seemed to be warning this all the time without actually checking torch.compile and use_orig_params, iiuc.

also, it seems that these 2 code sites share
things and can be deduped.

Reviewed By: daniellepintz

Differential Revision: D48961482

