### PR TITLE
Fix progress esitmation with no len support

### DIFF
--- a/tests/utils/test_progress.py
+++ b/tests/utils/test_progress.py
@@ -8,7 +8,10 @@
 import unittest
 from unittest.mock import patch
 
-from torchtnt.framework._test_utils import generate_random_dataloader
+from torchtnt.framework._test_utils import (
+    generate_random_dataloader,
+    generate_random_iterable_dataloader,
+)
 
 from torchtnt.utils.progress import (
     estimated_steps_in_epoch,
@@ -267,3 +270,17 @@ class ProgressTest(unittest.TestCase):
                 ),
                 None,  # if the returned number of training steps is None, we return None
             )
+
+    def test_estimate_epoch_without_len(self) -> None:
+        dataloader = generate_random_iterable_dataloader(
+            num_samples=10, input_dim=2, batch_size=2
+        )
+        self.assertEqual(
+            estimated_steps_in_epoch(
+                dataloader,
+                num_steps_completed=0,
+                max_steps=None,
+                max_steps_per_epoch=None,
+            ),
+            float("inf"),
+        )

--- a/torchtnt/utils/progress.py
+++ b/torchtnt/utils/progress.py
@@ -74,7 +74,7 @@ def estimated_steps_in_epoch(
     if isinstance(dataloader, Sized):
         try:
             total = len(dataloader)
-        except NotImplementedError:
+        except (NotImplementedError, TypeError):
             pass
 
     if max_steps_per_epoch and max_steps:


### PR DESCRIPTION
Summary:
When dataset does not implement __len__, it is actually throwing TypeError which is not being caught.
This diff fixes that

Reviewed By: ninginthecloud

Differential Revision: D50886583


