### PR TITLE
remove duplicate final snapshot path check

### DIFF
--- a/torchtnt/framework/callbacks/torchsnapshot_saver.py
+++ b/torchtnt/framework/callbacks/torchsnapshot_saver.py
@@ -245,12 +245,9 @@ class TorchSnapshotSaver(Callback):
         )
 
         fs = get_filesystem(snapshot_path)
-        if fs.exists(snapshot_path):
-            if fs.exists(os.path.join(snapshot_path, SNAPSHOT_METADATA_FNAME)):
-                rank_zero_warn(
-                    "Final checkpoint already exists, skipping.", logger=logger
-                )
-                return
+        if fs.exists(os.path.join(snapshot_path, SNAPSHOT_METADATA_FNAME)):
+            rank_zero_warn("Final checkpoint already exists, skipping.", logger=logger)
+            return
 
         self._checkpoint_impl(
             state,


### PR DESCRIPTION
Summary: Currently we check if two paths exist (one for snapshot path, and one for snapshot path/.snapshot_metadata) to determine whether to save final checkpoint or not. The first path is not necessary to check, so removing

Differential Revision: D51605223


