### PR TITLE
add DCP checkpointer

### DIFF
--- a/docs/source/utils/utils.rst
+++ b/docs/source/utils/utils.rst
@@ -258,6 +258,7 @@ Stateful
    :nosignatures:
 
    Stateful
+   MultiStateful
 
 
 SWA

--- a/tests/framework/callbacks/test_checkpoint_utils.py
+++ b/tests/framework/callbacks/test_checkpoint_utils.py
@@ -16,9 +16,11 @@ from torch import nn
 from torch.distributed import launcher
 from torchsnapshot import Snapshot
 from torchsnapshot.snapshot import SNAPSHOT_METADATA_FNAME
+from torchtnt.framework._test_utils import DummyTrainUnit, get_dummy_train_state
 
 from torchtnt.framework.callbacks._checkpoint_utils import (
     _delete_checkpoint,
+    _prepare_app_state_for_checkpoint,
     _retrieve_checkpoint_dirpaths,
     get_latest_checkpoint_path,
 )
@@ -172,3 +174,13 @@ class CheckpointUtilsTest(unittest.TestCase):
                 _delete_checkpoint(temp_dir, SNAPSHOT_METADATA_FNAME)
             _delete_checkpoint(dirpath)
             self.assertFalse(os.path.exists(dirpath))
+
+    def test_get_app_state(self) -> None:
+        my_unit = DummyTrainUnit(input_dim=2)
+        state = get_dummy_train_state()
+
+        app_state = _prepare_app_state_for_checkpoint(state, my_unit, intra_epoch=False)
+        self.assertCountEqual(
+            app_state.keys(),
+            ["module", "optimizer", "loss_fn", "train_progress"],
+        )

