### PR TITLE
auto unit - reset is_last_train_batch at the end of an epoch

### DIFF
--- a/tests/framework/test_auto_unit.py
+++ b/tests/framework/test_auto_unit.py
@@ -656,6 +656,10 @@ class TestAutoUnit(unittest.TestCase):
         dataloader = generate_random_dataloader(dataset_len, input_dim, batch_size)
         train(my_unit, dataloader, max_epochs=max_epochs)
 
+        my_unit = DummyAutoUnit(module=my_module)
+        train(my_unit, dataloader, max_epochs=1, max_steps_per_epoch=4)
+        self.assertFalse(my_unit._is_last_train_batch)
+
     def test_auto_unit_timing_train(self) -> None:
         """
         Test auto timing in AutoUnit for training

--- a/torchtnt/framework/auto_unit.py
+++ b/torchtnt/framework/auto_unit.py
@@ -798,6 +798,8 @@ class AutoUnit(
                     ):
                         lr_scheduler.step()
 
+        self._is_last_train_batch = False
+
     # pyre-fixme[3]: Return annotation cannot contain `Any`.
     def eval_step(
         self, state: State, data: Iterator[TData]


### PR DESCRIPTION
Summary: Setting is_last_train_batch to False when the train epoch ends.

Differential Revision: D50186361


