### PR TITLE
add unit_utils

### DIFF
--- a/tests/framework/test_loop_utils.py
+++ b/tests/framework/test_loop_utils.py
@@ -1,0 +1,163 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+import unittest
+from typing import cast, Dict, Iterator
+
+import torch
+from torch import distributed as dist, nn
+from torch.distributed import launcher
+
+from torch.utils.data import DataLoader
+from torch.utils.data.distributed import DistributedSampler
+from torchtnt.framework._loop_utils import (
+    _is_done,
+    _is_epoch_done,
+    _maybe_set_distributed_sampler_epoch,
+    _reset_module_training_mode,
+    _set_module_training_mode,
+    _step_requires_iterator,
+)
+from torchtnt.framework._test_utils import generate_random_dataset
+from torchtnt.framework.state import State
+from torchtnt.utils.progress import Progress
+from torchtnt.utils.test_utils import get_pet_launch_config
+
+
+class LoopUtilsTest(unittest.TestCase):
+    def test_maybe_set_distributed_sampler_epoch(self) -> None:
+        config = get_pet_launch_config(2)
+        launcher.elastic_launch(
+            config, entrypoint=self._test_maybe_set_distributed_sampler_epoch
+        )()
+
+    @staticmethod
+    def _test_maybe_set_distributed_sampler_epoch() -> None:
+        """
+        Test _maybe_set_distributed_sampler_epoch util function
+        """
+        dist.init_process_group("gloo")
+
+        random_dataset = generate_random_dataset(10, 3)
+        dummy_dataloader_with_distributed_sampler = DataLoader(
+            random_dataset, sampler=DistributedSampler(random_dataset)
+        )
+
+        _maybe_set_distributed_sampler_epoch(
+            dummy_dataloader_with_distributed_sampler, 20
+        )
+
+        sampler = cast(
+            DistributedSampler[object],
+            dummy_dataloader_with_distributed_sampler.sampler,
+        )
+        assert sampler.epoch == 20
+
+    def test_set_module_training_mode(self) -> None:
+        """
+        Test _set_module_training_mode
+        """
+        module = nn.Linear(1, 1)
+        loss_fn = nn.CrossEntropyLoss()
+
+        tracked_modules: Dict[str, torch.nn.Module] = {
+            "module": module,
+            "loss_fn": loss_fn,
+        }
+
+        # set module training mode to False
+        prior_module_train_states = _set_module_training_mode(tracked_modules, False)
+
+        self.assertFalse(module.training)
+        self.assertFalse(loss_fn.training)
+
+        self.assertTrue(prior_module_train_states["module"])
+        self.assertTrue(prior_module_train_states["loss_fn"])
+
+        # set back to True
+        prior_module_train_states = _set_module_training_mode(tracked_modules, True)
+
+        self.assertTrue(module.training)
+        self.assertTrue(loss_fn.training)
+
+        self.assertFalse(prior_module_train_states["module"])
+        self.assertFalse(prior_module_train_states["loss_fn"])
+
+    def test_reset_module_training_mode(self) -> None:
+        """
+        Test _reset_module_training_mode
+        """
+        module = nn.Linear(1, 1)
+        loss_fn = nn.CrossEntropyLoss()
+
+        tracked_modules: Dict[str, torch.nn.Module] = {
+            "module": module,
+            "loss_fn": loss_fn,
+        }
+
+        # set module training mode to False
+        prior_module_train_states = _set_module_training_mode(tracked_modules, False)
+
+        self.assertFalse(module.training)
+        self.assertFalse(loss_fn.training)
+
+        # set back to True using reset
+        _reset_module_training_mode(tracked_modules, prior_module_train_states)
+
+        self.assertTrue(module.training)
+        self.assertTrue(loss_fn.training)
+
+    def test_step_func_requires_iterator(self) -> None:
+        class Foo:
+            def bar(self, state: State, data: object) -> object:
+                return data
+
+            def baz(self, state: State, data: Iterator[torch.Tensor]) -> object:
+                pass
+
+        def dummy(a: int, b: str, data: Iterator[str]) -> None:
+            pass
+
+        foo = Foo()
+
+        self.assertFalse(_step_requires_iterator(foo.bar))
+        self.assertTrue(_step_requires_iterator(foo.baz))
+        self.assertTrue(_step_requires_iterator(dummy))
+
+    def test_is_done(self) -> None:
+        p = Progress(
+            num_epochs_completed=2,
+            num_steps_completed=100,
+            num_steps_completed_in_epoch=5,
+        )
+
+        self.assertTrue(_is_done(p, max_epochs=2, max_steps=200))
+        self.assertTrue(_is_done(p, max_epochs=2, max_steps=None))
+        self.assertTrue(_is_done(p, max_epochs=3, max_steps=100))
+        self.assertTrue(_is_done(p, max_epochs=None, max_steps=100))
+
+        self.assertFalse(_is_done(p, max_epochs=3, max_steps=200))
+        self.assertFalse(_is_done(p, max_epochs=None, max_steps=200))
+        self.assertFalse(_is_done(p, max_epochs=3, max_steps=None))
+        self.assertFalse(_is_done(p, max_epochs=None, max_steps=None))
+
+    def test_is_epoch_done(self) -> None:
+        p = Progress(
+            num_epochs_completed=2,
+            num_steps_completed=100,
+            num_steps_completed_in_epoch=5,
+        )
+
+        self.assertTrue(_is_epoch_done(p, max_steps_per_epoch=5, max_steps=200))
+        self.assertTrue(_is_epoch_done(p, max_steps_per_epoch=5, max_steps=None))
+        self.assertTrue(_is_epoch_done(p, max_steps_per_epoch=100, max_steps=100))
+        self.assertTrue(_is_epoch_done(p, max_steps_per_epoch=None, max_steps=100))
+
+        self.assertFalse(_is_epoch_done(p, max_steps_per_epoch=6, max_steps=200))
+        self.assertFalse(_is_epoch_done(p, max_steps_per_epoch=None, max_steps=200))
+        self.assertFalse(_is_epoch_done(p, max_steps_per_epoch=6, max_steps=None))
+        self.assertFalse(_is_epoch_done(p, max_steps_per_epoch=None, max_steps=None))