--- a/tests/framework/callbacks/test_dcp_saver.py
+++ b/tests/framework/callbacks/test_dcp_saver.py
@@ -1,0 +1,354 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+import math
+import os
+import shutil
+import tempfile
+import unittest
+from typing import Any, Dict, Iterator, List
+from unittest import mock
+from unittest.mock import MagicMock, patch
+
+import torch
+from torch import nn
+from torch.utils.data import DataLoader
+from torchsnapshot.test_utils import assert_state_dict_eq, check_state_dict_eq
+
+from torchtnt.framework._test_utils import (
+    DummyAutoUnit,
+    DummyTrainUnit,
+    generate_random_dataloader,
+)
+from torchtnt.framework.callbacks.checkpointer_types import RestoreOptions
+from torchtnt.framework.callbacks.dcp_saver import DistributedCheckpointSaver
+from torchtnt.framework.train import train
+from torchtnt.utils.distributed import get_global_rank
+from torchtnt.utils.env import seed
+from torchtnt.utils.test_utils import spawn_multi_process
+
+
+class DistributedCheckpointSaverTest(unittest.TestCase):
+    cuda_available: bool = torch.cuda.is_available()
+    distributed_available: bool = torch.distributed.is_available()
+
+    def test_save_restore(self) -> None:
+        input_dim = 2
+        dataset_len = 10
+        batch_size = 2
+        max_epochs = 2
+        expected_steps_per_epoch = math.ceil(dataset_len / batch_size)
+        save_every_n_train_steps = 2
+
+        my_unit = DummyTrainUnit(input_dim=input_dim)
+        dataloader = generate_random_dataloader(dataset_len, input_dim, batch_size)
+        expected_paths: List[str] = []
+        with tempfile.TemporaryDirectory() as temp_dir:
+            cumulative_steps = 0
+            for epoch in range(max_epochs):
+                for _ in range(
+                    save_every_n_train_steps,
+                    expected_steps_per_epoch + 1,
+                    save_every_n_train_steps,
+                ):
+                    cumulative_steps += save_every_n_train_steps
+                    expected_paths.append(
+                        os.path.join(temp_dir, f"epoch_{epoch}_step_{cumulative_steps}")
+                    )
+            dcp_cb = DistributedCheckpointSaver(
+                temp_dir,
+                save_every_n_train_steps=save_every_n_train_steps,
+            )
+            train(my_unit, dataloader, max_epochs=max_epochs, callbacks=[dcp_cb])
+
+            end_num_steps_completed = my_unit.train_progress.num_steps_completed
+            self.assertGreater(len(expected_paths), 0)
+            dcp_cb.restore(expected_paths[0], my_unit)
+            restored_num_steps_completed = my_unit.train_progress.num_steps_completed
+            # A snapshot is saved every n steps
+            # so the first snapshot's progress will be equal to save_every_n_train_steps
+            self.assertNotEqual(restored_num_steps_completed, end_num_steps_completed)
+            self.assertEqual(restored_num_steps_completed, save_every_n_train_steps)
+
+    def test_save_restore_dataloader_state(self) -> None:
+        input_dim = 2
+        dataset_len = 10
+        batch_size = 2
+        save_every_n_train_steps = 2
+        max_steps = 3
+
+        my_unit = DummyTrainUnit(input_dim=input_dim)
+        stateful_dataloader = DummyStatefulDataLoader(
+            dataloader=generate_random_dataloader(dataset_len, input_dim, batch_size)
+        )
+        with tempfile.TemporaryDirectory() as temp_dir:
+            dcp_cb = DistributedCheckpointSaver(
+                temp_dir,
+                save_every_n_train_steps=save_every_n_train_steps,
+            )
+            train(
+                my_unit,
+                stateful_dataloader,
+                max_steps=max_steps,
+                callbacks=[dcp_cb],
+            )
+            # state_dict has been called once on dataloader
+            self.assertEqual(stateful_dataloader.state_dict_call_count, 1)
+            self.assertEqual(stateful_dataloader.load_state_dict_call_count, 0)
+
+            # restoring from first checkpoint, has dataloader in manifest
+            dcp_cb.restore(
+                temp_dir + f"/epoch_{0}_step_{save_every_n_train_steps}",
+                my_unit,
+                train_dataloader=stateful_dataloader,
+            )
+            # load_state_dict has been called once on dataloader
+            self.assertEqual(stateful_dataloader.load_state_dict_call_count, 1)
+
+            # restoring from last checkpoint (on train end), does not have dataloader state in manifest
+
+            with self.assertLogs(level="WARNING") as log:
+                dcp_cb.restore(
+                    temp_dir + f"/epoch_{1}_step_{max_steps}",
+                    my_unit,
+                    train_dataloader=stateful_dataloader,
+                )
+                # load_state_dict is not called again on dataloader because there is no dataloader in manifest
+                self.assertEqual(stateful_dataloader.load_state_dict_call_count, 1)
+                self.assertEqual(
+                    log.output,
+                    [
+                        "WARNING:torchtnt.utils.rank_zero_log:train_dataloader was passed to `restore` but no train dataloader exists in the Snapshot"
+                    ],
+                )
+
+    def test_restore_from_latest(self) -> None:
+        input_dim = 2
+        dataset_len = 10
+        batch_size = 2
+        max_epochs = 1
+        save_every_n_train_steps = 2
+        expected_steps_per_epoch = math.ceil(dataset_len / batch_size)
+
+        my_unit = DummyTrainUnit(input_dim=input_dim)
+        dataloader = generate_random_dataloader(dataset_len, input_dim, batch_size)
+        with tempfile.TemporaryDirectory() as temp_dir:
+            dcp_cb = DistributedCheckpointSaver(
+                temp_dir,
+                save_every_n_train_steps=save_every_n_train_steps,
+            )
+            train(my_unit, dataloader, max_epochs=max_epochs, callbacks=[dcp_cb])
+
+            with mock.patch(
+                "torchtnt.framework.callbacks.dcp_saver.DistributedCheckpointSaver.restore"
+            ) as mock_restore:
+                restored = dcp_cb.restore_from_latest(temp_dir, my_unit, no_dist=True)
+                self.assertIn(
+                    temp_dir + f"/epoch_{max_epochs}_step_{expected_steps_per_epoch}",
+                    mock_restore.call_args.args,
+                )
+                self.assertTrue(restored)
+
+    def test_save_restore_no_train_progress(self) -> None:
+        input_dim = 2
+        dataset_len = 10
+        batch_size = 2
+        max_epochs = 2
+        expected_steps_per_epoch = math.ceil(dataset_len / batch_size)
+        save_every_n_train_steps = 2
+
+        my_unit = DummyTrainUnit(input_dim=input_dim)
+        dataloader = generate_random_dataloader(dataset_len, input_dim, batch_size)
+        expected_paths: List[str] = []
+        with tempfile.TemporaryDirectory() as temp_dir:
+            cumulative_steps = 0
+            for epoch in range(max_epochs):
+                for _ in range(
+                    save_every_n_train_steps,
+                    expected_steps_per_epoch + 1,
+                    save_every_n_train_steps,
+                ):
+                    cumulative_steps += save_every_n_train_steps
+                    expected_paths.append(
+                        os.path.join(temp_dir, f"epoch_{epoch}_step_{cumulative_steps}")
+                    )
+            dcp_cb = DistributedCheckpointSaver(
+                temp_dir,
+                save_every_n_train_steps=save_every_n_train_steps,
+            )
+            train(my_unit, dataloader, max_epochs=max_epochs, callbacks=[dcp_cb])
+
+            end_num_steps_completed = my_unit.train_progress.num_steps_completed
+            self.assertGreater(len(expected_paths), 0)
+            dcp_cb.restore(
+                expected_paths[0],
+                my_unit,
+                restore_options=RestoreOptions(restore_train_progress=False),
+            )
+            restored_num_steps_completed = my_unit.train_progress.num_steps_completed
+            # no train progress was restored so the progress after restoration should be the same as the progress before restoration
+            self.assertEqual(restored_num_steps_completed, end_num_steps_completed)
+
+    @patch("torchtnt.framework.callbacks.dcp_saver.dist_cp")
+    def test_save_restore_no_optimizer_restore(self, mock_dist_cp: MagicMock) -> None:
+        my_unit = DummyTrainUnit(input_dim=2)
+        restore_options = RestoreOptions(restore_optimizers=False)
+        DistributedCheckpointSaver.restore(
+            path="path/to/snapshot",
+            unit=my_unit,
+            restore_options=restore_options,
+        )
+        app_state = mock_dist_cp.load_state_dict.call_args.args[0]["app_state"]
+        self.assertNotIn("optimizer", app_state)
+        DistributedCheckpointSaver.restore(path="path/to/snapshot", unit=my_unit)
+        app_state = mock_dist_cp.load_state_dict.call_args.args[0]["app_state"]
+        self.assertIn("optimizer", app_state)
+
+    @patch("torchtnt.framework.callbacks.dcp_saver.dist_cp")
+    def test_save_restore_no_lr_scheduler_restore(
+        self, mock_dist_cp: MagicMock
+    ) -> None:
+        my_unit = DummyAutoUnit(module=nn.Linear(2, 3))
+        restore_options = RestoreOptions(restore_lr_schedulers=False)
+        DistributedCheckpointSaver.restore(
+            path="path/to/snapshot", unit=my_unit, restore_options=restore_options
+        )
+        app_state = mock_dist_cp.load_state_dict.call_args.args[0]["app_state"]
+        self.assertNotIn("lr_scheduler", app_state)
+        DistributedCheckpointSaver.restore(path="path/to/snapshot", unit=my_unit)
+        app_state = mock_dist_cp.load_state_dict.call_args.args[0]["app_state"]
+        self.assertIn("lr_scheduler", app_state)
+
+    @unittest.skipUnless(
+        condition=distributed_available, reason="Torch distributed is needed to run"
+    )
+    @unittest.skipUnless(
+        condition=cuda_available, reason="This test needs a GPU host to run."
+    )
+    def test_save_restore_fsdp(self) -> None:
+        spawn_multi_process(
+            2,
+            "nccl",
+            self._save_restore_fsdp,
+        )
+
+    @staticmethod
+    def _save_restore_fsdp() -> None:
+        input_dim = 2
+        dataset_len = 10
+        batch_size = 2
+        max_epochs = 2
+        save_every_n_epochs = 1
+
+        my_unit = DummyAutoUnit(module=torch.nn.Linear(input_dim, 2), strategy="fsdp")
+        dataloader = generate_random_dataloader(dataset_len, input_dim, batch_size)
+        if get_global_rank() == 0:
+            temp_dir = tempfile.mkdtemp()
+        else:
+            temp_dir = ""
+
+        dcp_cb = DistributedCheckpointSaver(
+            temp_dir,
+            save_every_n_epochs=save_every_n_epochs,
+        )
+        temp_dir = dcp_cb.dirpath
+        train(my_unit, dataloader, max_epochs=max_epochs, callbacks=[dcp_cb])
+
+        tc = unittest.TestCase()
+        try:
+            my_new_unit = DummyAutoUnit(
+                module=torch.nn.Linear(input_dim, 2), strategy="fsdp"
+            )
+            tc.assertNotEqual(
+                my_new_unit.optimizer.state_dict(), my_unit.optimizer.state_dict()
+            )
+            # get latest checkpoint
+            ckpt_path = os.path.join(temp_dir, f"epoch_{max_epochs}_step_10")
+            dcp_cb.restore(ckpt_path, my_new_unit)
+            tc.assertEqual(
+                my_new_unit.optimizer.state_dict(), my_unit.optimizer.state_dict()
+            )
+        finally:
+            if get_global_rank() == 0:
+                shutil.rmtree(temp_dir)  # delete temp directory
+
+    @unittest.skipUnless(
+        condition=distributed_available, reason="Torch distributed is needed to run"
+    )
+    def test_save_restore_ddp(self) -> None:
+        spawn_multi_process(
+            2,
+            "gloo",
+            self._save_restore_ddp,
+        )
+
+    @staticmethod
+    def _save_restore_ddp() -> None:
+        input_dim = 2
+        dataset_len = 10
+        batch_size = 2
+        max_epochs = 2
+        save_every_n_epochs = 1
+        seed(0)
+
+        my_unit = DummyAutoUnit(module=torch.nn.Linear(input_dim, 2), strategy="ddp")
+        dataloader = generate_random_dataloader(dataset_len, input_dim, batch_size)
+        if get_global_rank() == 0:
+            temp_dir = tempfile.mkdtemp()
+        else:
+            temp_dir = ""
+
+        dcp_cb = DistributedCheckpointSaver(
+            temp_dir,
+            save_every_n_epochs=save_every_n_epochs,
+        )
+        temp_dir = dcp_cb.dirpath
+        train(my_unit, dataloader, max_epochs=max_epochs, callbacks=[dcp_cb])
+        tc = unittest.TestCase()
+        try:
+            my_new_unit = DummyAutoUnit(
+                module=torch.nn.Linear(input_dim, 2), strategy="ddp"
+            )
+            optim_equal = check_state_dict_eq(
+                my_new_unit.optimizer.state_dict(), my_unit.optimizer.state_dict()
+            )
+            tc.assertFalse(optim_equal)
+            module_equal = check_state_dict_eq(
+                my_new_unit.module.state_dict(), my_unit.module.state_dict()
+            )
+            tc.assertFalse(module_equal)
+            # get latest checkpoint
+            ckpt_path = os.path.join(temp_dir, f"epoch_{max_epochs}_step_10")
+            dcp_cb.restore(ckpt_path, my_new_unit)
+
+            assert_state_dict_eq(
+                tc, my_new_unit.optimizer.state_dict(), my_unit.optimizer.state_dict()
+            )
+            assert_state_dict_eq(
+                tc, my_new_unit.module.state_dict(), my_unit.module.state_dict()
+            )
+        finally:
+            if get_global_rank() == 0:
+                shutil.rmtree(temp_dir)  # delete temp directory
+
+
+class DummyStatefulDataLoader:
+    def __init__(self, dataloader: DataLoader) -> None:
+        self.dataloader = dataloader
+        self.state_dict_call_count = 0
+        self.load_state_dict_call_count = 0
+
+    def state_dict(self) -> Dict[str, Any]:
+        self.state_dict_call_count += 1
+        return {}
+
+    def load_state_dict(self, state_dict: Dict[str, Any]) -> None:
+        self.load_state_dict_call_count += 1
+        return None
+
+    def __iter__(self) -> Iterator[object]:
+        return iter(self.dataloader)

