### PR TITLE
add base checkpointer class

### DIFF
--- a/tests/framework/callbacks/test_base_checkpointer.py
+++ b/tests/framework/callbacks/test_base_checkpointer.py
@@ -1,0 +1,450 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+import io
+import math
+import os
+import shutil
+import tempfile
+import time
+import unittest
+from typing import Iterable, List, Optional
+from unittest.mock import MagicMock, patch
+
+import torch
+import torch.distributed as dist
+
+from torchtnt.framework._test_utils import (
+    DummyFitUnit,
+    DummyTrainUnit,
+    generate_random_dataloader,
+    get_dummy_fit_state,
+    get_dummy_train_state,
+)
+from torchtnt.framework.callbacks.base_checkpointer import BaseCheckpointer
+from torchtnt.framework.callbacks.checkpointer_types import RestoreOptions
+from torchtnt.framework.callbacks.lambda_callback import Lambda
+from torchtnt.framework.state import State
+
+from torchtnt.framework.train import train
+from torchtnt.framework.unit import AppStateMixin, TTrainData
+from torchtnt.utils.distributed import get_global_rank
+from torchtnt.utils.env import init_from_env
+from torchtnt.utils.test_utils import spawn_multi_process
+
+
+class BaseCheckpointSaver(BaseCheckpointer):
+    """
+    A basic checkpointer class that generates an empty directory upon checkpoint
+    """
+
+    def __init__(
+        self,
+        dirpath: str,
+        *,
+        save_every_n_train_steps: Optional[int] = None,
+        save_every_n_epochs: Optional[int] = None,
+        keep_last_n_checkpoints: Optional[int] = None,
+        process_group: Optional[dist.ProcessGroup] = None,
+    ) -> None:
+        super().__init__(
+            dirpath,
+            save_every_n_train_steps=save_every_n_train_steps,
+            save_every_n_epochs=save_every_n_epochs,
+            keep_last_n_checkpoints=keep_last_n_checkpoints,
+            process_group=process_group,
+        )
+        self._latest_checkpoint_path: str = ""
+
+    def _checkpoint_impl(
+        self, state: State, unit: AppStateMixin, checkpoint_path: str, hook: str
+    ) -> bool:
+        self._latest_checkpoint_path = checkpoint_path
+        if not os.path.exists(checkpoint_path):
+            os.mkdir(checkpoint_path)
+        return True
+
+    @staticmethod
+    def restore(
+        path: str,
+        unit: AppStateMixin,
+        *,
+        train_dataloader: Optional[Iterable[TTrainData]] = None,
+        process_group: Optional[dist.ProcessGroup] = None,
+        restore_options: Optional[RestoreOptions] = None,
+        msg: str = "",
+    ) -> None:
+        print(f"Checkpoint restored with message: {msg}")
+        return
+
+
+class BaseCheckpointerTest(unittest.TestCase):
+    cuda_available: bool = torch.cuda.is_available()
+    distributed_available: bool = torch.distributed.is_available()
+
+    def test_save_every_n_train_steps(self) -> None:
+        input_dim = 2
+        dataset_len = 10
+        batch_size = 2
+        max_epochs = 2
+        expected_steps_per_epoch = math.ceil(dataset_len / batch_size)
+        save_every_n_train_steps = 2
+
+        my_unit = DummyTrainUnit(input_dim=input_dim)
+        dataloader = generate_random_dataloader(dataset_len, input_dim, batch_size)
+        expected_paths: List[str] = []
+        with tempfile.TemporaryDirectory() as temp_dir:
+            cumulative_steps = 0
+            for epoch in range(max_epochs):
+                for _ in range(
+                    save_every_n_train_steps,
+                    expected_steps_per_epoch + 1,
+                    save_every_n_train_steps,
+                ):
+                    cumulative_steps += save_every_n_train_steps
+                    expected_paths.append(
+                        os.path.join(temp_dir, f"epoch_{epoch}_step_{cumulative_steps}")
+                    )
+            checkpointer = BaseCheckpointSaver(
+                temp_dir,
+                save_every_n_train_steps=save_every_n_train_steps,
+            )
+            train(
+                my_unit,
+                dataloader,
+                max_epochs=max_epochs,
+                callbacks=[checkpointer],
+            )
+            for path in expected_paths:
+                self.assertTrue(os.path.exists(path) and os.path.isdir(path))
+
+    def test_save_every_n_train_epochs(self) -> None:
+        input_dim = 2
+        dataset_len = 10
+        batch_size = 2
+        max_epochs = 3
+        expected_steps_per_epoch = math.ceil(dataset_len / batch_size)
+        save_every_n_train_epochs = 2
+
+        my_unit = DummyTrainUnit(input_dim=input_dim)
+        dataloader = generate_random_dataloader(dataset_len, input_dim, batch_size)
+        with tempfile.TemporaryDirectory() as temp_dir:
+            expected_path = os.path.join(
+                temp_dir,
+                f"epoch_{save_every_n_train_epochs}_step_{expected_steps_per_epoch * (save_every_n_train_epochs)}",
+            )
+            checkpointer = BaseCheckpointSaver(
+                temp_dir,
+                save_every_n_epochs=save_every_n_train_epochs,
+            )
+            train(my_unit, dataloader, max_epochs=max_epochs, callbacks=[checkpointer])
+            self.assertTrue(
+                os.path.exists(expected_path) and os.path.isdir(expected_path)
+            )
+
+    def test_save_fit_entrypoint(self) -> None:
+        input_dim = 2
+
+        my_unit = DummyFitUnit(input_dim=input_dim)
+        with tempfile.TemporaryDirectory() as temp_dir:
+            checkpointer = BaseCheckpointSaver(
+                temp_dir, save_every_n_train_steps=1, save_every_n_epochs=1
+            )
+            train_state = get_dummy_train_state()
+            fit_state = get_dummy_fit_state()
+            my_unit.train_progress._num_steps_completed = 15
+            my_unit.eval_progress._num_steps_completed = 10
+
+            checkpointer.on_train_step_end(train_state, my_unit)
+            self.assertIn(f"epoch_0_step_{15}", checkpointer._latest_checkpoint_path)
+
+            checkpointer.on_train_step_end(fit_state, my_unit)
+            self.assertIn(
+                f"epoch_0_step_{15 + 10}", checkpointer._latest_checkpoint_path
+            )
+
+            checkpointer.on_train_epoch_end(train_state, my_unit)
+            self.assertIn(f"epoch_0_step_{15}", checkpointer._latest_checkpoint_path)
+
+            checkpointer.on_train_epoch_end(fit_state, my_unit)
+            self.assertIn(
+                f"epoch_0_step_{15 + 10}", checkpointer._latest_checkpoint_path
+            )
+
+    @unittest.mock.patch("sys.stdout", new_callable=io.StringIO)
+    def test_restore_from_latest(self, mock_stdout: MagicMock) -> None:
+        my_unit = DummyTrainUnit(input_dim=2)
+        with tempfile.TemporaryDirectory() as temp_dir:
+            # create a dummy directory structure
+            os.makedirs(os.path.join(temp_dir, "epoch_0_step_0"))
+
+            BaseCheckpointSaver.restore_from_latest(temp_dir, my_unit, msg="foo")
+
+            # ensure **kwargs are plumbed through correctly
+            self.assertEqual(
+                mock_stdout.getvalue(), "Checkpoint restored with message: foo\n"
+            )
+
+    def test_restore_from_latest_empty_dir(self) -> None:
+        input_dim = 2
+        save_every_n_train_steps = 2
+
+        my_unit = DummyTrainUnit(input_dim=input_dim)
+        with tempfile.TemporaryDirectory() as temp_dir:
+            bcs_cb = BaseCheckpointSaver(
+                temp_dir,
+                save_every_n_train_steps=save_every_n_train_steps,
+            )
+
+            with self.assertLogs(level="WARNING") as log:
+                restored = bcs_cb.restore_from_latest(temp_dir, my_unit)
+                self.assertEqual(
+                    log.output,
+                    [
+                        f"WARNING:torchtnt.framework.callbacks._checkpoint_utils:Input dirpath doesn't contain any subdirectories: {temp_dir}"
+                    ],
+                )
+                self.assertFalse(restored)
+
+    def test_save_on_train_end(self) -> None:
+        input_dim = 2
+        dataset_len = 10
+        batch_size = 2
+        max_epochs = 2
+
+        expected_path = (
+            f"epoch_{max_epochs}_step_{max_epochs * (dataset_len // batch_size)}"
+        )
+
+        my_unit = DummyTrainUnit(input_dim=input_dim)
+        dataloader = generate_random_dataloader(dataset_len, input_dim, batch_size)
+        with tempfile.TemporaryDirectory() as temp_dir:
+            self.assertFalse(os.path.exists(os.path.join(temp_dir, expected_path)))
+            checkpoint_cb = BaseCheckpointSaver(
+                temp_dir,
+            )
+            train(my_unit, dataloader, max_epochs=max_epochs, callbacks=[checkpoint_cb])
+
+            expected_path = (
+                f"epoch_{max_epochs}_step_{max_epochs * (dataset_len // batch_size)}"
+            )
+            self.assertTrue(os.path.exists(os.path.join(temp_dir, expected_path)))
+
+            with self.assertLogs(level="WARNING") as log:
+                checkpoint_cb.metadata_fname = ".metadata"
+                # create metadata file
+                with open(os.path.join(temp_dir, expected_path, ".metadata"), "w"):
+                    pass
+
+                # train again without resetting progress
+                train(
+                    my_unit,
+                    dataloader,
+                    max_epochs=max_epochs,
+                    callbacks=[checkpoint_cb],
+                )
+                self.assertEqual(
+                    log.output,
+                    [
+                        "WARNING:torchtnt.framework.callbacks.base_checkpointer:Final checkpoint already exists, skipping."
+                    ],
+                )
+
+    @unittest.skipUnless(
+        condition=distributed_available, reason="Torch distributed is needed to run"
+    )
+    def test_directory_sync_collective(self) -> None:
+        spawn_multi_process(
+            2,
+            "gloo",
+            self._directory_sync_collective,
+        )
+
+    @staticmethod
+    def _directory_sync_collective() -> None:
+        init_from_env()
+        try:
+            if get_global_rank() == 0:
+                temp_dir = tempfile.mkdtemp()
+            else:
+                temp_dir = "foo"
+
+            bcs = BaseCheckpointSaver(temp_dir)
+            dirpath = bcs.dirpath
+            tc = unittest.TestCase()
+            tc.assertTrue("tmp" in dirpath)
+            tc.assertFalse("foo" in dirpath)
+        finally:
+            if get_global_rank() == 0:
+                shutil.rmtree(temp_dir)  # delete temp directory
+
+    def test_invalid_args(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            with self.assertRaisesRegex(
+                ValueError, "Invalid value passed for save_every_n_train_steps.*"
+            ):
+                BaseCheckpointSaver(temp_dir, save_every_n_train_steps=-2)
+            with self.assertRaisesRegex(
+                ValueError, "Invalid value passed for save_every_n_train_steps.*"
+            ):
+                BaseCheckpointSaver(temp_dir, save_every_n_train_steps=0)
+            with self.assertRaisesRegex(
+                ValueError, "Invalid value passed for save_every_n_epochs.*"
+            ):
+                BaseCheckpointSaver(temp_dir, save_every_n_epochs=-2)
+            with self.assertRaisesRegex(
+                ValueError, "Invalid value passed for save_every_n_epochs.*"
+            ):
+                BaseCheckpointSaver(temp_dir, save_every_n_epochs=0)
+
+    @unittest.skipUnless(
+        condition=distributed_available, reason="Torch distributed is needed to run"
+    )
+    @unittest.skipUnless(
+        condition=cuda_available, reason="This test needs a GPU host to run."
+    )
+    def test_process_group_plumbing(self) -> None:
+        """
+        Creates a new process group and verifies that it's passed through correctly
+        """
+        spawn_multi_process(
+            2,
+            "nccl",
+            self._test_process_group_plumbing,
+        )
+
+    @staticmethod
+    def _test_process_group_plumbing() -> None:
+        new_pg = dist.new_group(backend="gloo")
+
+        if get_global_rank() == 0:
+            temp_dir = tempfile.mkdtemp()
+        else:
+            temp_dir = ""
+
+        checkpoint_cb = BaseCheckpointSaver(
+            temp_dir,
+            process_group=new_pg,
+        )
+        tc = unittest.TestCase()
+        try:
+            tc.assertEqual(checkpoint_cb._process_group, new_pg)
+        finally:
+            if get_global_rank() == 0:
+                shutil.rmtree(temp_dir)  # delete temp directory
+
+    def test_should_remove_checkpoint(self) -> None:
+        """
+        Tests the helper function that checks if checkpoint should be removed or not
+        """
+        bc = BaseCheckpointSaver("temp")
+
+        # keep_last_n_checkpoints is toggled off
+        self.assertFalse(bc._should_remove_checkpoint())
+
+        # not enough checkpoints are saved yet to be removed
+        bc._keep_last_n_checkpoints = 2
+        bc._ckpt_dirpaths = ["bar"]
+        self.assertFalse(bc._should_remove_checkpoint())
+
+        # enough checkpoints are there to remove
+        bc._keep_last_n_checkpoints = 2
+        bc._ckpt_dirpaths = ["foo", "bar"]
+        self.assertTrue(bc._should_remove_checkpoint())
+
+    @patch("torchtnt.framework.callbacks.base_checkpointer._delete_checkpoint")
+    def test_cleanup_surplus(self, mock_delete_checkpoint: MagicMock) -> None:
+        """
+        Tests surplus of checkpoints being cleaned up
+        """
+        state = get_dummy_train_state()
+        unit = DummyTrainUnit(input_dim=2)
+        warning_messages = []
+        with tempfile.TemporaryDirectory() as temp_dir:
+            bc = BaseCheckpointSaver(temp_dir, keep_last_n_checkpoints=1)
+            bc._ckpt_dirpaths = ["foo", "bar", "baz"]
+
+            expected_warning_msg = " ".join(
+                [
+                    f"3 checkpoints found in {temp_dir}.",
+                    f"Deleting {2} oldest",
+                    "checkpoints to enforce ``keep_last_n_checkpoints`` argument.",
+                ]
+            )
+
+            with patch(
+                "torchtnt.framework.callbacks.base_checkpointer.logging.Logger.warning",
+                warning_messages.append,
+            ):
+                bc.on_train_start(state, unit)
+            self.assertEqual(bc._ckpt_dirpaths, ["baz"])
+            self.assertEqual(warning_messages[0], expected_warning_msg)
+
+            bc = BaseCheckpointSaver(temp_dir)
+            bc._ckpt_dirpaths = ["foo", "bar", "baz"]
+
+            bc.on_train_start(state, unit)
+            self.assertEqual(bc._ckpt_dirpaths, ["foo", "bar", "baz"])
+
+    def test_keep_last_n_checkpoints(self) -> None:
+        """
+        Tests removing checkpoint directories
+        """
+        unit = DummyTrainUnit(input_dim=2)
+        state = get_dummy_train_state()
+        with tempfile.TemporaryDirectory() as temp_dir:
+            bc = BaseCheckpointSaver(
+                temp_dir,
+                save_every_n_train_steps=1,
+                keep_last_n_checkpoints=2,
+            )
+
+            # take 10 steps
+            for _ in range(10):
+                unit.train_progress.increment_step()
+                bc.on_train_step_end(state, unit)
+                # TODO remove time.sleep to avoid potential flaky test
+                time.sleep(0.1)  # sleep to ensure enough time to checkpoint
+
+            dirs = os.listdir(temp_dir)
+            self.assertEqual(len(dirs), 2)
+            self.assertIn("epoch_0_step_9", dirs)
+            self.assertIn("epoch_0_step_10", dirs)
+
+    def test_keep_last_n_checkpoints_e2e(self) -> None:
+        """
+        Tests removing checkpoint directories e2e
+        """
+        input_dim = 2
+        dataset_len = 10
+        batch_size = 2
+        max_epochs = 2
+
+        my_unit = DummyTrainUnit(input_dim=input_dim)
+        dataloader = generate_random_dataloader(dataset_len, input_dim, batch_size)
+        with tempfile.TemporaryDirectory() as temp_dir:
+            bc = BaseCheckpointSaver(
+                temp_dir,
+                save_every_n_train_steps=2,
+                keep_last_n_checkpoints=1,
+            )
+            # Artificially increase the step duration, otherwise torchcheckpoint
+            # doesn't have the time to save all checkpoints and will skip some.
+            slowdown = Lambda(on_train_step_end=lambda *_: time.sleep(0.1))
+
+            train(
+                my_unit,
+                dataloader,
+                max_epochs=max_epochs,
+                callbacks=[bc, slowdown],
+            )
+            dirs = os.listdir(temp_dir)
+            self.assertEqual(len(dirs), 1)
+            self.assertIn(
+                f"epoch_{max_epochs}_step_{dataset_len // batch_size * max_epochs}",
+                os.listdir(temp_dir),
+            )

--- a/torchtnt/framework/callbacks/base_checkpointer.py
+++ b/torchtnt/framework/callbacks/base_checkpointer.py
@@ -1,0 +1,313 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+import abc
+import logging
+import os
+from typing import Any, cast, Iterable, List, Optional
+
+import torch.distributed as dist
+
+from torchtnt.framework.callback import Callback
+from torchtnt.framework.callbacks._checkpoint_utils import (
+    _delete_checkpoint,
+    _retrieve_checkpoint_dirpaths,
+    get_latest_checkpoint_path,
+)
+from torchtnt.framework.callbacks.checkpointer_types import RestoreOptions
+from torchtnt.framework.state import EntryPoint, State
+from torchtnt.framework.unit import AppStateMixin, TEvalUnit, TTrainData, TTrainUnit
+from torchtnt.framework.utils import get_timing_context
+from torchtnt.utils.distributed import PGWrapper
+from torchtnt.utils.fsspec import get_filesystem
+from torchtnt.utils.rank_zero_log import rank_zero_warn
+
+logger: logging.Logger = logging.getLogger(__name__)
+
+
+class BaseCheckpointer(Callback, metaclass=abc.ABCMeta):
+    """
+    Abstract base class for file-based state_dict checkpointing. This class can be used as the base of a checkpointing callback, and handles
+    checkpointing frequency logic, checkpoint naming, checkpoint purging / upkeep, and process group synchronization. There are only two methods
+    that need to be implemented by subclasses:
+
+    1) ``_checkpoint_impl`` which implements the checkpoint saving logic, given the relevant checkpoint items and path.
+    2) ``restore`` which implements restoring the checkpoint given the relevant checkpoint path.
+
+    The subclass may override the ``metadata_fname`` attribute to specify the filename of the metadata file that will be written within the checkpoint directory.
+    This will be used by this base class to ensure the integrity of the checkpoint.
+
+    Args:
+        dirpath: Parent directory to save checkpoints to.
+        save_every_n_train_steps: Frequency of steps with which to save checkpoints during the train epoch. If None, no intra-epoch checkpoints are generated.
+        save_every_n_epochs: Frequency of epochs with which to save checkpoints during training. If None, no end-of-epoch checkpoints are generated.
+        keep_last_n_checkpoints: Number of most recent checkpoints to keep. If None, all checkpoints are kept. If an excess of existing checkpoints are present, the oldest ones will be deleted to clean the difference.
+        process_group: The process group on which the ranks will communicate on. default: ``None`` (the entire world)
+
+    Note:
+        If torch.distributed is available and default process group is initialized, the constructor will call a collective operation for rank 0 to broadcast the dirpath to all other ranks
+
+     Note:
+        This class assumes checkpoint items are saved in the directory provided in ``_checkpoint_impl`` and will be in the form of ``<dirpath>/<epoch>-<step>/``. Checkpoint contents
+        should be stored within this directory, as deleting and retrieving latest checkpoint relies on reading the <epoch>-<step> directory name within <dirpath>
+    """
+
+    metadata_fname: Optional[str] = None
+
+    def __init__(
+        self,
+        dirpath: str,
+        *,
+        save_every_n_train_steps: Optional[int] = None,
+        save_every_n_epochs: Optional[int] = None,
+        keep_last_n_checkpoints: Optional[int] = None,
+        process_group: Optional[dist.ProcessGroup] = None,
+    ) -> None:
+        if save_every_n_train_steps is not None and save_every_n_train_steps <= 0:
+            raise ValueError(
+                f"Invalid value passed for save_every_n_train_steps. Expected to receive either None or positive number, but received {save_every_n_train_steps}"
+            )
+        if save_every_n_epochs is not None and save_every_n_epochs <= 0:
+            raise ValueError(
+                f"Invalid value passed for save_every_n_epochs. Expected to receive either None or positive number, but received {save_every_n_epochs}"
+            )
+        if keep_last_n_checkpoints is not None and keep_last_n_checkpoints <= 0:
+            raise ValueError(
+                f"Invalid value passed for keep_last_n_checkpoints. Expected to receive either None or positive number, but received {keep_last_n_checkpoints}"
+            )
+
+        self._save_every_n_train_steps = save_every_n_train_steps
+        self._save_every_n_epochs = save_every_n_epochs
+        self._keep_last_n_checkpoints = keep_last_n_checkpoints
+        self._ckpt_dirpaths: List[str] = []
+        if self._keep_last_n_checkpoints:
+            self._ckpt_dirpaths = _retrieve_checkpoint_dirpaths(dirpath)
+        self._process_group = process_group
+        self._pg_wrapper = PGWrapper(process_group)
+
+        # sync dirpaths from rank 0
+        self._sync_dirpath_to_all_ranks(dirpath)
+
+    def _sync_dirpath_to_all_ranks(self, dirpath: str) -> None:
+        if not (dist.is_available() and dist.is_initialized()):
+            self._dirpath: str = dirpath
+            return
+
+        dirpath_container = [dirpath] if self._pg_wrapper.get_rank() == 0 else [""]
+        # broadcast directory from global rank 0
+        dist.broadcast_object_list(dirpath_container, src=0, group=self._process_group)
+        updated_dirpath = dirpath_container[0]
+        if updated_dirpath != dirpath:
+            logger.warning(f"Updating dirpath to match rank 0: {updated_dirpath}")
+
+        self._dirpath: str = updated_dirpath
+
+    @property
+    def dirpath(self) -> str:
+        """Returns parent directory to save to."""
+        return self._dirpath
+
+    def _generate_checkpoint_and_upkeep(
+        self, state: State, unit: TTrainUnit, hook: str
+    ) -> bool:
+        """
+        Implementation for saving checkpoint while taking care of checkpoint
+        name generation and cleanup of oldest checkpoints.
+
+        Args:
+            state: Current state of the trainer.
+            unit: Current training unit.
+            hook: Hook at which checkpoint is being saved.
+
+        Returns:
+            True if checkpoint was successfully saved. False otherwise.
+        """
+        # 1) generate checkpoint name
+        num_steps_completed = unit.train_progress.num_steps_completed
+        if state.entry_point == EntryPoint.FIT:
+            num_steps_completed += cast(
+                TEvalUnit, unit
+            ).eval_progress.num_steps_completed
+        epoch = unit.train_progress.num_epochs_completed
+        checkpoint_path = _get_save_path(self._dirpath, epoch, num_steps_completed)
+
+        # 1.5) If metadata_fname is set, ensure metadata file doesn't exist on final checkpoint
+        if hook == "on_train_end" and self.metadata_fname:
+            metadata_filepath = os.path.join(checkpoint_path, self.metadata_fname)
+            fs = get_filesystem(metadata_filepath)
+            if fs.exists(metadata_filepath):
+                rank_zero_warn(
+                    "Final checkpoint already exists, skipping.", logger=logger
+                )
+                return False
+
+        # 2) save checkpoint
+        success = self._checkpoint_impl(
+            state,
+            unit,
+            checkpoint_path=checkpoint_path,
+            hook=hook,
+        )
+
+        # 3) book keep and remove oldest checkpoints
+        if success:
+            if self._should_remove_checkpoint():
+                self._remove_checkpoint(state)
+            self._ckpt_dirpaths.append(checkpoint_path)
+
+        return success
+
+    def on_train_start(self, state: State, unit: TTrainUnit) -> None:
+        # clean up the difference if surplus of checkpoints exist
+        keep_last_n_checkpoints = self._keep_last_n_checkpoints
+        if (
+            keep_last_n_checkpoints
+            and len(self._ckpt_dirpaths) > keep_last_n_checkpoints
+        ):
+            logger.warning(
+                " ".join(
+                    [
+                        f"{len(self._ckpt_dirpaths)} checkpoints found in {self._dirpath}.",
+                        f"Deleting {len(self._ckpt_dirpaths) - keep_last_n_checkpoints} oldest",
+                        "checkpoints to enforce ``keep_last_n_checkpoints`` argument.",
+                    ]
+                )
+            )
+            for _ in range(len(self._ckpt_dirpaths) - keep_last_n_checkpoints):
+                self._remove_checkpoint(state)
+
+    def on_train_step_end(self, state: State, unit: TTrainUnit) -> None:
+        num_steps_completed = unit.train_progress.num_steps_completed
+        save_every_n_train_steps = self._save_every_n_train_steps
+        if (
+            save_every_n_train_steps is None
+            or num_steps_completed % save_every_n_train_steps != 0
+        ):
+            return
+
+        self._generate_checkpoint_and_upkeep(state, unit, hook="on_train_step_end")
+
+    def on_train_epoch_end(self, state: State, unit: TTrainUnit) -> None:
+        epoch = unit.train_progress.num_epochs_completed
+        save_every_n_epochs = self._save_every_n_epochs
+        if save_every_n_epochs is None or epoch % save_every_n_epochs != 0:
+            return
+
+        self._generate_checkpoint_and_upkeep(state, unit, hook="on_train_epoch_end")
+
+    def on_train_end(self, state: State, unit: TTrainUnit) -> None:
+        self._generate_checkpoint_and_upkeep(state, unit, hook="on_train_end")
+
+    @abc.abstractmethod
+    def _checkpoint_impl(
+        self,
+        state: State,
+        unit: AppStateMixin,
+        *,
+        checkpoint_path: str,
+        hook: str,
+    ) -> bool:
+        """
+        Implementation of saving checkpoint.
+
+        Args:
+            state: current application state
+            unit: current unit
+            checkpoint_path: path to save checkpoint
+            hook: name of callback hook that triggered this function call
+
+        Returns:
+            Whether a new checkpoint was created.
+        """
+        ...
+
+    def _should_remove_checkpoint(self) -> bool:
+        keep_last_n_checkpoints = self._keep_last_n_checkpoints
+        return (
+            keep_last_n_checkpoints is not None
+            and len(self._ckpt_dirpaths) >= keep_last_n_checkpoints
+        )
+
+    def _remove_checkpoint(self, state: State) -> None:
+        # remove oldest checkpoint directory
+        oldest_ckpt_path = self._ckpt_dirpaths.pop(0)
+        with get_timing_context(state, f"{self.__class__.__name__}.delete_checkpoint"):
+            if self._pg_wrapper.get_rank() == 0:
+                # only delete on rank 0
+                _delete_checkpoint(oldest_ckpt_path)
+            self._pg_wrapper.barrier()
+
+    @staticmethod
+    @abc.abstractmethod
+    def restore(
+        path: str,
+        unit: AppStateMixin,
+        *,
+        train_dataloader: Optional[Iterable[TTrainData]] = None,
+        process_group: Optional[dist.ProcessGroup] = None,
+        restore_options: Optional[RestoreOptions] = None,
+    ) -> None:
+        """Method to restore checkpoint state from a path.
+
+        There are additional flags offered should the user want to skip loading the train and eval progress.
+        By default, the train and eval progress are restored, if applicable.
+
+        Args:
+            path: Path of the checkpoint to restore.
+            unit: An instance of :class:`~torchtnt.framework.unit.TrainUnit`, :class:`~torchtnt.framework.unit.EvalUnit`, or :class:`~torchtnt.framework.unit.PredictUnit` containing states to restore.
+            train_dataloader: An optional train dataloader to restore.
+            process_group: The process group on which the ranks will communicate on. default: ``None`` (the entire world)
+            restore_options: Controls what to filter when restoring the state.
+        """
+        ...
+
+    @classmethod
+    def restore_from_latest(
+        cls,
+        dirpath: str,
+        unit: AppStateMixin,
+        *,
+        train_dataloader: Optional[Iterable[TTrainData]] = None,
+        process_group: Optional[dist.ProcessGroup] = None,
+        restore_options: Optional[RestoreOptions] = None,
+        **kwargs: Any,
+    ) -> bool:
+        """
+        Given a parent directory where checkpoints are saved, restore the checkppoint state from the latest checkpoint in the directory.
+
+        There are additional flags offered should the user want to skip loading the train and eval progress.
+        By default, the train and eval progress are restored, if applicable.
+
+        Args:
+            dirpath: Parent directory from which to get the latest checkpoint.
+            unit: An instance of :class:`~torchtnt.framework.unit.TrainUnit`, :class:`~torchtnt.framework.unit.EvalUnit`, or :class:`~torchtnt.framework.unit.PredictUnit` containing states to restore.
+            train_dataloader: An optional train dataloader to restore.
+            process_group: The process group on which the ranks will communicate on. default: ``None`` (the entire world)
+            restore_options: Controls what to  filter when restoring the state.
+
+        Returns:
+            True if the latest checkpoint directory was found and successfully restored, otherwise False.
+        """
+        path = get_latest_checkpoint_path(
+            dirpath, metadata_fname=cls.metadata_fname, process_group=process_group
+        )
+        if path is None:
+            return False
+        logger.info(f"Restoring from path: {path}")
+        cls.restore(
+            path,
+            unit,
+            train_dataloader=train_dataloader,
+            process_group=process_group,
+            restore_options=restore_options,
+            **kwargs,
+        )
+        return True
+
+
+def _get_save_path(dirpath: str, epoch: int, step: int) -> str:
+    # TODO: discuss whether this path should be customized
+    return os.path.join(dirpath, f"epoch_{epoch}_step_{step}")


### PR DESCRIPTION
Summary:
# Context
We want to add another checkpointer using [DCP](https://pytorch.org/docs/stable/distributed.checkpoint.html). However, we don't want to duplicate the logic that already exists in TorchSnapshotSaver related to checkpoint frequency, keeping k latest checkpoints, etc

# This Diff
* Adds abstract `BaseCheckpointer` class to implements common logic like syncing dirpath's across all ranks, implementing all hooks where checkpoint may occur, etc.

* Any class subclassing must implement `_checkpoint_impl` and `restore` functions. The `restore_from_latest` method will call the user defined `restore`.

* Additionally `TorchSnapshotSaver` is now refactored to subclass `BaseCheckpointer`

Differential Revision: D51328340


