### PR TITLE
avoid framework utils dependency on unit

### DIFF
--- a/torchtnt/framework/auto_unit.py
+++ b/torchtnt/framework/auto_unit.py
@@ -29,12 +29,13 @@ from torch.nn.parallel import DistributedDataParallel as DDP
 from torch.optim.swa_utils import SWALR
 from torchtnt.framework.state import ActivePhase, EntryPoint, State
 from torchtnt.framework.unit import EvalUnit, PredictUnit, TPredictData, TrainUnit
-from torchtnt.framework.utils import _is_fsdp_module, get_timing_context
+from torchtnt.framework.utils import get_timing_context
 from torchtnt.utils.device import copy_data_to_device, record_data_in_stream
 from torchtnt.utils.env import init_from_env
 from torchtnt.utils.lr_scheduler import TLRScheduler
 from torchtnt.utils.precision import convert_precision_str_to_dtype
 from torchtnt.utils.prepare_module import (
+    _is_fsdp_module,
     ActivationCheckpointParams,
     FSDPStrategy,
     prepare_fsdp,

--- a/torchtnt/framework/callbacks/torchsnapshot_saver.py
+++ b/torchtnt/framework/callbacks/torchsnapshot_saver.py
@@ -38,7 +38,7 @@ from torchtnt.framework.unit import (
     TTrainData,
     TTrainUnit,
 )
-from torchtnt.framework.utils import _construct_tracked_optimizers, get_timing_context
+from torchtnt.framework.utils import get_timing_context
 from torchtnt.utils.distributed import get_global_rank, PGWrapper
 from torchtnt.utils.fsspec import get_filesystem
 from torchtnt.utils.optimizer import init_optim_state
@@ -505,7 +505,7 @@ def _get_snapshot_save_path(dirpath: str, epoch: int, step: int) -> str:
 def _app_state(unit: AppStateMixin) -> Dict[str, Any]:
     """Join together all of the tracked stateful entities to simplify registration of snapshottable states, deals with FSDP case"""
     app_state = unit.app_state()
-    tracked_optimizers = _construct_tracked_optimizers(unit)  # handles fsdp
+    tracked_optimizers = unit._construct_tracked_optimizers()  # handles fsdp
     app_state.update(tracked_optimizers)
     return app_state
 


### PR DESCRIPTION
Summary: Avoid dependency of `unit` module in framework utils

Differential Revision: D51162743


