### PR TITLE
add use_buffers to swa_utils interface

### DIFF
--- a/torchtnt/framework/auto_unit.py
+++ b/torchtnt/framework/auto_unit.py
@@ -54,10 +54,8 @@ class _ConfigureOptimizersCaller(ABCMeta):
 
             if x.swa_params:
                 if not x.swa_params.avg_fn:
-                    # pyre-ignore: Unexpected keyword [28]
                     x.swa_model = AveragedModel(x.module, use_buffers=True)
                 else:
-                    # pyre-ignore: Unexpected keyword [28]
                     x.swa_model = AveragedModel(
                         x.module, avg_fn=x.swa_params.avg_fn, use_buffers=True
                     )


### PR DESCRIPTION
Summary:
X-link: https://github.com/pytorch/pytorch/pull/109078

As title, this already exists in swa_utils.py

Internal

I saw this when we wanted to add type annotations in TorchTNT (see next diff). The param already exists in the `.py` file so I guess we can add it here as well

Differential Revision: D49155243


