### PR TITLE
replace del w/ pop to remove from app_state

### DIFF
--- a/torchtnt/framework/callbacks/torchsnapshot_saver.py
+++ b/torchtnt/framework/callbacks/torchsnapshot_saver.py
@@ -244,10 +244,10 @@ class TorchSnapshotSaver(Callback):
         app_state[_RNG_STATE_KEY] = rng_state
 
         if not restore_train_progress:
-            del app_state[_TRAIN_PROGRESS_STATE_KEY]
+            app_state.pop(_TRAIN_PROGRESS_STATE_KEY, None)
 
         if not restore_eval_progress:
-            del app_state[_EVAL_PROGRESS_STATE_KEY]
+            app_state.pop(_EVAL_PROGRESS_STATE_KEY, None)
 
         if train_dataloader is not None:
             # request to restore the dataloader state only if


### PR DESCRIPTION
Summary:
# Context
It is assumed that app_state will have train_progress and eval_progress keys. But this may not be the case if the user manually overrides the `app_state`. This will cause `KeyError: 'train_progress'`when loading checkpoint
# This diff
Replaces `del app_state[KEY]` to `app_state.pop(KEY, None)` which will delete the key if it exists, or do nothing otherwise

Reviewed By: galrotem

Differential Revision: D50034777