--- a/tests/framework/callbacks/test_torchsnapshot_saver.py
+++ b/tests/framework/callbacks/test_torchsnapshot_saver.py
@@ -27,7 +27,6 @@ from torchtnt.framework._test_utils import (
 )
 from torchtnt.framework.callbacks.checkpointer_types import KnobOptions, RestoreOptions
 from torchtnt.framework.callbacks.torchsnapshot_saver import (
-    _get_app_state,
     _override_knobs,
     TorchSnapshotSaver,
 )
@@ -368,16 +367,6 @@ class TorchSnapshotSaverTest(unittest.TestCase):
         snapshot_cb._sync_snapshot = MagicMock()
         snapshot_cb.on_train_step_end(state, my_unit)
         snapshot_cb._sync_snapshot.assert_called_once()
-
-    def test_get_app_state(self) -> None:
-        my_unit = DummyTrainUnit(input_dim=2)
-        state = get_dummy_train_state()
-
-        app_state = _get_app_state(state, my_unit, intra_epoch=False)
-        self.assertCountEqual(
-            app_state.keys(),
-            ["module", "optimizer", "loss_fn", "rng_state", "train_progress"],
-        )
 
 
 class DummyStatefulDataLoader:

--- a/torchtnt/framework/callbacks/dcp_saver.py
+++ b/torchtnt/framework/callbacks/dcp_saver.py
@@ -1,0 +1,158 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+import logging
+from typing import Iterable, Optional
+
+import torch.distributed as dist
+
+from torch.distributed import checkpoint as dist_cp
+from torch.distributed.checkpoint._fsspec_filesystem import FsspecReader, FsspecWriter
+
+from torchtnt.framework.callbacks._checkpoint_utils import (
+    _prepare_app_state_for_checkpoint,
+    _prepare_app_state_for_restore,
+    _TRAIN_DL_STATE_KEY,
+)
+
+from torchtnt.framework.callbacks.base_checkpointer import BaseCheckpointer
+from torchtnt.framework.callbacks.checkpointer_types import RestoreOptions
+from torchtnt.framework.state import State
+from torchtnt.framework.unit import AppStateMixin, TTrainData
+from torchtnt.framework.utils import get_timing_context
+from torchtnt.utils.rank_zero_log import rank_zero_info, rank_zero_warn
+from torchtnt.utils.stateful import MultiStateful, Stateful
+
+
+logger: logging.Logger = logging.getLogger(__name__)
+
+
+class DistributedCheckpointSaver(BaseCheckpointer):
+    """
+    A callback which periodically saves the application state during training using `Distributed Checkpoint <https://pytorch.org/docs/stable/distributed.checkpoint.html/>`_.
+
+    This callback supplements the application state provided by :class:`torchtnt.unit.AppStateMixin`
+    with the train progress, and train dataloader (if applicable).
+
+    If used with :func:`torchtnt.framework.fit`, this class will also save the evaluation progress state.
+
+    Checkpoints will be saved under ``dirpath/epoch_{epoch}_step_{step}`` where step is the *total* number of training steps completed across all epochs.
+
+    Args:
+        dirpath: Parent directory to save snapshots to.
+        save_every_n_train_steps: Frequency of steps with which to save snapshots during the train epoch. If None, no intra-epoch snapshots are generated.
+        save_every_n_epochs: Frequency of epochs with which to save snapshots during training. If None, no end-of-epoch snapshots are generated.
+        keep_last_n_checkpoints: Number of most recent checkpoints to keep. If None, all checkpoints are kept. If an excess of existing checkpoints are present, the oldest ones will be deleted to clean the difference.
+        process_group: The process group on which the ranks will communicate on. default: ``None`` (the entire world)
+
+    Note:
+        If torch.distributed is available and default process group is initialized, dcp's `no_dist <https://pytorch.org/docs/stable/distributed.checkpoint.html#torch.distributed.checkpoint.load_state_dict/>_`
+        argument is automatically set to False. Otherwise it's set to True.
+
+    Note:
+        If checkpointing FSDP model, you can set state_dict type calling `set_state_dict_type <https://pytorch.org/docs/stable/fsdp.html#torch.distributed.fsdp.FullyShardedDataParallel.set_state_dict_type>`_ prior to starting training.
+    """
+
+    def __init__(
+        self,
+        dirpath: str,
+        *,
+        save_every_n_train_steps: Optional[int] = None,
+        save_every_n_epochs: Optional[int] = None,
+        keep_last_n_checkpoints: Optional[int] = None,
+        process_group: Optional[dist.ProcessGroup] = None,
+    ) -> None:
+        super().__init__(
+            dirpath=dirpath,
+            save_every_n_train_steps=save_every_n_train_steps,
+            save_every_n_epochs=save_every_n_epochs,
+            keep_last_n_checkpoints=keep_last_n_checkpoints,
+            process_group=process_group,
+        )
+
+    def _checkpoint_impl(
+        self,
+        state: State,
+        unit: AppStateMixin,
+        *,
+        checkpoint_path: str,
+        hook: str,
+    ) -> bool:
+        intra_epoch = False
+        if hook == "on_train_step_end":
+            intra_epoch = True
+
+        storage_writer = FsspecWriter(checkpoint_path)
+
+        app_state = _prepare_app_state_for_checkpoint(state, unit, intra_epoch)
+        # flag to indicate whether distributed is available
+        # determines what to set ``no_dist`` arg in DCP apis
+        pg_available: bool = dist.is_initialized()
+        with get_timing_context(state, f"{self.__class__.__name__}.save_state_dict"):
+            dist_cp.save_state_dict(
+                {"app_state": MultiStateful(app_state).state_dict()},
+                storage_writer=storage_writer,
+                process_group=self._process_group,
+                no_dist=not pg_available,
+            )
+        return True
+
+    @staticmethod
+    def restore(
+        path: str,
+        unit: AppStateMixin,
+        *,
+        train_dataloader: Optional[Iterable[TTrainData]] = None,
+        process_group: Optional[dist.ProcessGroup] = None,
+        restore_options: Optional[RestoreOptions] = None,
+    ) -> None:
+        """Utility method to restore dcp checkpoint from a path.
+
+        There are additional flags offered should the user want to skip loading the train and eval progress.
+        By default, the train and eval progress are restored, if applicable.
+
+        Args:
+            path: Path of the snapshot to restore.
+            unit: An instance of :class:`~torchtnt.framework.unit.TrainUnit`, :class:`~torchtnt.framework.unit.EvalUnit`, or :class:`~torchtnt.framework.unit.PredictUnit` containing states to restore.
+            train_dataloader: An optional train dataloader to restore.
+            process_group: The process group on which the ranks will communicate on. default: ``None`` (the entire world)
+            restore_options: Controls what to  filter when restoring the state.
+            no_dist: Set to true if loading in non-distributed setting
+        """
+        storage_reader = FsspecReader(path)
+
+        restore_options = restore_options or RestoreOptions()
+        app_state = _prepare_app_state_for_restore(unit, restore_options)
+
+        if train_dataloader is not None:
+            if not isinstance(train_dataloader, Stateful):
+                rank_zero_warn(
+                    "train_dataloader was passed to `restore` but the dataloader does not implement the Stateful protocol to load states"
+                )
+            else:
+                # request to restore the dataloader state only if
+                # the persisted snapshot state includes the dataloader entry
+                metadata = storage_reader.read_metadata()
+                for key in metadata.state_dict_metadata.keys():
+                    if _TRAIN_DL_STATE_KEY in key:
+                        app_state[_TRAIN_DL_STATE_KEY] = train_dataloader
+                        break
+
+                if _TRAIN_DL_STATE_KEY not in app_state:
+                    rank_zero_warn(
+                        "train_dataloader was passed to `restore` but no train dataloader exists in the Snapshot"
+                    )
+
+        state_dict = {"app_state": MultiStateful(app_state).state_dict()}
+        no_dist = not dist.is_initialized()
+        dist_cp.load_state_dict(
+            state_dict,
+            storage_reader=storage_reader,
+            process_group=process_group,
+            no_dist=no_dist,
+        )
+        MultiStateful(app_state).load_state_dict(state_dict["app_state"])
+        rank_zero_info(f"Restored snapshot from path: {path}", logger=logger)

