### PR TITLE
Log eval and prediction iteration times

### DIFF
--- a/tests/framework/callbacks/test_iteration_time_logger.py
+++ b/tests/framework/callbacks/test_iteration_time_logger.py
@@ -6,10 +6,15 @@
 # LICENSE file in the root directory of this source tree.
 
 import unittest
-from unittest.mock import MagicMock
+from unittest.mock import call, MagicMock
 
 from torch.utils.tensorboard import SummaryWriter
-from torchtnt.framework._test_utils import DummyTrainUnit, generate_random_dataloader
+from torchtnt.framework._test_utils import (
+    DummyEvalUnit,
+    DummyPredictUnit,
+    DummyTrainUnit,
+    generate_random_dataloader,
+)
 from torchtnt.framework.callbacks.iteration_time_logger import IterationTimeLogger
 
 from torchtnt.framework.state import State
@@ -22,20 +27,54 @@ class IterationTimeLoggerTest(unittest.TestCase):
         logger = MagicMock(spec=TensorBoardLogger)
         logger.writer = MagicMock(spec=SummaryWriter)
         state = MagicMock(spec=State)
-        state.train_state.iteration_timer.recorded_durations = {
-            "train_iteration_time": [1, 3, 5, 7, 9]
+
+        # Test that the recorded times are tracked separately and that we properly
+        # handle when there are no values for a given metric.
+        recorded_durations = {
+            "train_iteration_time": [1, 3, 5, 7, 9],
+            "eval_iteration_time": [],
+            "predict_iteration_time": [11, 13, 15, 17, 19],
         }
+        state.train_state.iteration_timer.recorded_durations = recorded_durations.copy()
+        state.eval_state.iteration_timer.recorded_durations = recorded_durations.copy()
+        state.predict_state.iteration_timer.recorded_durations = (
+            recorded_durations.copy()
+        )
 
-        my_unit = DummyTrainUnit(input_dim=2)
-        my_unit.train_progress.increment_step()
-        my_unit.train_progress.increment_step()
         callback = IterationTimeLogger(logger=logger, moving_avg_window=4)
-        callback.on_train_step_end(state, my_unit)
 
-        logger.writer.add_scalar.assert_called_with(
-            "Train Iteration Time (seconds)",
-            6,  # the average of the last 4 numbers is 6
-            2,  # after incrementing twice, step should be 2
+        # Set up some dummy units for invoking the callback.
+        train_unit = DummyTrainUnit(input_dim=2)
+        train_unit.train_progress.increment_step()
+        train_unit.train_progress.increment_step()
+
+        eval_unit = DummyEvalUnit(input_dim=2)
+        eval_unit.eval_progress.increment_step()
+        eval_unit.eval_progress.increment_step()
+
+        predict_unit = DummyPredictUnit(input_dim=2)
+        predict_unit.predict_progress.increment_step()
+        predict_unit.predict_progress.increment_step()
+
+        # Invoke the callback for each step type we are tracking iteration time for.
+        callback = IterationTimeLogger(logger=logger, moving_avg_window=4)
+        callback.on_train_step_end(state, train_unit)
+        callback.on_eval_step_end(state, eval_unit)
+        callback.on_predict_step_end(state, predict_unit)
+
+        logger.writer.add_scalar.assert_has_calls(
+            [
+                call(
+                    "Train Iteration Time (seconds)",
+                    6.0,  # the average of the last 4 numbers is 6
+                    2,  # after incrementing twice, step should be 2
+                ),
+                call(
+                    "Prediction Iteration Time (seconds)",
+                    16.0,  # the average of the last 4 numbers is 16
+                    2,  # after incrementing twice, step should be 2
+                ),
+            ]
         )
 
     def test_with_train_epoch(self) -> None:

--- a/torchtnt/framework/callbacks/iteration_time_logger.py
+++ b/torchtnt/framework/callbacks/iteration_time_logger.py
@@ -12,9 +12,10 @@ from torch.utils.tensorboard import SummaryWriter
 
 from torchtnt.framework.callback import Callback
 from torchtnt.framework.state import PhaseState, State
-from torchtnt.framework.unit import TTrainUnit
+from torchtnt.framework.unit import TEvalUnit, TPredictUnit, TTrainUnit
 from torchtnt.utils.distributed import get_global_rank
 from torchtnt.utils.loggers.tensorboard import TensorBoardLogger
+from torchtnt.utils.timer import TimerProtocol
 
 
 class IterationTimeLogger(Callback):
@@ -46,24 +47,64 @@ class IterationTimeLogger(Callback):
         self.moving_avg_window = moving_avg_window
         self.log_every_n_steps = log_every_n_steps
 
-    def on_train_step_end(self, state: State, unit: TTrainUnit) -> None:
-        if self._writer is None:
-            return
+    def _log_step_metrics(
+        self,
+        writer: SummaryWriter,
+        metric_label: str,
+        iteration_timer: TimerProtocol,
+        step_logging_for: int,
+    ) -> None:
+        """
+        Helper function to write a timing log message to writer based on how the class
+        was configured.
 
-        step_logging_for = unit.train_progress.num_steps_completed
+        """
         if step_logging_for % self.log_every_n_steps != 0:
             return
 
-        train_state: PhaseState = none_throws(state.train_state)
-        train_iteration_time_list = none_throws(
-            train_state.iteration_timer
-        ).recorded_durations.get("train_iteration_time", [])
-        if len(train_iteration_time_list) == 0:
+        human_metric_names = {
+            "train_iteration_time": "Train Iteration Time (seconds)",
+            "eval_iteration_time": "Eval Iteration Time (seconds)",
+            "predict_iteration_time": "Prediction Iteration Time (seconds)",
+        }
+
+        time_list = iteration_timer.recorded_durations.get(metric_label, [])
+        if not time_list:
             return
 
-        last_n_values = train_iteration_time_list[-self.moving_avg_window :]
-        none_throws(self._writer).add_scalar(
-            "Train Iteration Time (seconds)",
+        last_n_values = time_list[-self.moving_avg_window :]
+        writer.add_scalar(
+            human_metric_names[metric_label],
             sum(last_n_values) / len(last_n_values),
             step_logging_for,
         )
+
+    def on_train_step_end(self, state: State, unit: TTrainUnit) -> None:
+        timer = none_throws(state.train_state).iteration_timer
+        if writer := self._writer:
+            self._log_step_metrics(
+                writer,
+                "train_iteration_time",
+                timer,
+                unit.train_progress.num_steps_completed,
+            )
+
+    def on_eval_step_end(self, state: State, unit: TEvalUnit) -> None:
+        timer = none_throws(state.eval_state).iteration_timer
+        if writer := self._writer:
+            self._log_step_metrics(
+                writer,
+                "eval_iteration_time",
+                timer,
+                unit.eval_progress.num_steps_completed,
+            )
+
+    def on_predict_step_end(self, state: State, unit: TPredictUnit) -> None:
+        timer = none_throws(state.predict_state).iteration_timer
+        if writer := self._writer:
+            self._log_step_metrics(
+                writer,
+                "predict_iteration_time",
+                timer,
+                unit.predict_progress.num_steps_completed,
+            )


### PR DESCRIPTION
Summary:
In addition to previously logging `train_iteration_time`, now
also log `eval_iteration_time` and `predict_iteration_time` in
`IterationTimeLogger`.

Reviewed By: galrotem

Differential Revision: D50435391


