### PR TITLE
In TensorBoardLogger docstring mention that logger should be constructed on all ranks

### DIFF
--- a/torchtnt/utils/loggers/tensorboard.py
+++ b/torchtnt/utils/loggers/tensorboard.py
@@ -29,6 +29,7 @@ class TensorBoardLogger(MetricLogger):
     Note:
         If using this logger with distributed training:
 
+        - This logger should be constructed on all ranks
         - This logger can call collective operations
         - Logs will be written on rank 0 only
         - Logger must be constructed synchronously *after* initializing the distributed process group.


### PR DESCRIPTION
Differential Revision: D49441883