--- a/torchtnt/utils/stateful.py
+++ b/torchtnt/utils/stateful.py
@@ -4,7 +4,12 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
-from typing import Any, Dict
+from typing import Any, Dict, Union
+
+import torch
+from torchtnt.utils.lr_scheduler import TLRScheduler
+from torchtnt.utils.prepare_module import FSDPOptimizerWrapper
+from torchtnt.utils.progress import Progress
 
 from typing_extensions import Protocol, runtime_checkable
 
@@ -18,3 +23,35 @@ class Stateful(Protocol):
 
     def load_state_dict(self, state_dict: Dict[str, Any]) -> None:
         ...
+
+
+StatefulDict = Dict[str, Stateful]
+ModuleDict = Dict[str, torch.nn.Module]
+OptimizerAndLRSchedulerDict = Dict[
+    str, Union[TLRScheduler, torch.optim.Optimizer, FSDPOptimizerWrapper]
+]
+ProgressDict = Dict[str, Progress]
+
+
+class MultiStateful:
+    """
+    Wrapper for multiple stateful objects. Necessary because we might have multiple nn.Modules or multiple optimizers,
+    but save/load_checkpoint APIs may only accepts one stateful object.
+
+    Stores state_dict as a dict of state_dicts.
+    """
+
+    def __init__(
+        self,
+        stateful_objs: Union[
+            StatefulDict, ModuleDict, OptimizerAndLRSchedulerDict, ProgressDict
+        ],
+    ) -> None:
+        self.stateful_objs = stateful_objs
+
+    def state_dict(self) -> Dict[str, Any]:
+        return {k: v.state_dict() for k, v in self.stateful_objs.items()}
+
+    def load_state_dict(self, state_dict: Dict[str, Any]) -> None:
+        for k in state_dict:
+            self.stateful_objs[k].load_state_dict(state_dict[k])


### PR DESCRIPTION
Summary:
Adds checkpointer callback which uses pytorch's [Distributed Checkpoint](https://pytorch.org/docs/stable/distributed.checkpoint.html).

Subclasses `BaseCheckpointer` and implements `_checkpoint_impl()` and `restore()`. `no_dist` arg when saving checkpoint is handled automatically

Differential Revision: D51460620