--- a/tests/framework/test_unit_utils.py
+++ b/tests/framework/test_unit_utils.py
@@ -1,0 +1,84 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+import unittest
+from typing import Dict, Iterator
+
+import torch
+
+from torch.distributed.fsdp import FullyShardedDataParallel as FSDP
+from torch.optim import Optimizer
+from torchtnt.framework._unit_utils import (
+    _find_optimizers_for_module,
+    _step_requires_iterator,
+)
+from torchtnt.framework.state import State
+from torchtnt.utils.env import init_from_env
+from torchtnt.utils.test_utils import spawn_multi_process
+
+
+class UnitUtilsTest(unittest.TestCase):
+    cuda_available: bool = torch.cuda.is_available()
+    distributed_available: bool = torch.distributed.is_available()
+
+    def test_step_func_requires_iterator(self) -> None:
+        class Foo:
+            def bar(self, state: State, data: object) -> object:
+                return data
+
+            def baz(self, state: State, data: Iterator[torch.Tensor]) -> object:
+                pass
+
+        def dummy(a: int, b: str, data: Iterator[str]) -> None:
+            pass
+
+        foo = Foo()
+
+        self.assertFalse(_step_requires_iterator(foo.bar))
+        self.assertTrue(_step_requires_iterator(foo.baz))
+        self.assertTrue(_step_requires_iterator(dummy))
+
+    def test_find_optimizers_for_module(self) -> None:
+        module1 = torch.nn.Linear(10, 10)
+        module2 = torch.nn.Linear(10, 10)
+        optim1 = torch.optim.Adam(module1.parameters())
+        optim2 = torch.optim.Adagrad(module2.parameters())
+
+        opts: Dict[str, Optimizer] = {"optim1": optim1, "optim2": optim2}
+        optimizers = _find_optimizers_for_module(module1, opts)
+        optim_name, _ = optimizers[0]
+        self.assertEqual(optim_name, "optim1")
+        optimizers = _find_optimizers_for_module(module2, opts)
+        optim_name, _ = optimizers[0]
+        self.assertEqual(optim_name, "optim2")
+
+    @unittest.skipUnless(
+        condition=distributed_available, reason="Torch distributed is needed to run"
+    )
+    @unittest.skipUnless(
+        condition=cuda_available, reason="This test needs a GPU host to run."
+    )
+    def test_find_optimizers_for_FSDP_module(self) -> None:
+        spawn_multi_process(2, "nccl", self._find_optimizers_for_FSDP_module)
+
+    @staticmethod
+    def _find_optimizers_for_FSDP_module() -> None:
+        device = init_from_env()
+        module1 = FSDP(torch.nn.Linear(10, 10).to(device))
+        module2 = torch.nn.Linear(10, 10)
+        optim1 = torch.optim.Adam(module1.parameters())
+        optim2 = torch.optim.Adagrad(module2.parameters())
+
+        opts: Dict[str, Optimizer] = {"optim1": optim1, "optim2": optim2}
+        optim_list = _find_optimizers_for_module(module1, opts)
+        optim_name, _ = optim_list[0]
+
+        tc = unittest.TestCase()
+        tc.assertEqual(optim_name, "optim1")
+        optim_list = _find_optimizers_for_module(module2, opts)
+        optim_name, _ = optim_list[0]
+        tc.assertEqual(optim_name, "optim2")

