### PR TITLE
In TorchSnapshotSaver initialize optimizer state before restoring

### DIFF
--- a/docs/source/utils/utils.rst
+++ b/docs/source/utils/utils.rst
@@ -168,6 +168,17 @@ OOM Utils
    attach_oom_observer
 
 
+Optimizer Utils
+~~~~~~~~~~~~~~~~~~~~~
+
+.. currentmodule:: torchtnt.utils.optimizer
+.. autosummary::
+   :toctree: generated
+   :nosignatures:
+
+   init_optim_state
+
+
 Precision Utils
 ~~~~~~~~~~~~~~~~~~~~~
 

--- a/tests/utils/test_optimizer.py
+++ b/tests/utils/test_optimizer.py
@@ -1,0 +1,41 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+import unittest
+
+import torch
+from torchtnt.utils.env import init_from_env
+from torchtnt.utils.optimizer import init_optim_state
+
+
+class OptimizerTest(unittest.TestCase):
+    def test_init_optim_state(self) -> None:
+        """Test optimizer skeleton state initialization."""
+        device = init_from_env()
+        module = torch.nn.Linear(1, 1, device=device)
+        original_state_dict = module.state_dict().copy()
+        optimizer = torch.optim.AdamW(module.parameters(), lr=0.01)
+        self.assertEqual(optimizer.state, {})
+
+        init_optim_state(optimizer)
+
+        # check that optimizer state has been initialized
+        self.assertNotEqual(optimizer.state, {})
+
+        # check that parameters have not changed
+        self.assertTrue(
+            torch.allclose(
+                original_state_dict["weight"],
+                module.state_dict()["weight"],
+            )
+        )
+        self.assertTrue(
+            torch.allclose(
+                original_state_dict["bias"],
+                module.state_dict()["bias"],
+            )
+        )

--- a/torchtnt/framework/callbacks/torchsnapshot_saver.py
+++ b/torchtnt/framework/callbacks/torchsnapshot_saver.py
@@ -20,6 +20,7 @@ from torchtnt.framework.unit import AppStateMixin, TEvalUnit, TPredictUnit, TTra
 from torchtnt.framework.utils import _construct_tracked_optimizers, get_timing_context
 from torchtnt.utils.distributed import get_global_rank, PGWrapper
 from torchtnt.utils.fsspec import get_filesystem
+from torchtnt.utils.optimizer import init_optim_state
 from torchtnt.utils.rank_zero_log import rank_zero_info, rank_zero_warn
 from torchtnt.utils.stateful import Stateful
 
@@ -229,6 +230,11 @@ class TorchSnapshotSaver(Callback):
         """
 
         _validate_snapshot_available()
+
+        # initialize optimizer state skeletons for in-place loading of optimizer state with torchsnapshot
+        for optimizer in unit.tracked_optimizers().values():
+            init_optim_state(optimizer)
+
         app_state = _app_state(unit)
         _check_app_state_collision(app_state)
 

--- a/torchtnt/utils/optimizer.py
+++ b/torchtnt/utils/optimizer.py
@@ -1,0 +1,35 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+import torch
+
+
+def init_optim_state(optimizer: torch.optim.Optimizer) -> None:
+    """
+    Initialize optimizer states by calling step() with zero grads. This is necessary because some optimizers like AdamW
+    initialize some states in their state_dicts lazily, only after calling step() for the first time. Certain checkpointing
+    solutions may rely on in-place loading, re-using existing tensor allocated memory from the optimizer state dict. This
+    optimization does not work with optimizers that lazily initialize their states, as certain states will not be restored.
+    Calling this function ensures that these states are available in the state dict for in place loading.
+
+    Args:
+        optimizer: A PyTorch optimizer.
+    """
+    if optimizer.state:
+        # The optimizer state is initialized.
+        return
+
+    for param_group in optimizer.param_groups:
+        for param in param_group["params"]:
+            if param.grad is not None:
+                raise RuntimeError(
+                    "Initializing the optimizer states requires that no existing gradients for parameters are found."
+                )
+            if param.requires_grad:
+                param.grad = torch.zeros_like(param)
+    optimizer.step(closure=None)
+    optimizer.zero_grad(set_to_none=True)


### PR DESCRIPTION
Summary:
Optimizer state is lazily initialized, meaning when you create an optimizer and call state_dict() it will have fewer keys than when you create an optimizer, call optimizer.step() and then call state_dict().

If you create an optimizer and then try to restore the optimizer from a previously saved state_dict() (which was saved after optimizer.step()), it will fail because not all of the keys are in the state_dict() of the initial optimizer.

The workaround is to initialize optimizer state with `optimizer.step()` before restoring.

Differential Revision: D49563335


