### PR TITLE
add custom AveragedModel to TNT utils

### DIFF
--- a/docs/source/utils/utils.rst
+++ b/docs/source/utils/utils.rst
@@ -246,6 +246,17 @@ Stateful
    Stateful
 
 
+SWA
+~~~~~~~~~~~~~~~~~~~~~
+
+.. currentmodule:: torchtnt.utils.swa
+.. autosummary::
+   :toctree: generated
+   :nosignatures:
+
+   AveragedModel
+
+
 Test Utils
 ~~~~~~~~~~~~~~~~~~~~~
 

--- a/torchtnt/utils/__init__.py
+++ b/torchtnt/utils/__init__.py
@@ -57,6 +57,7 @@ from .rank_zero_log import (
     rank_zero_warn,
 )
 from .stateful import Stateful
+from .swa import AveragedModel
 from .test_utils import get_pet_launch_config, spawn_multi_process
 from .timer import FullSyncPeriodicTimer, get_timer_summary, log_elapsed_time, Timer
 from .tqdm import close_progress_bar, create_progress_bar, update_progress_bar
@@ -121,6 +122,7 @@ __all__ = [
     "rank_zero_print",
     "rank_zero_warn",
     "Stateful",
+    "AveragedModel",
     "FullSyncPeriodicTimer",
     "get_timer_summary",
     "log_elapsed_time",

--- a/torchtnt/utils/swa.py
+++ b/torchtnt/utils/swa.py
@@ -1,0 +1,64 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+from typing import Callable, List, Optional
+
+import torch
+
+from torch.optim.swa_utils import AveragedModel as PyTorchAveragedModel
+
+
+TSWA_avg_fn = Callable[[torch.Tensor, torch.Tensor, int], torch.Tensor]
+TSWA_multi_avg_fn = Callable[[List[torch.Tensor], List[torch.Tensor], int], None]
+
+
+class AveragedModel(PyTorchAveragedModel):
+    def __init__(
+        self,
+        model: torch.nn.Module,
+        device: Optional[torch.device] = None,
+        avg_fn: Optional[TSWA_avg_fn] = None,
+        multi_avg_fn: Optional[TSWA_multi_avg_fn] = None,
+        use_buffers: bool = False,
+        skip_deepcopy: bool = False,
+    ) -> None:
+        """
+        This class is a custom version of AveragedModel that allows us to skip the
+        automatic deepcopy step. This gives flexibility to use modules that are not
+        compatible with deepcopy, like FSDP wrapped modules. Check out
+        https://github.com/pytorch/pytorch/blob/main/torch/optim/swa_utils.py#L66
+        to see what the arguments entail.
+
+        Args:
+            skip_deepcopy: If True, will skip the deepcopy step. The user must ensure
+                that the module passed in is already copied in someway
+        """
+        if skip_deepcopy:
+            # calls parent init manually, but skips deepcopy step
+            torch.nn.Module.__init__(self)  # inits grandparent class
+
+            assert (
+                avg_fn is None or multi_avg_fn is None
+            ), "Only one of avg_fn and multi_avg_fn should be provided"
+            self.module: torch.nn.Module = model
+            self.register_buffer(
+                "n_averaged", torch.tensor(0, dtype=torch.long, device=device)
+            )
+            self.avg_fn: Optional[TSWA_avg_fn] = avg_fn
+            self.multi_avg_fn: Optional[TSWA_multi_avg_fn] = multi_avg_fn
+            self.use_buffers: bool = use_buffers
+        else:
+            # use default init implementation
+
+            # TODO: torch/optim/swa_utils.pyi needs to be updated
+            # pyre-ignore Unexpected keyword [28]
+            super().__init__(
+                model,
+                device=device,
+                avg_fn=avg_fn,
+                multi_avg_fn=multi_avg_fn,
+                use_buffers=use_buffers,
+            )


### PR DESCRIPTION
Summary:
# Context
To enable EMA + FSDP in AutoUnit, the [AveragedModel](https://www.internalfb.com/code/fbsource/[25883e9b1e5c09632cf6e43d4dee8c6e026a9e76]/fbcode/caffe2/torch/optim/swa_utils.py?lines=66) class must be changed slightly so that deepcopy isn't always called on the passed in module. However, upstreaming a change like this to PyTorch is not ideal as it can look a bit hacky.

# This Diff
Creates a `AveragedModel` class in TNT utils that subclasses pytorch's [AveragedModel](https://www.internalfb.com/code/fbsource/[25883e9b1e5c09632cf6e43d4dee8c6e026a9e76]/fbcode/caffe2/torch/optim/swa_utils.py?lines=66) and adds an additional flag `skip_deepcopy`. If set True, a custom `__init__` is called that replicates the parent AveragedModel's `__init__` but removes the deepcopy lines.

Differential Revision: D49930226