--- a/tests/framework/test_utils.py
+++ b/tests/framework/test_utils.py
@@ -7,45 +7,14 @@
 
 import time
 import unittest
-from typing import Dict, Iterator
 from unittest.mock import MagicMock, patch
 
-import torch
+from torchtnt.framework.utils import get_timing_context
 
-from torch.distributed.fsdp import FullyShardedDataParallel as FSDP
-from torch.optim import Optimizer
-from torchtnt.framework.state import State
-from torchtnt.framework.utils import (
-    _find_optimizers_for_module,
-    _step_requires_iterator,
-    get_timing_context,
-)
-from torchtnt.utils.env import init_from_env
-from torchtnt.utils.test_utils import spawn_multi_process
 from torchtnt.utils.timer import Timer
 
 
 class UtilsTest(unittest.TestCase):
-    cuda_available: bool = torch.cuda.is_available()
-    distributed_available: bool = torch.distributed.is_available()
-
-    def test_step_func_requires_iterator(self) -> None:
-        class Foo:
-            def bar(self, state: State, data: object) -> object:
-                return data
-
-            def baz(self, state: State, data: Iterator[torch.Tensor]) -> object:
-                pass
-
-        def dummy(a: int, b: str, data: Iterator[str]) -> None:
-            pass
-
-        foo = Foo()
-
-        self.assertFalse(_step_requires_iterator(foo.bar))
-        self.assertTrue(_step_requires_iterator(foo.baz))
-        self.assertTrue(_step_requires_iterator(dummy))
-
     @patch("torchtnt.framework.utils.record_function")
     def test_get_timing_context(self, mock_record_function: MagicMock) -> None:
         state = MagicMock()
@@ -62,44 +31,3 @@ class UtilsTest(unittest.TestCase):
             time.sleep(1)
         self.assertTrue("b" in state.timer.recorded_durations.keys())
         mock_record_function.assert_called_with("b")
-
-    def test_find_optimizers_for_module(self) -> None:
-        module1 = torch.nn.Linear(10, 10)
-        module2 = torch.nn.Linear(10, 10)
-        optim1 = torch.optim.Adam(module1.parameters())
-        optim2 = torch.optim.Adagrad(module2.parameters())
-
-        opts: Dict[str, Optimizer] = {"optim1": optim1, "optim2": optim2}
-        optimizers = _find_optimizers_for_module(module1, opts)
-        optim_name, _ = optimizers[0]
-        self.assertEqual(optim_name, "optim1")
-        optimizers = _find_optimizers_for_module(module2, opts)
-        optim_name, _ = optimizers[0]
-        self.assertEqual(optim_name, "optim2")
-
-    @unittest.skipUnless(
-        condition=distributed_available, reason="Torch distributed is needed to run"
-    )
-    @unittest.skipUnless(
-        condition=cuda_available, reason="This test needs a GPU host to run."
-    )
-    def test_find_optimizers_for_FSDP_module(self) -> None:
-        spawn_multi_process(2, "nccl", self._find_optimizers_for_FSDP_module)
-
-    @staticmethod
-    def _find_optimizers_for_FSDP_module() -> None:
-        device = init_from_env()
-        module1 = FSDP(torch.nn.Linear(10, 10).to(device))
-        module2 = torch.nn.Linear(10, 10)
-        optim1 = torch.optim.Adam(module1.parameters())
-        optim2 = torch.optim.Adagrad(module2.parameters())
-
-        opts: Dict[str, Optimizer] = {"optim1": optim1, "optim2": optim2}
-        optim_list = _find_optimizers_for_module(module1, opts)
-        optim_name, _ = optim_list[0]
-
-        tc = unittest.TestCase()
-        tc.assertEqual(optim_name, "optim1")
-        optim_list = _find_optimizers_for_module(module2, opts)
-        optim_name, _ = optim_list[0]
-        tc.assertEqual(optim_name, "optim2")

