### PR TITLE
Add start_step to MemorySnapshotProfiler

### DIFF
--- a/torchtnt/framework/callbacks/memory_snapshot.py
+++ b/torchtnt/framework/callbacks/memory_snapshot.py
@@ -8,7 +8,7 @@ import logging
 from typing import Optional
 
 from torchtnt.framework.callback import Callback
-from torchtnt.framework.state import EntryPoint, State
+from torchtnt.framework.state import State
 from torchtnt.framework.unit import TEvalUnit, TPredictUnit, TTrainUnit
 from torchtnt.utils.memory_snapshot_profiler import (
     MemorySnapshotParams,
@@ -42,24 +42,12 @@ class MemorySnapshot(Callback):
         self.memory_snapshot_profiler = MemorySnapshotProfiler(
             output_dir=output_dir, memory_snapshot_params=memory_snapshot_params
         )
-        self.memory_snapshot_profiler.start()
 
     def on_train_step_end(self, state: State, unit: TTrainUnit) -> None:
         self.memory_snapshot_profiler.step()
 
-    def on_train_end(self, state: State, unit: TTrainUnit) -> None:
-        self.memory_snapshot_profiler.stop()
-
     def on_eval_step_end(self, state: State, unit: TEvalUnit) -> None:
         self.memory_snapshot_profiler.step()
 
-    def on_eval_end(self, state: State, unit: TEvalUnit) -> None:
-        # if in fit do nothing since the profiler will be stopped in on_train_end
-        if state.entry_point == EntryPoint.EVALUATE:
-            self.memory_snapshot_profiler.stop()
-
     def on_predict_step_end(self, state: State, unit: TPredictUnit) -> None:
         self.memory_snapshot_profiler.step()
-
-    def on_predict_end(self, state: State, unit: TPredictUnit) -> None:
-        self.memory_snapshot_profiler.stop()


### PR DESCRIPTION
Summary:
Allows user to configure a `start_step` for when to start recording memory history. Addressing YanjunChen329 's feedback that he would like to record memory history for a specific range of steps, e.g. step 500-503.

Also:
* improve docstrings
* add validation for params
* MemorySnapshot callback no longer needs to call `start` and `stop`

Differential Revision: D51048945


