### PR TITLE
add DDP, FSDP strategies links to docs

### DIFF
--- a/docs/source/distributed.rst
+++ b/docs/source/distributed.rst
@@ -21,7 +21,7 @@ If you are using the the :class:`~torchtnt.framework.unit.TrainUnit`/ :class:`~t
     device_ids = [device.index]
     model = torch.nn.parallel.DistributedDataParallel(module, device_ids=device_ids)
 
-We also offer :py:func:`~torchtnt.utils.prepare_ddp` which can assist in wrapping the model for you.
+We also offer :py:func:`~torchtnt.utils.prepare_module.prepare_ddp` which can assist in wrapping the model for you.
 
 The :class:`~torchtnt.framework.auto_unit.AutoUnit` automatically wraps the module in DDP when either
 
@@ -32,7 +32,7 @@ The :class:`~torchtnt.framework.auto_unit.AutoUnit` automatically wraps the modu
         module = nn.Linear(input_dim, 1)
         my_auto_unit = MyAutoUnit(module=module, strategy="ddp")
 
-2. The dataclass :class:`~torchtnt.utils.DDPStrategy` is passed in to the strategy argument. This is helpful when wanting to customize the settings in DDP
+2. The dataclass :class:`~torchtnt.utils.prepare_module.DDPStrategy` is passed in to the strategy argument. This is helpful when wanting to customize the settings in DDP
 
     .. code-block:: python
 
@@ -55,7 +55,7 @@ If using one or more of or :class:`~torchtnt.framework.unit.TrainUnit`, :class:`
     # wrap module in FSDP
     model = torch.distributed.fsdp.FullyShardedDataParallel(module, device_id=device)
 
-We also offer :py:func:`~torchtnt.utils.prepare_fsdp` which can assist in wrapping the model for you.
+We also offer :py:func:`~torchtnt.utils.prepare_module.prepare_fsdp` which can assist in wrapping the model for you.
 
 The :class:`~torchtnt.framework.auto_unit.AutoUnit` automatically wraps the module in FSDP when either
 
@@ -66,7 +66,7 @@ The :class:`~torchtnt.framework.auto_unit.AutoUnit` automatically wraps the modu
         module = nn.Linear(input_dim, 1)
         my_auto_unit = MyAutoUnit(module=module, strategy="fsdp")
 
-2. The dataclass :class:`~torchtnt.utils.FSDPStrategy` is passed in to the strategy argument. This is helpful when wanting to customize the settings in FSDP
+2. The dataclass :class:`~torchtnt.utils.prepare_module.FSDPStrategy` is passed in to the strategy argument. This is helpful when wanting to customize the settings in FSDP
 
     .. code-block:: python
 

--- a/docs/source/utils/utils.rst
+++ b/docs/source/utils/utils.rst
@@ -203,6 +203,8 @@ Prepare Module Utils
    prepare_ddp
    prepare_fsdp
    convert_str_to_strategy
+   DDPStrategy
+   FSDPStrategy
 
 
 Progress Utils

--- a/torchtnt/framework/auto_unit.py
+++ b/torchtnt/framework/auto_unit.py
@@ -364,7 +364,7 @@ class AutoUnit(
         training: if True, the optimizer and optionally LR scheduler will be created after the class is initialized.
 
     Note:
-        If FSDPStrategy and SWAParams are passed in, the swa model will be sharded with the same FSDP parameters.
+        If :class:`~torchtnt.utils.prepare_module.FSDPStrategy` and SWAParams are passed in, the swa model will be sharded with the same FSDP parameters.
 
     Note:
         Torch compile support is only available in PyTorch 2.0 or higher.

--- a/torchtnt/utils/prepare_module.py
+++ b/torchtnt/utils/prepare_module.py
@@ -143,7 +143,7 @@ def prepare_ddp(
     Args:
         module: module to be wrapped in DDP
         device: device to which module will be moved
-        strategy: an instance of DDPStrategy which defines the settings of DDP APIs
+        strategy: an instance of :class:`~torchtnt.utils.prepare_module.DDPStrategy` which defines the settings of DDP APIs
 
     Examples::
         strategy = DDPStrategy(find_unused_parameters=True, gradient_as_bucket_view=True)
@@ -189,7 +189,7 @@ def prepare_fsdp(
     Args:
         module: module to be wrapped in FSDP
         device: device to which module will be moved
-        strategy: an instance of FSDPStrategy which defines the settings of FSDP APIs
+        strategy: an instance of :class:`~torchtnt.utils.prepare_module.FSDPStrategy` which defines the settings of FSDP APIs
 
     Examples::
         strategy = FSDPStrategy(limit_all_gathers=True)


### PR DESCRIPTION
Summary: Currently `DDPStrategy` and `FSDPStrategy` do not appear in docs, and links to those dataclasses do not appear in docstrings. This diff adds them in. Also updates links to `prepare_ddp`, `prepare_fsdp` as the links don't work currently.

Differential Revision: D50198680


