### PR TITLE
Change file path in `log_memory_snapshot`

### DIFF
--- a/tests/utils/test_memory_snapshot_profiler.py
+++ b/tests/utils/test_memory_snapshot_profiler.py
@@ -47,7 +47,7 @@ class MemorySnapshotProfilerTest(unittest.TestCase):
             memory_snapshot_profiler.step()
 
             # Check if the corresponding files exist
-            save_dir = os.path.join(temp_dir, "memory_snapshot", "oom_rank0")
+            save_dir = os.path.join(temp_dir, "step_2_rank0")
 
             pickle_dump_path = os.path.join(save_dir, "snapshot.pickle")
             trace_path = os.path.join(save_dir, "trace_plot.html")

--- a/tests/utils/test_oom.py
+++ b/tests/utils/test_oom.py
@@ -78,10 +78,10 @@ class OomTest(unittest.TestCase):
             _ = (a + b) * (a - b)
 
             # save a snapshot
-            log_memory_snapshot(temp_dir)
+            log_memory_snapshot(temp_dir, "foo")
 
             # Check if the corresponding files exist
-            save_dir = os.path.join(temp_dir, "memory_snapshot", "oom_rank0")
+            save_dir = os.path.join(temp_dir, "foo_rank0")
 
             pickle_dump_path = os.path.join(save_dir, "snapshot.pickle")
             self.assertTrue(os.path.exists(pickle_dump_path))

--- a/torchtnt/utils/memory_snapshot_profiler.py
+++ b/torchtnt/utils/memory_snapshot_profiler.py
@@ -150,5 +150,7 @@ class MemorySnapshotProfiler:
         ):
             self.start()
         if self.params.stop_step is not None and self.step_num == self.params.stop_step:
-            log_memory_snapshot(output_dir=self.output_dir)
+            log_memory_snapshot(
+                output_dir=self.output_dir, file_prefix=f"step_{self.step_num}"
+            )
             self.stop()


### PR DESCRIPTION
Summary:
* Don't append an extra `memory_snapshot` dir to the path, let the user pass in the directory where they want to save the files
* Allow passing in a filename prefix so we can distinguish between OOM snapshots and snapshots taken on a specific step

Differential Revision: D51056427


