### PR TITLE
ema + fsdp support in AutoUnit

### DIFF
--- a/docs/source/utils/utils.rst
+++ b/docs/source/utils/utils.rst
@@ -246,6 +246,17 @@ Stateful
    Stateful
 
 
+SWA
+~~~~~~~~~~~~~~~~~~~~~
+
+.. currentmodule:: torchtnt.utils.swa
+.. autosummary::
+   :toctree: generated
+   :nosignatures:
+
+   AveragedModel
+
+
 Test Utils
 ~~~~~~~~~~~~~~~~~~~~~
 

--- a/tests/utils/test_prepare_module.py
+++ b/tests/utils/test_prepare_module.py
@@ -20,7 +20,6 @@ from torchtnt.utils.prepare_module import (
     prepare_ddp,
     prepare_fsdp,
     prepare_module,
-    SWAParams,
     TorchCompileParams,
 )
 from torchtnt.utils.test_utils import spawn_multi_process
@@ -207,11 +206,6 @@ class PrepareModelTest(unittest.TestCase):
             "nccl",
             self._test_prepare_module_fsdp_string_wrapped_in_fsdp,
         )
-        spawn_multi_process(
-            2,
-            "nccl",
-            self._test_stochastic_weight_averaging_with_fsdp_raises,
-        )
 
     @staticmethod
     def _test_prepare_module_fsdp_strategy_wrapped_in_fsdp() -> None:
@@ -242,24 +236,6 @@ class PrepareModelTest(unittest.TestCase):
         tc = unittest.TestCase()
 
         tc.assertTrue(isinstance(fsdp_module, FSDP))
