### PR TITLE
Use python-3.11 in pre-commit.yaml

### DIFF
--- a/.github/workflows/pre_commit.yaml
+++ b/.github/workflows/pre_commit.yaml
@@ -11,4 +11,6 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     - uses: actions/setup-python@v3
+      with:
+        python-version: 3.11
     - uses: pre-commit/action@v3.0.0


### PR DESCRIPTION
As we are not ready yet to the Python-3.12

Summary:
Add `with: python-version: 3.11`

Test plan:
CI