--- a/torchtnt/framework/_loop_utils.py
+++ b/torchtnt/framework/_loop_utils.py
@@ -1,0 +1,96 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+import collections
+import inspect
+import logging
+from typing import Callable, Dict, Iterable, Optional, TypeVar
+
+import torch
+import torch.nn as nn
+import typing_extensions
+from torchtnt.framework.state import State
+from torchtnt.utils.progress import Progress
+
+_logger: logging.Logger = logging.getLogger(__name__)
+T = TypeVar("T")
+
+
+# Helper functions common across the loops
+def _is_done(
+    progress: Progress, max_epochs: Optional[int], max_steps: Optional[int]
+) -> bool:
+    return (max_steps is not None and progress.num_steps_completed >= max_steps) or (
+        max_epochs is not None and progress.num_epochs_completed >= max_epochs
+    )
+
+
+def _is_epoch_done(
+    progress: Progress, max_steps_per_epoch: Optional[int], max_steps: Optional[int]
+) -> bool:
+    return (max_steps is not None and progress.num_steps_completed >= max_steps) or (
+        max_steps_per_epoch is not None
+        and progress.num_steps_completed_in_epoch >= max_steps_per_epoch
+    )
+
+
+def _maybe_set_distributed_sampler_epoch(
+    dataloader: Iterable[object],
+    current_epoch: int,
+) -> None:
+    """Set epoch of distributed sampler in dataloader, if applicable.
+    See: https://pytorch.org/docs/stable/data.html#torch.utils.data.distributed.DistributedSampler
+    """
+    # Set current training epoch for any DistributedSampler in dataloader
+    if isinstance(dataloader, torch.utils.data.DataLoader) and isinstance(
+        dataloader.sampler,
+        torch.utils.data.distributed.DistributedSampler,
+    ):
+        dataloader.sampler.set_epoch(current_epoch)
+
+
+def _set_module_training_mode(
+    modules: Dict[str, nn.Module], mode: bool
+) -> Dict[str, bool]:
+    """Returns states to allow for a reset at the end of the loop."""
+    prior_module_train_states = {}
+    for name, module in modules.items():
+        prior_module_train_states[name] = module.training
+        module.train(mode)
+    return prior_module_train_states
+
+
+def _reset_module_training_mode(
+    modules: Dict[str, nn.Module], prior_modes: Dict[str, bool]
+) -> None:
+    # Reset training mode for modules at the end of the epoch
+    # This ensures that side-effects made by the loop are reset before
+    # returning back to the user
+    for name, module in modules.items():
+        if name in prior_modes:
+            module.train(prior_modes[name])
+
+
+def _log_api_usage(entry_point: str) -> None:
+    torch._C._log_api_usage_once(f"torchtnt.framework.{entry_point}")
+
+
+def _step_requires_iterator(step_func: Callable[[State, T], object]) -> bool:
+    """
+    Helper function to evaluate whether the loops should pass the data iterator to the `_step`
+    functions, or whether the loop should call `next(data_iter)` and pass a single batch to process.
+
+    This is closely tied to the Unit's corresponding step function signature.
+    """
+    argspec = inspect.getfullargspec(step_func)
+    annotations = argspec.annotations
+    if "data" not in annotations:
+        _logger.warning(
+            f"Expected step function to have an annotated argument named ``data``. Found {annotations}."
+        )
+        return False
+    annotated_type = annotations["data"]
+    return typing_extensions.get_origin(annotated_type) is collections.abc.Iterator