-
-    @staticmethod
-    def _test_stochastic_weight_averaging_with_fsdp_raises() -> None:
-        """
-        Test that a RuntimeError is thrown when attempting to use Stochastic Weight Averaging and FSDP
-        """
-
-        tc = unittest.TestCase()
-        with tc.assertRaisesRegex(
-            RuntimeError,
-            "Stochastic Weight Averaging is currently not supported with the FSDP strategy",
-        ):
-            prepare_module(
-                module=torch.nn.Linear(2, 2),
-                device=init_from_env(),
-                strategy=FSDPStrategy(),
-                swa_params=SWAParams(epoch_start=1, anneal_epochs=5),
-            )
 
     @unittest.skipUnless(
         distributed_available, reason="Torch distributed is needed to run"

--- a/tests/utils/test_swa.py
+++ b/tests/utils/test_swa.py
@@ -1,0 +1,201 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+import itertools
+import unittest
+from copy import deepcopy
+from typing import List, Tuple
+
+import torch
+
+# TODO: torch/optim/swa_utils.pyi needs to be updated
+# pyre-ignore: Undefined import [21]
+from torch.optim.swa_utils import get_ema_multi_avg_fn, get_swa_multi_avg_fn
+
+from torchtnt.utils.swa import AveragedModel
+
+
+class TestSWA(unittest.TestCase):
+    def _test_averaged_model(
+        self, net_device: torch.device, swa_device: torch.device, ema: bool
+    ) -> None:
+        dnn = torch.nn.Sequential(
+            torch.nn.Conv2d(1, 5, kernel_size=3),
+            torch.nn.ReLU(),
+            torch.nn.MaxPool2d(kernel_size=2),
+            torch.nn.BatchNorm2d(5, momentum=0.3),
+            torch.nn.Conv2d(5, 2, kernel_size=3),
+            torch.nn.ReLU(),
+            torch.nn.Linear(5, 5),
+            torch.nn.ReLU(),
+            torch.nn.Linear(5, 10),
+        ).to(net_device)
+
+        averaged_params, averaged_dnn = self._run_averaged_steps(dnn, swa_device, ema)
+
+        for p_avg, p_swa in zip(averaged_params, averaged_dnn.parameters()):
+            torch.testing.assert_close(p_avg, p_swa, check_device=False)
+            # Check that AveragedModel is on the correct device
+            self.assertTrue(p_swa.device == swa_device)
+            self.assertTrue(p_avg.device == net_device)
+        self.assertTrue(averaged_dnn.n_averaged.device == swa_device)
+
+    def _run_averaged_steps(
+        self, dnn: torch.nn.Module, swa_device: torch.device, ema: bool
+    ) -> Tuple[List[torch.Tensor], torch.nn.Module]:
+        ema_decay = 0.999
+        multi_avg_fn = (
+            # pyre-ignore: Undefined attribute [16]
+            get_ema_multi_avg_fn(ema_decay)
+            if ema
+            # pyre-ignore: Undefined attribute [16]
+            else get_swa_multi_avg_fn()
+        )
+        averaged_dnn = AveragedModel(
+            dnn,
+            device=swa_device,
+            multi_avg_fn=multi_avg_fn,
+        )
+
+        averaged_params = [torch.zeros_like(param) for param in dnn.parameters()]
+
+        n_updates = 10
+        for i in range(n_updates):
+            for p, p_avg in zip(dnn.parameters(), averaged_params):
+                p.detach().add_(torch.randn_like(p))
+                if ema:
+                    p_avg += (
+                        p.detach()
+                        * ema_decay ** (n_updates - i - 1)
+                        * ((1 - ema_decay) if i > 0 else 1.0)
+                    )
+                else:
+                    p_avg += p.detach() / n_updates
+            averaged_dnn.update_parameters(dnn)
+
+        return averaged_params, averaged_dnn
+
+    def test_averaged_model_all_devices(self) -> None:
+        cpu = torch.device("cpu")
+        self._test_averaged_model(cpu, cpu, ema=True)
+        self._test_averaged_model(cpu, cpu, ema=False)
+        if torch.cuda.is_available():
+            cuda = torch.device(0)
+            combos = itertools.product([cuda, cpu], [cuda, cpu], [True, False])
+            for device1, device2, ema in combos:
+                self._test_averaged_model(device1, device2, ema=ema)
+
+    def test_averaged_model_state_dict(self) -> None:
+        dnn = torch.nn.Sequential(
+            torch.nn.Conv2d(1, 5, kernel_size=3), torch.nn.Linear(5, 10)
+        )
+        averaged_dnn = AveragedModel(dnn)
+        averaged_dnn2 = AveragedModel(dnn)
+        n_updates = 10
+        for _ in range(n_updates):
+            for p in dnn.parameters():
+                p.detach().add_(torch.randn_like(p))
+            averaged_dnn.update_parameters(dnn)
+        averaged_dnn2.load_state_dict(averaged_dnn.state_dict())
+        for p_swa, p_swa2 in zip(averaged_dnn.parameters(), averaged_dnn2.parameters()):
+            torch.testing.assert_close(p_swa, p_swa2, check_device=False)
+        self.assertTrue(averaged_dnn.n_averaged == averaged_dnn2.n_averaged)
+
+    def test_averaged_model_exponential(self) -> None:
+        combos = itertools.product([True, False], [True, False], [True, False])
+        for use_multi_avg_fn, use_buffers, skip_deepcopy in combos:
+            self._test_averaged_model_exponential(
+                use_multi_avg_fn, use_buffers, skip_deepcopy
+            )
+
+    def _test_averaged_model_exponential(
+        self, use_multi_avg_fn: bool, use_buffers: bool, skip_deepcopy: bool
+    ) -> None:
+        # Test AveragedModel with EMA as avg_fn and use_buffers as True.
+        dnn = torch.nn.Sequential(
+            torch.nn.Conv2d(1, 5, kernel_size=3),
+            torch.nn.BatchNorm2d(5, momentum=0.3),
+            torch.nn.Linear(5, 10),
+        )
+        decay: float = 0.9
+
+        if use_multi_avg_fn:
+            averaged_dnn = AveragedModel(
+                deepcopy(dnn) if skip_deepcopy else dnn,
+                # pyre-ignore Undefined attribute [16]
+                multi_avg_fn=get_ema_multi_avg_fn(decay),
+                use_buffers=use_buffers,
+                skip_deepcopy=skip_deepcopy,
+            )
+        else:
+
+            def avg_fn(
+                p_avg: torch.Tensor, p: torch.Tensor, n_avg: float
+            ) -> torch.Tensor:
+                return decay * p_avg + (1 - decay) * p
+
+            averaged_dnn = AveragedModel(dnn, avg_fn=avg_fn, use_buffers=use_buffers)
+
+        if use_buffers:
+            dnn_params = list(itertools.chain(dnn.parameters(), dnn.buffers()))
+        else:
+            dnn_params = list(dnn.parameters())
+
+        averaged_params = [
+            torch.zeros_like(param)
+            for param in dnn_params
+            if param.size() != torch.Size([])
+        ]
+
+        n_updates = 10
+        for i in range(n_updates):
+            updated_averaged_params = []
+            for p, p_avg in zip(dnn_params, averaged_params):
+                if p.size() == torch.Size([]):
+                    continue
+                p.detach().add_(torch.randn_like(p))
+                if i == 0:
+                    updated_averaged_params.append(p.clone())
+                else:
+                    updated_averaged_params.append(
+                        (p_avg * decay + p * (1 - decay)).clone()
+                    )
+            averaged_dnn.update_parameters(dnn)
+            averaged_params = updated_averaged_params
+
+        if use_buffers:
+            for p_avg, p_swa in zip(
+                averaged_params,
+                itertools.chain(
+                    averaged_dnn.module.parameters(), averaged_dnn.module.buffers()
+                ),
+            ):
+                torch.testing.assert_close(p_avg, p_swa, check_device=False)
+        else:
+            for p_avg, p_swa in zip(averaged_params, averaged_dnn.parameters()):
+                torch.testing.assert_close(p_avg, p_swa, check_device=False)
+            for b_avg, b_swa in zip(dnn.buffers(), averaged_dnn.module.buffers()):
+                torch.testing.assert_close(b_avg, b_swa, check_device=False)
+
+    def test_averaged_model_skip_deepcopy(self) -> None:
+        device = torch.device("cpu")
+        dnn = torch.nn.Sequential(
+            torch.nn.Conv2d(1, 5, kernel_size=3),
+            torch.nn.ReLU(),
+            torch.nn.MaxPool2d(kernel_size=2),
+            torch.nn.BatchNorm2d(5, momentum=0.3),
+            torch.nn.Conv2d(5, 2, kernel_size=3),
+            torch.nn.ReLU(),
+            torch.nn.Linear(5, 5),
+            torch.nn.ReLU(),
+            torch.nn.Linear(5, 10),
+        ).to(device)
+        averaged_dnn = AveragedModel(dnn, device, skip_deepcopy=True)
+        # check both modules are pointing to same reference (since no deepcopy)
+        self.assertEqual(id(dnn), id(averaged_dnn.module))
+
+        averaged_dnn2 = AveragedModel(dnn, device)
+        self.assertNotEqual(id(dnn), id(averaged_dnn2.module))

--- a/torchtnt/utils/__init__.py
+++ b/torchtnt/utils/__init__.py
@@ -57,6 +57,7 @@ from .rank_zero_log import (
     rank_zero_warn,
 )
 from .stateful import Stateful
+from .swa import AveragedModel
 from .test_utils import get_pet_launch_config, spawn_multi_process
 from .timer import FullSyncPeriodicTimer, get_timer_summary, log_elapsed_time, Timer
 from .tqdm import close_progress_bar, create_progress_bar, update_progress_bar
@@ -121,6 +122,7 @@ __all__ = [
     "rank_zero_print",
     "rank_zero_warn",
     "Stateful",
+    "AveragedModel",
     "FullSyncPeriodicTimer",
     "get_timer_summary",
     "log_elapsed_time",

--- a/torchtnt/utils/swa.py
+++ b/torchtnt/utils/swa.py
@@ -1,0 +1,64 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+from typing import Callable, List, Optional
+
+import torch
+
+from torch.optim.swa_utils import AveragedModel as PyTorchAveragedModel
+
+
+TSWA_avg_fn = Callable[[torch.Tensor, torch.Tensor, int], torch.Tensor]
+TSWA_multi_avg_fn = Callable[[List[torch.Tensor], List[torch.Tensor], int], None]
+
+
+class AveragedModel(PyTorchAveragedModel):
+    def __init__(
+        self,
+        model: torch.nn.Module,
+        device: Optional[torch.device] = None,
+        avg_fn: Optional[TSWA_avg_fn] = None,
+        multi_avg_fn: Optional[TSWA_multi_avg_fn] = None,
+        use_buffers: bool = False,
+        skip_deepcopy: bool = False,
+    ) -> None:
+        """
+        This class is a custom version of AveragedModel that allows us to skip the
+        automatic deepcopy step. This gives flexibility to use modules that are not
+        compatible with deepcopy, like FSDP wrapped modules. Check out
+        https://github.com/pytorch/pytorch/blob/main/torch/optim/swa_utils.py#L66
+        to see what the arguments entail.
+
+        Args:
+            skip_deepcopy: If True, will skip the deepcopy step. The user must ensure
+                that the module passed in is already copied in someway
+        """
+        if skip_deepcopy:
+            # calls parent init manually, but skips deepcopy step
+            torch.nn.Module.__init__(self)  # inits grandparent class
+
+            assert (
+                avg_fn is None or multi_avg_fn is None
+            ), "Only one of avg_fn and multi_avg_fn should be provided"
+            self.module: torch.nn.Module = model
+            self.register_buffer(
+                "n_averaged", torch.tensor(0, dtype=torch.long, device=device)
+            )
+            self.avg_fn: Optional[TSWA_avg_fn] = avg_fn
+            self.multi_avg_fn: Optional[TSWA_multi_avg_fn] = multi_avg_fn
+            self.use_buffers: bool = use_buffers
+        else:
+            # use default init implementation
+
+            # TODO: torch/optim/swa_utils.pyi needs to be updated
+            # pyre-ignore Unexpected keyword [28]
+            super().__init__(
+                model,
+                device=device,
+                avg_fn=avg_fn,
+                multi_avg_fn=multi_avg_fn,
+                use_buffers=use_buffers,
+            )


### PR DESCRIPTION
Summary:
# Context
Currently the AutoUnit does not handle EMA / SWA with FSDP

# This Diff
Adds FSDP support to EMA. The core change was this: In the swa initialization, if `FSDPStrategy` is used, apply that strategy to the (deepcopied) model prior to passing it into `AveragedModel`. This ensures the original model and the model managed by `AveragedModel` are sharded identically. With identical shards, the `AveragedModel` can safely update it's parameters on it's local rank without gathering params from other ranks, since EMA updates are point wise. This means each rank can update it's own shard locally. When `self.swa_module.forward()` is called, the appropriate params will be gathered and resemble the correct ema model.

# Specific Changes made
__SWAParam dataclass related changes__
1. Moved SWAParams out of prepare_module.py and into auto_unit.py. This is since SWA is a feature exclusive to AutoUnit
2. Moved SWALR params into its own dataclass (`SWALRParams`) and made it an optional arg into `SWAParams`. This is because it is not required to use a separate lr scheduler with EMA
2. Remove `swa_param` arg in `prepare_module` as swa is now supported w/ FSDP
2. Add `multi_avg_fn` param to SWAParams. This was a feature added recently into AveragedModel
3. Add `step_or_epoch_...` params to SWAParams. Before, SWA would only update at the frequency of epochs, but some users may want to do this on the granularity of steps. Between steps and epochs is decided on what the AutoUnit's `step_lr_interval` value is
 ---
__Refactors__
4. Moved the `AveragedModel` initialization out of `class _ConfigureOptimizersCaller(ABCMeta)` and into the AutoUnit constructor instead, since this doesn't do any optimizer related instantiation
6. Consolidate / refactor the logic to check whether to apply an ema update or not
 ---
__FSDP related and other__
5. Apply `FSDPStrategy` to module prior to sending into AveragedModel, if FSDP enabled
7. Removed model weight transfer from the ema model to the original model at end of training. This is so users can compare performances of the original and ema model more easily.

Differential Revision: D49378516

