### PR TITLE
Enabling grad for _torch_impl function

### DIFF
--- a/torchtnt/framework/train.py
+++ b/torchtnt/framework/train.py
@@ -110,6 +110,8 @@ def train(
         raise e
 
 
+# Enabling grad in case this function is called directly from elsewhere in the framework.
+@torch.enable_grad()
 def _train_impl(
     state: State,
     train_unit: TTrainUnit,


### PR DESCRIPTION
Summary: The `fit` function calls `_train_impl` which is not decorated with `torch.enable_grad()`. If the user were to call `fit` after disabling grad, the call will fail. See example in simple.py below.

Reviewed By: JKSenthil

Differential Revision: D49265347


