### PR TITLE
tss saver - add constructor param to control adding progress to replicated by default

### DIFF
--- a/tests/framework/callbacks/test_torchsnapshot_saver.py
+++ b/tests/framework/callbacks/test_torchsnapshot_saver.py
@@ -35,6 +35,7 @@ from torchtnt.framework._test_utils import (
 from torchtnt.framework.callbacks.lambda_callback import Lambda
 from torchtnt.framework.callbacks.torchsnapshot_saver import (
     _delete_snapshot,
+    _get_app_state,
     _override_knobs,
     _retrieve_checkpoint_dirpaths,
     get_latest_checkpoint_path,
@@ -839,6 +840,16 @@ class TorchSnapshotSaverTest(unittest.TestCase):
                 f"epoch_{max_epochs}_step_{dataset_len // batch_size * max_epochs}",
                 os.listdir(temp_dir),
             )
+
+    def test_get_app_state(self) -> None:
+        my_unit = DummyTrainUnit(input_dim=2)
+        state = get_dummy_train_state()
+
+        app_state = _get_app_state(state, my_unit, intra_epoch=False)
+        self.assertCountEqual(
+            app_state.keys(),
+            ["module", "optimizer", "loss_fn", "rng_state", "train_progress"],
+        )
 
 
 class DummyStatefulDataLoader:

--- a/torchtnt/framework/callbacks/torchsnapshot_saver.py
+++ b/torchtnt/framework/callbacks/torchsnapshot_saver.py
@@ -282,7 +282,9 @@ class TorchSnapshotSaver(Callback):
             curr_snapshot_wait: Whether to wait for current snapshot to finish writing
         """
         app_state = _get_app_state(
-            state, unit, self._replicated, intra_epoch=intra_epoch
+            state,
+            unit,
+            intra_epoch=intra_epoch,
         )
         with get_timing_context(
             state, f"{self.__class__.__name__}.take_async_snapshot"
@@ -606,7 +608,10 @@ def _app_state(unit: AppStateMixin) -> Dict[str, Any]:
 
 
 def _get_app_state(
-    state: State, unit: AppStateMixin, replicated: Set[str], *, intra_epoch: bool
+    state: State,
+    unit: AppStateMixin,
+    *,
+    intra_epoch: bool,
 ) -> Dict[str, _TStateful]:
     train_state = none_throws(state.train_state)
     app_state = _app_state(unit)
@@ -618,14 +623,6 @@ def _get_app_state(
     train_dl = train_state.dataloader
     if intra_epoch and isinstance(train_dl, _TStateful):
         app_state[_TRAIN_DL_STATE_KEY] = train_dl
-
-    # add progress to replicated
-    train_prog_glob = f"{_TRAIN_PROGRESS_STATE_KEY}/*"
-    replicated.add(train_prog_glob)
-
-    if state.entry_point == EntryPoint.FIT:
-        eval_prog_glob = f"{_EVAL_PROGRESS_STATE_KEY}/*"
-        replicated.add(eval_prog_glob)
 
     return app_state
 


### PR DESCRIPTION
Summary: Control whether TSS saver assumes that train/eval progress is replicated by introducing a constructor param (defaults to True)

Differential Revision: D51488554


