### PR TITLE
Ensure that GC remains disabled in GC callback

### DIFF
--- a/torchtnt/framework/callbacks/garbage_collector.py
+++ b/torchtnt/framework/callbacks/garbage_collector.py
@@ -56,6 +56,9 @@ class GarbageCollector(Callback):
         if total_num_steps_completed % self._step_interval == 0:
             gc.collect()
 
+        # Ensure that GC is disabled, in case GC was reenabled elsewhere
+        gc.disable()
+
     def on_train_end(self, state: State, unit: TTrainUnit) -> None:
         gc.enable()
 


### PR DESCRIPTION
Summary: Ensure that the GC remains disabled after every training batch since it may have been re-enabled elsewhere.

Reviewed By: anshulverma

Differential Revision: D49100568