--- a/torchtnt/framework/_unit_utils.py
+++ b/torchtnt/framework/_unit_utils.py
@@ -1,0 +1,52 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+import collections
+import inspect
+import logging
+from typing import Callable, Dict, List, Tuple, TypeVar
+
+import torch
+import typing_extensions
+from torchtnt.framework.state import State
+
+_logger: logging.Logger = logging.getLogger(__name__)
+T = TypeVar("T")
+
+
+def _step_requires_iterator(step_func: Callable[[State, T], object]) -> bool:
+    """
+    Helper function to evaluate whether the get_next_X_batch method should pass the data iterator to the `X_step`
+    functions, or whether get_next_X_batch should call `next(data_iter)` and pass a single batch to the step method.
+
+    This is closely tied to the Unit's corresponding step function signature.
+    """
+    argspec = inspect.getfullargspec(step_func)
+    annotations = argspec.annotations
+    if "data" not in annotations:
+        _logger.warning(
+            f"Expected step function to have an annotated argument named ``data``. Found {annotations}."
+        )
+        return False
+    annotated_type = annotations["data"]
+    return typing_extensions.get_origin(annotated_type) is collections.abc.Iterator
+
+
+def _find_optimizers_for_module(
+    module: torch.nn.Module, optimizers: Dict[str, torch.optim.Optimizer]
+) -> List[Tuple[str, torch.optim.Optimizer]]:
+    """
+    Given a module, returns a list of optimizers that are associated with it.
+    """
+    optimizer_list = []
+    module_params = [param.data_ptr() for param in module.parameters()]
+    for optim_name, optimizer in optimizers.items():
+        optimizer_params = [
+            param.data_ptr() for param in optimizer.param_groups[0]["params"]
+        ]
+        if all(module_param in optimizer_params for module_param in module_params):
+            optimizer_list.append((optim_name, optimizer))
+    return optimizer_list

--- a/torchtnt/framework/auto_unit.py
+++ b/torchtnt/framework/auto_unit.py
@@ -27,9 +27,10 @@ from torch.cuda.amp import GradScaler
 from torch.distributed.fsdp import FullyShardedDataParallel as FSDP
 from torch.nn.parallel import DistributedDataParallel as DDP
 from torch.optim.swa_utils import SWALR
+from torchtnt.framework._loop_utils import _step_requires_iterator
 from torchtnt.framework.state import ActivePhase, EntryPoint, State
 from torchtnt.framework.unit import EvalUnit, PredictUnit, TPredictData, TrainUnit
-from torchtnt.framework.utils import _step_requires_iterator, get_timing_context
+from torchtnt.framework.utils import get_timing_context
 from torchtnt.utils.device import copy_data_to_device, record_data_in_stream
 from torchtnt.utils.env import init_from_env
 from torchtnt.utils.lr_scheduler import TLRScheduler

--- a/torchtnt/framework/evaluate.py
+++ b/torchtnt/framework/evaluate.py
@@ -10,17 +10,17 @@ from typing import Iterable, List, Optional
 import torch
 from pyre_extensions import none_throws
 from torchtnt.framework._callback_handler import CallbackHandler
+from torchtnt.framework._loop_utils import (
+    _is_epoch_done,
+    _log_api_usage,
+    _reset_module_training_mode,
+    _set_module_training_mode,
+)
 from torchtnt.framework.callback import Callback
 
 from torchtnt.framework.state import ActivePhase, EntryPoint, PhaseState, State
 from torchtnt.framework.unit import TEvalData, TEvalUnit
-from torchtnt.framework.utils import (
-    _is_epoch_done,
-    _reset_module_training_mode,
-    _set_module_training_mode,
-    get_timing_context,
-    log_api_usage,
-)
+from torchtnt.framework.utils import get_timing_context
 from torchtnt.utils.timer import get_timer_summary, TimerProtocol
 
 logger: logging.Logger = logging.getLogger(__name__)
