### PR TITLE
move lr callback utils to general utils

### DIFF
--- a/torchtnt/utils/__init__.py
+++ b/torchtnt/utils/__init__.py
@@ -44,6 +44,7 @@ from .oom import (
     is_out_of_memory_error,
     log_memory_snapshot,
 )
+from .optimizer import extract_lr_from_optimizer, init_optim_state
 from .precision import convert_precision_str_to_dtype
 from .prepare_module import DDPStrategy, FSDPStrategy, prepare_ddp, prepare_fsdp
 from .progress import Progress
@@ -105,6 +106,8 @@ __all__ = [
     "is_out_of_cuda_memory",
     "is_out_of_memory_error",
     "log_memory_snapshot",
+    "extract_lr_from_optimizer",
+    "init_optim_state",
     "convert_precision_str_to_dtype",
     "DDPStrategy",
     "FSDPStrategy",


### PR DESCRIPTION
Summary:
# Context
Few utils in `learning_rate_monitor.py` are generic and should be moved out into the respective utils folders

# This Diff
1. moves `_extract_lr_from_optimizer` into `utils/optimizer.py` and returns a dict instead of in-place updating a passing in dict
2. moves `_extract_lr` into `framework/utils.py` since it takes a TrainUnit, and merges the dicts returned by `_extract_lr_from_optimizer`

Reviewed By: ananthsub

Differential Revision: D49832312


