### PR TITLE
add synchronise flag to TSS

### DIFF
--- a/tests/framework/callbacks/test_torchsnapshot_saver.py
+++ b/tests/framework/callbacks/test_torchsnapshot_saver.py
@@ -853,6 +853,23 @@ class TorchSnapshotSaverTest(unittest.TestCase):
                 os.listdir(temp_dir),
             )
 
+    @patch("torchtnt.framework.callbacks.torchsnapshot_saver.torchsnapshot")
+    def test_sync_checkpoint(self, _: MagicMock) -> None:
+        """
+        Tests the _sync_snapshot function is called if async is turned off.
+        """
+        my_unit = DummyTrainUnit(input_dim=2)
+        state = get_dummy_train_state()
+
+        snapshot_cb = TorchSnapshotSaver(
+            "tmp/foo",
+            save_every_n_train_steps=1,
+            async_checkpoint=False,
+        )
+        snapshot_cb._sync_snapshot = MagicMock()
+        snapshot_cb.on_train_step_end(state, my_unit)
+        snapshot_cb._sync_snapshot.assert_called_once()
+
     def test_get_app_state(self) -> None:
         my_unit = DummyTrainUnit(input_dim=2)
         state = get_dummy_train_state()


### PR DESCRIPTION
Summary:
# Context
If async checkpoint fails, hard to propagate this error back up.

# This Diff
Adds `async_checkpoint` flag to TSS that toggles on/off the async checkpoint feature in case there are instances where users may want to use synchronous checkpointing instead

Reviewed By: galrotem

Differential Revision: D51677960