@@ -76,7 +76,7 @@ def evaluate(
         call on_eval_epoch_end on unit first and then callbacks
         call on_eval_end on unit first and then callbacks
     """
-    log_api_usage("evaluate")
+    _log_api_usage("evaluate")
     callback_handler = CallbackHandler(callbacks or [])
     state = State(
         entry_point=EntryPoint.EVALUATE,

--- a/torchtnt/framework/fit.py
+++ b/torchtnt/framework/fit.py
@@ -8,6 +8,7 @@ import logging
 from typing import Iterable, List, Optional
 
 from torchtnt.framework._callback_handler import CallbackHandler
+from torchtnt.framework._loop_utils import _log_api_usage
 from torchtnt.framework.callback import Callback
 from torchtnt.framework.state import EntryPoint, PhaseState, State
 from torchtnt.framework.train import _train_impl
@@ -18,7 +19,6 @@ from torchtnt.framework.unit import (
     TTrainData,
     TTrainUnit,
 )
-from torchtnt.framework.utils import log_api_usage
 from torchtnt.utils.timer import get_timer_summary, TimerProtocol
 
 logger: logging.Logger = logging.getLogger(__name__)
@@ -92,7 +92,7 @@ def fit(
                 run eval loop
         call on_train_end on unit first and then callbacks
     """
-    log_api_usage("fit")
+    _log_api_usage("fit")
 
     # input validation
     if not isinstance(unit, TrainUnit):

--- a/torchtnt/framework/predict.py
+++ b/torchtnt/framework/predict.py
@@ -11,16 +11,16 @@ import torch
 from pyre_extensions import none_throws
 
 from torchtnt.framework._callback_handler import CallbackHandler
+from torchtnt.framework._loop_utils import (
+    _is_epoch_done,
+    _log_api_usage,
+    _reset_module_training_mode,
+    _set_module_training_mode,
+)
 from torchtnt.framework.callback import Callback
 from torchtnt.framework.state import ActivePhase, EntryPoint, PhaseState, State
 from torchtnt.framework.unit import TPredictData, TPredictUnit
-from torchtnt.framework.utils import (
-    _is_epoch_done,
-    _reset_module_training_mode,
-    _set_module_training_mode,
-    get_timing_context,
-    log_api_usage,
-)
+from torchtnt.framework.utils import get_timing_context
 from torchtnt.utils.timer import get_timer_summary, TimerProtocol
 
 logger: logging.Logger = logging.getLogger(__name__)
@@ -76,7 +76,7 @@ def predict(
         call on_predict_epoch_end on unit first and then callbacks
         call on_predict_end on unit first and then callbacks
     """
-    log_api_usage("predict")
+    _log_api_usage("predict")
     callback_handler = CallbackHandler(callbacks or [])
     state = State(
         entry_point=EntryPoint.PREDICT,

--- a/torchtnt/framework/train.py
+++ b/torchtnt/framework/train.py
@@ -10,19 +10,19 @@ from typing import Iterable, List, Optional
 import torch
 from pyre_extensions import none_throws
 from torchtnt.framework._callback_handler import CallbackHandler
+from torchtnt.framework._loop_utils import (
+    _is_done,
+    _is_epoch_done,
+    _log_api_usage,
+    _maybe_set_distributed_sampler_epoch,
+    _reset_module_training_mode,
+    _set_module_training_mode,
+)
 from torchtnt.framework.callback import Callback
 from torchtnt.framework.evaluate import _evaluate_impl
 from torchtnt.framework.state import ActivePhase, EntryPoint, PhaseState, State
 from torchtnt.framework.unit import TTrainData, TTrainUnit
-from torchtnt.framework.utils import (
-    _is_done,
-    _is_epoch_done,
-    _maybe_set_distributed_sampler_epoch,
-    _reset_module_training_mode,
-    _set_module_training_mode,
-    get_timing_context,
-    log_api_usage,
-)
+from torchtnt.framework.utils import get_timing_context
 from torchtnt.utils.timer import get_timer_summary, TimerProtocol
 
 logger: logging.Logger = logging.getLogger(__name__)
@@ -84,7 +84,7 @@ def train(
             call on_train_epoch_end on unit first and then callbacks
         call on_train_end on unit first and then callbacks
     """
-    log_api_usage("train")
+    _log_api_usage("train")
     callback_handler = CallbackHandler(callbacks or [])
     state = State(
         entry_point=EntryPoint.TRAIN,

--- a/torchtnt/framework/unit.py
+++ b/torchtnt/framework/unit.py
@@ -11,9 +11,9 @@ from typing import Any, cast, Dict, Generic, Iterator, TypeVar, Union
 
 import torch
 from torchtnt.framework._loop_utils import _step_requires_iterator
+from torchtnt.framework._unit_utils import _find_optimizers_for_module
 
 from torchtnt.framework.state import State
-from torchtnt.framework.utils import _find_optimizers_for_module
 from torchtnt.utils.lr_scheduler import TLRScheduler
 from torchtnt.utils.prepare_module import _is_fsdp_module, FSDPOptimizerWrapper
 from torchtnt.utils.progress import Progress

--- a/torchtnt/framework/unit.py
+++ b/torchtnt/framework/unit.py
@@ -10,12 +10,10 @@ from abc import ABC, abstractmethod
 from typing import Any, cast, Dict, Generic, Iterator, TypeVar, Union
 
 import torch
+from torchtnt.framework._loop_utils import _step_requires_iterator
 
 from torchtnt.framework.state import State
-from torchtnt.framework.utils import (
-    _find_optimizers_for_module,
-    _step_requires_iterator,
-)
+from torchtnt.framework.utils import _find_optimizers_for_module
 from torchtnt.utils.lr_scheduler import TLRScheduler
 from torchtnt.utils.prepare_module import _is_fsdp_module, FSDPOptimizerWrapper
 from torchtnt.utils.progress import Progress

--- a/torchtnt/framework/utils.py
+++ b/torchtnt/framework/utils.py
@@ -4,14 +4,10 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
-import collections
-import inspect
 import logging
 from contextlib import contextmanager, nullcontext
-from typing import Callable, ContextManager, Dict, Generator, List, Tuple, TypeVar
+from typing import ContextManager, Generator, Tuple, TypeVar
 
-import torch
-import typing_extensions
 from torch.profiler import record_function
 from torchtnt.framework.state import State
 
@@ -36,38 +32,3 @@ def get_timing_context(
     profiler_context = record_function(event_name)
     with timer_context, profiler_context:
         yield (timer_context, profiler_context)
-
-
-def _step_requires_iterator(step_func: Callable[[State, T], object]) -> bool:
-    """
-    Helper function to evaluate whether the loops should pass the data iterator to the `_step`
-    functions, or whether the loop should call `next(data_iter)` and pass a single batch to process.
-
-    This is closely tied to the Unit's corresponding step function signature.
-    """
-    argspec = inspect.getfullargspec(step_func)
-    annotations = argspec.annotations
-    if "data" not in annotations:
-        _logger.warning(
-            f"Expected step function to have an annotated argument named ``data``. Found {annotations}."
-        )
-        return False
-    annotated_type = annotations["data"]
-    return typing_extensions.get_origin(annotated_type) is collections.abc.Iterator
-
-
-def _find_optimizers_for_module(
-    module: torch.nn.Module, optimizers: Dict[str, torch.optim.Optimizer]
-) -> List[Tuple[str, torch.optim.Optimizer]]:
-    """
-    Given a module, returns a list of optimizers that are associated with it.
-    """
-    optimizer_list = []
-    module_params = [param.data_ptr() for param in module.parameters()]
-    for optim_name, optimizer in optimizers.items():
-        optimizer_params = [
-            param.data_ptr() for param in optimizer.param_groups[0]["params"]
-        ]
-        if all(module_param in optimizer_params for module_param in module_params):
-            optimizer_list.append((optim_name, optimizer))
-    return optimizer_list


### PR DESCRIPTION
Summary:
# Context
Having `torchtnt/framework/utils` is a bit misleading since one might think these are external utils, while at the moment it's more of a combination of internal and external (get_timing_context), so for the sake of discoverability, it makes sense to split `framework/utils.py`

# This diff
Extract loop related utils from `framework/utils.py` to `framework/_unit_utils.py.py`

Reviewed By: JKSenthil

Differential Revision: D51593728


