### PR TITLE
stdout logger for TNT

### DIFF
--- a/docs/source/utils/utils.rst
+++ b/docs/source/utils/utils.rst
@@ -123,6 +123,7 @@ Logger Utils
    MetricLogger
    CSVLogger
    InMemoryLogger
+   StdoutLogger
    JSONLogger
    TensorBoardLogger
 

--- a/tests/utils/loggers/test_in_memory.py
+++ b/tests/utils/loggers/test_in_memory.py
@@ -5,13 +5,11 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
-import sys
 import unittest
 from collections import OrderedDict
-from contextlib import contextmanager
-from io import StringIO
 
 from torchtnt.utils.loggers.in_memory import InMemoryLogger
+from torchtnt.utils.test_utils import captured_output
 
 
 class InMemoryLoggerTest(unittest.TestCase):
@@ -47,16 +45,3 @@ class InMemoryLoggerTest(unittest.TestCase):
         # Closing the log clears the buffer.
         logger.close()
         self.assertEqual(logger.log_buffer, OrderedDict([]))
-
-
-@contextmanager
-def captured_output() -> None:
-    new_out, new_err = StringIO(), StringIO()
-    old_out, old_err = sys.stdout, sys.stderr
-    try:
-        sys.stdout, sys.stderr = new_out, new_err
-        # pyre-fixme[7]: Expected `None` but got `Generator[Tuple[TextIO, TextIO],
-        #  typing.Any, typing.Any]`.
-        yield sys.stdout, sys.stderr
-    finally:
-        sys.stdout, sys.stderr = old_out, old_err

--- a/tests/utils/loggers/test_stdout.py
+++ b/tests/utils/loggers/test_stdout.py
@@ -1,0 +1,98 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+
+import unittest
+
+from torchtnt.utils.loggers.stdout import StdoutLogger
+from torchtnt.utils.test_utils import captured_output
+
+
+class StdoutLoggerTest(unittest.TestCase):
+    def test_stdout_log(self) -> None:
+        logger = StdoutLogger(precision=2)
+        # pyre-fixme[16]: `None` has no attribute `__enter__`.
+        with captured_output() as (out, _):
+            logger.log(step=0, name="metric_1", data=1.1)
+            self.assertTrue(
+                out.getvalue() == "\n[Step 0] metric_1=1.10",
+                msg=repr(f"Actual output: {out.getvalue()}"),
+            )
+
+            logger.log(step=0, name="metric_2", data=1.2)
+            self.assertTrue(
+                out.getvalue() == "\n[Step 0] metric_1=1.10 metric_2=1.20",
+                msg=repr(f"Actual output: {out.getvalue()}"),
+            )
+
+            logger.log(step=1, name="metric_1", data=2.1)
+            self.assertTrue(
+                out.getvalue()
+                == "\n[Step 0] metric_1=1.10 metric_2=1.20\n[Step 1] metric_1=2.10",
+                msg=repr(f"Actual output: {out.getvalue()}"),
+            )
+
+            logger.close()
+            self.assertTrue(
+                out.getvalue()
+                == "\n[Step 0] metric_1=1.10 metric_2=1.20\n[Step 1] metric_1=2.10\n\n",
+                msg=repr(f"Actual output: {out.getvalue()}"),
+            )
+
+    def test_stdout_log_dict(self) -> None:
+        logger = StdoutLogger(precision=0)
+        # pyre-fixme[16]: `None` has no attribute `__enter__`.
+        with captured_output() as (out, _):
+            logger.log_dict(step=0, payload={"metric_1": 1, "metric_2": 1})
+            self.assertTrue(
+                out.getvalue() == "\n[Step 0] metric_1=1 metric_2=1",
+                msg=repr(f"Actual output: {out.getvalue()}"),
+            )
+
+            logger.log_dict(step=0, payload={"metric_3": 1})
+            self.assertTrue(
+                out.getvalue() == "\n[Step 0] metric_1=1 metric_2=1 metric_3=1",
+                msg=repr(f"Actual output: {out.getvalue()}"),
+            )
+
+            logger.log_dict(
+                step=1, payload={"metric_1": 2, "metric_2": 2.2, "metric_3": 2.2344}
+            )
+            self.assertTrue(
+                out.getvalue()
+                == "\n[Step 0] metric_1=1 metric_2=1 metric_3=1\n[Step 1] metric_1=2 metric_2=2 metric_3=2",
+                msg=repr(f"Actual output: {out.getvalue()}"),
+            )
+
+            logger.close()
+            self.assertTrue(
+                out.getvalue()
+                == "\n[Step 0] metric_1=1 metric_2=1 metric_3=1\n[Step 1] metric_1=2 metric_2=2 metric_3=2\n\n",
+                msg=repr(f"Actual output: {out.getvalue()}"),
+            )
+
+    def test_out_of_order_steps(self) -> None:
+        logger = StdoutLogger(precision=2)
+        # pyre-fixme[16]: `None` has no attribute `__enter__`.
+        with captured_output() as (out, _):
+            logger.log(step=-1, name="metric_1", data=1.1234)
+            self.assertTrue(
+                out.getvalue() == "\n[Step -1] metric_1=1.12",
+                msg=repr(f"Actual output: {out.getvalue()}"),
+            )
+
+            logger.log(step=10, name="metric_1", data=1.234)
+            self.assertTrue(
+                out.getvalue() == "\n[Step -1] metric_1=1.12\n[Step 10] metric_1=1.23",
+                msg=repr(f"Actual output: {out.getvalue()}"),
+            )
+
+            logger.log_dict(step=2, payload={"metric_2": 2.1234, "metric_3": 3.987})
+            self.assertTrue(
+                out.getvalue()
+                == "\n[Step -1] metric_1=1.12\n[Step 10] metric_1=1.23\n[Step 2] metric_2=2.12 metric_3=3.99",
+                msg=repr(f"Actual output: {out.getvalue()}"),
+            )

