### PR TITLE
create app_state preparer utils

### DIFF
--- a/tests/framework/callbacks/test_checkpoint_utils.py
+++ b/tests/framework/callbacks/test_checkpoint_utils.py
@@ -16,9 +16,11 @@ from torch import nn
 from torch.distributed import launcher
 from torchsnapshot import Snapshot
 from torchsnapshot.snapshot import SNAPSHOT_METADATA_FNAME
+from torchtnt.framework._test_utils import DummyTrainUnit, get_dummy_train_state
 
 from torchtnt.framework.callbacks._checkpoint_utils import (
     _delete_checkpoint,
+    _prepare_app_state_for_checkpoint,
     _retrieve_checkpoint_dirpaths,
     get_latest_checkpoint_path,
 )
@@ -172,3 +174,13 @@ class CheckpointUtilsTest(unittest.TestCase):
                 _delete_checkpoint(temp_dir, SNAPSHOT_METADATA_FNAME)
             _delete_checkpoint(dirpath)
             self.assertFalse(os.path.exists(dirpath))
+
+    def test_get_app_state(self) -> None:
+        my_unit = DummyTrainUnit(input_dim=2)
+        state = get_dummy_train_state()
+
+        app_state = _prepare_app_state_for_checkpoint(state, my_unit, intra_epoch=False)
+        self.assertCountEqual(
+            app_state.keys(),
+            ["module", "optimizer", "loss_fn", "train_progress"],
+        )

--- a/tests/framework/callbacks/test_torchsnapshot_saver.py
+++ b/tests/framework/callbacks/test_torchsnapshot_saver.py
@@ -27,7 +27,6 @@ from torchtnt.framework._test_utils import (
 )
 from torchtnt.framework.callbacks.checkpointer_types import KnobOptions, RestoreOptions
 from torchtnt.framework.callbacks.torchsnapshot_saver import (
-    _get_app_state,
     _override_knobs,
     TorchSnapshotSaver,
 )
@@ -368,16 +367,6 @@ class TorchSnapshotSaverTest(unittest.TestCase):
         snapshot_cb._sync_snapshot = MagicMock()
         snapshot_cb.on_train_step_end(state, my_unit)
         snapshot_cb._sync_snapshot.assert_called_once()
-
-    def test_get_app_state(self) -> None:
-        my_unit = DummyTrainUnit(input_dim=2)
-        state = get_dummy_train_state()
-
-        app_state = _get_app_state(state, my_unit, intra_epoch=False)
-        self.assertCountEqual(
-            app_state.keys(),
-            ["module", "optimizer", "loss_fn", "rng_state", "train_progress"],
-        )
 
 
 class DummyStatefulDataLoader:


### PR DESCRIPTION
Summary:
# Context

As part of adding a new checkpointing callback, we want to share few functionalities between multiple checkpointers

# This Diff

The `app_state` preparing utilities in `TorchSnapshotSaver` are moved to a new file `_checkpoint_utils.py`
* `_prepare_app_state` - prepares app state by dealing with potential FSDP case
* `_prepare_app_state_for_checkpoint` - prepares app state for checkpoint by including dataloader if checkpointing during intra epoch
* `_prepare_app_state_for_restore` - prepares app state for restore by parsing through `RestoreOption` and removing unwanted keys accordingly

Differential Revision: D51460613


