### PR TITLE
encapsulate snapshot restoration params in a struct

### DIFF
--- a/torchtnt/framework/callbacks/torchsnapshot_saver.py
+++ b/torchtnt/framework/callbacks/torchsnapshot_saver.py
@@ -25,8 +25,6 @@ from typing import (
 import torch.distributed as dist
 
 from pyre_extensions import none_throws
-from torchsnapshot.knobs import override_max_per_rank_io_concurrency
-from torchsnapshot.snapshot import PendingSnapshot, Snapshot, SNAPSHOT_METADATA_FNAME
 
 from torchtnt.framework.callback import Callback
 from torchtnt.framework.state import EntryPoint, State
@@ -46,6 +44,12 @@ from torchtnt.utils.stateful import Stateful
 
 try:
     import torchsnapshot
+    from torchsnapshot.knobs import override_max_per_rank_io_concurrency
+    from torchsnapshot.snapshot import (
+        PendingSnapshot,
+        Snapshot,
+        SNAPSHOT_METADATA_FNAME,
+    )
 
     _TStateful = torchsnapshot.Stateful
     _TORCHSNAPSHOT_AVAILABLE = True


### PR DESCRIPTION
Summary:
# Context
Users may want to opt out of restoring certain parts of the app state (for example, like optimizer and lr scheduler states when finetuning). This is currently not supported in torchsnapshot saver

# This Diff
* Adds `RestoreOptions` dataclass to encapsulate all restoration params
* moves `restore_train_progress`, `restore_eval_progress` to the struct
* Replaces all `restore` apis to take `RestoreOptions` struct, replacing the `restore_train_progress`, `restore_eval_progress`
* Adds optimizer and lr_scheduler to `RestoreOptions`

Differential Revision: D50757494