--- a/torchtnt/utils/loggers/__init__.py
+++ b/torchtnt/utils/loggers/__init__.py
@@ -9,6 +9,7 @@ from .file import FileLogger
 from .in_memory import InMemoryLogger
 from .json import JSONLogger
 from .logger import MetricLogger, Scalar
+from .stdout import StdoutLogger
 from .tensorboard import TensorBoardLogger
 from .utils import scalar_to_float
 
@@ -20,6 +21,7 @@ __all__ = [
     "JSONLogger",
     "MetricLogger",
     "Scalar",
+    "StdoutLogger",
     "TensorBoardLogger",
     "scalar_to_float",
 ]

--- a/torchtnt/utils/loggers/stdout.py
+++ b/torchtnt/utils/loggers/stdout.py
@@ -1,0 +1,72 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+import atexit
+import logging
+import sys
+from typing import Mapping, Optional
+
+from torchtnt.utils.distributed import rank_zero_fn
+
+from torchtnt.utils.loggers.logger import MetricLogger, Scalar
+from torchtnt.utils.loggers.utils import scalar_to_float
+
+logger: logging.Logger = logging.getLogger(__name__)
+
+
+class StdoutLogger(MetricLogger):
+    """
+    Logger that prints metrics to stdout on rank 0. Each step is logged on a different line.
+    Metrics belonging to the same step will be printed in the order they were logged on
+    the same line. Step number is treated as an opaque identifier, successive steps do
+    not have to be consecutive, but it is generally good practice to make them so.
+
+    Args:
+        precision (int): The number of digits to print after the decimal point. The default value is
+        set to 4. The output will be rounded per the usual rounding rules.
+
+    Example:
+        from torchtnt.utils.loggers import StdoutLogger
+
+        logger = StdoutLogger()
+        logger.log(step=1, name="accuracy", data=0.982378)
+        logger.log(step=1, name="loss", data=0.23112)
+        logger.log_dict(step=2, payload={"accuracy": 0.99123, "loss": 0.18787})
+
+        This will print the following to stdout in order:
+        [Step 1] accuracy=0.9824, loss=0.2311
+        [Step 2] accuracy=0.9912, loss=0.1879
+    """
+
+    def __init__(self, precision: int = 4) -> None:
+        self._current_step: Optional[int] = None
+        self._precision = precision
+        logger.info("Logging metrics to stdout")
+        atexit.register(self.close)
+
+    def _start_new_step_if_needed(self, step: int) -> None:
+        if self._current_step is None or step != self._current_step:
+            self._current_step = step
+            print(f"\n[Step {step}]", end="")
+
+    def _log_metric(self, metric_name: str, metric_value: Scalar) -> None:
+        metric_value = scalar_to_float(metric_value)
+        print(f" {metric_name}={metric_value:.{self._precision}f}", end="", flush=True)
+
+    @rank_zero_fn
+    def log(self, name: str, data: Scalar, step: int) -> None:
+        self._start_new_step_if_needed(step)
+        self._log_metric(name, data)
+
+    @rank_zero_fn
+    def log_dict(self, payload: Mapping[str, Scalar], step: int) -> None:
+        self._start_new_step_if_needed(step)
+        for k, v in payload.items():
+            self._log_metric(k, v)
+
+    def close(self) -> None:
+        print("\n")
+        sys.stdout.flush()


### PR DESCRIPTION
Summary: A simple `MetricsLogger` that will print out the metrics on stdout on rank 0. Mostly expected to be use in iterative development.

Reviewed By: ananthsub

Differential Revision: D49621807


