### PR TITLE
add no-op strategy

### DIFF
--- a/torchtnt/utils/__init__.py
+++ b/torchtnt/utils/__init__.py
@@ -46,7 +46,13 @@ from .oom import (
 )
 from .optimizer import extract_lr_from_optimizer, init_optim_state
 from .precision import convert_precision_str_to_dtype
-from .prepare_module import DDPStrategy, FSDPStrategy, prepare_ddp, prepare_fsdp
+from .prepare_module import (
+    DDPStrategy,
+    FSDPStrategy,
+    NOOPStrategy,
+    prepare_ddp,
+    prepare_fsdp,
+)
 from .progress import Progress
 from .rank_zero_log import (
     rank_zero_critical,
@@ -112,6 +118,7 @@ __all__ = [
     "convert_precision_str_to_dtype",
     "DDPStrategy",
     "FSDPStrategy",
+    "NOOPStrategy",
     "prepare_ddp",
     "prepare_fsdp",
     "Progress",

--- a/torchtnt/utils/prepare_module.py
+++ b/torchtnt/utils/prepare_module.py
@@ -41,6 +41,17 @@ class Strategy:
 
 
 @dataclass
+class NOOPStrategy(Strategy):
+    """
+    Dataclass representing a no-op strategy. Nothing is applied to the module, and no device transfer occurs
+    Use this strategy if applying custom wrapping to module prior to passing it into class:`~torchtnt.framework.auto_unit.AutoUnit`
+    or into :py:func:`~torchtnt.utils.prepare_module.prepare_module`
+    """
+
+    pass
+
+
+@dataclass
 class DDPStrategy(Strategy):
     """
     Dataclass representing the `DistributedDataParallel <https://pytorch.org/docs/stable/generated/torch.nn.parallel.DistributedDataParallel.html>`_ strategy.
@@ -317,7 +328,9 @@ def prepare_module(
     return module
 
 
-def convert_str_to_strategy(strategy: str) -> Union[DDPStrategy, FSDPStrategy]:
+def convert_str_to_strategy(
+    strategy: str,
+) -> Union[DDPStrategy, FSDPStrategy, NOOPStrategy]:
     """
     Converts strategy as a string to a default instance of the Strategy dataclass.
 
@@ -331,6 +344,7 @@ def convert_str_to_strategy(strategy: str) -> Union[DDPStrategy, FSDPStrategy]:
     string_to_strategy_mapping = {
         "ddp": DDPStrategy(),
         "fsdp": FSDPStrategy(),
+        "noop": NOOPStrategy(),
     }
 
     if strategy not in string_to_strategy_mapping:


### PR DESCRIPTION
Summary:
# Context
Currently there is no way for user to skip `prepare_module` call in AutoUnit constructor. This will always augment the model in some way, depending on what's passed as the `strategy` (and if `None` is passed, module is moved to device). This may not be desirable for users who want to do all their processing of their module on their own and don't want even the module to be moved to device.

# This Diff
Adds a no-op strategy for users that essentially skips `prepare_modules` application of strategy on the module, and avoids moving module to device.

# Future
Once this unblocks immediate users, we can maybe look to introduce a `MoveToDevice` strategy and let `None` be the equivalent of the no-op strategy

Differential Revision: D50202998


