### PR TITLE
Remove __enter__ and __exit__ from MemorySnapshotProfiler

### DIFF
--- a/torchtnt/framework/callbacks/memory_snapshot.py
+++ b/torchtnt/framework/callbacks/memory_snapshot.py
@@ -8,7 +8,7 @@ import logging
 from typing import Optional
 
 from torchtnt.framework.callback import Callback
-from torchtnt.framework.state import EntryPoint, State
+from torchtnt.framework.state import State
 from torchtnt.framework.unit import TEvalUnit, TPredictUnit, TTrainUnit
 from torchtnt.utils.memory_snapshot_profiler import (
     MemorySnapshotParams,
@@ -42,24 +42,12 @@ class MemorySnapshot(Callback):
         self.memory_snapshot_profiler = MemorySnapshotProfiler(
             output_dir=output_dir, memory_snapshot_params=memory_snapshot_params
         )
-        self.memory_snapshot_profiler.start()
 
     def on_train_step_end(self, state: State, unit: TTrainUnit) -> None:
         self.memory_snapshot_profiler.step()
 
-    def on_train_end(self, state: State, unit: TTrainUnit) -> None:
-        self.memory_snapshot_profiler.stop()
-
     def on_eval_step_end(self, state: State, unit: TEvalUnit) -> None:
         self.memory_snapshot_profiler.step()
 
-    def on_eval_end(self, state: State, unit: TEvalUnit) -> None:
-        # if in fit do nothing since the profiler will be stopped in on_train_end
-        if state.entry_point == EntryPoint.EVALUATE:
-            self.memory_snapshot_profiler.stop()
-
     def on_predict_step_end(self, state: State, unit: TPredictUnit) -> None:
         self.memory_snapshot_profiler.step()
-
-    def on_predict_end(self, state: State, unit: TPredictUnit) -> None:
-        self.memory_snapshot_profiler.stop()

--- a/torchtnt/utils/memory_snapshot_profiler.py
+++ b/torchtnt/utils/memory_snapshot_profiler.py
@@ -6,8 +6,7 @@
 
 import logging
 from dataclasses import dataclass
-from types import TracebackType
-from typing import Optional, Type
+from typing import Optional
 
 import torch
 from torchtnt.utils.oom import attach_oom_observer, log_memory_snapshot
@@ -114,17 +113,6 @@ class MemorySnapshotProfiler:
         logger.info(
             f"Created MemorySnapshotProfiler with MemorySnapshotParams={self.params}."
         )
-
-    def __enter__(self) -> None:
-        self.start()
-
-    def __exit__(
-        self,
-        exc_type: Optional[Type[BaseException]],
-        exc_value: Optional[BaseException],
-        tb: Optional[TracebackType],
-    ) -> Optional[bool]:
-        self.stop()
 
     def start(self) -> None:
         if not torch.cuda.is_available():


### PR DESCRIPTION
Summary: There is no need for MemorySnapshotProfiler to be a context manager since it conflicts with start_step and stop_step

Differential Revision: D51049497


