### PR TITLE
Add `.detach()` in `scalar_to_float()`

### DIFF
--- a/torchtnt/utils/loggers/utils.py
+++ b/torchtnt/utils/loggers/utils.py
@@ -18,7 +18,7 @@ def scalar_to_float(scalar: Scalar) -> float:
                 f"Scalar tensor must contain a single item, {numel} given."
             )
 
-        return float(scalar.cpu().numpy().item())
+        return float(scalar.cpu().detach().numpy().item())
     elif isinstance(scalar, ndarray):
         numel = scalar.size
         if numel != 1:


### PR DESCRIPTION
Summary:
Calling from an integration test with full training loop that used in mem logger was throwing this exception:
```
RuntimeError: Can't call numpy() on Tensor that requires grad. Use tensor.detach().numpy() instead.
```

This diff adds the `.detach()`

Reviewed By: JKSenthil

Differential Revision: D49600572


