### PR TITLE
move checkpoint directory utils from TSS into new utils file

### DIFF
--- a/tests/framework/callbacks/test_checkpoint_utils.py
+++ b/tests/framework/callbacks/test_checkpoint_utils.py
@@ -1,0 +1,174 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+import os
+import shutil
+import tempfile
+import unittest
+from unittest.mock import MagicMock, patch
+
+import torch
+import torch.distributed as dist
+from torch import nn
+from torch.distributed import launcher
+from torchsnapshot import Snapshot
+from torchsnapshot.snapshot import SNAPSHOT_METADATA_FNAME
+
+from torchtnt.framework.callbacks._checkpoint_utils import (
+    _delete_checkpoint,
+    _retrieve_checkpoint_dirpaths,
+    get_latest_checkpoint_path,
+)
+from torchtnt.utils.distributed import get_global_rank, PGWrapper
+from torchtnt.utils.test_utils import get_pet_launch_config
+
+METADATA_FNAME: str = ".metadata"
+
+
+class CheckpointUtilsTest(unittest.TestCase):
+    distributed_available: bool = torch.distributed.is_available()
+
+    @staticmethod
+    def _create_snapshot_metadata(output_dir: str) -> None:
+        path = os.path.join(output_dir, METADATA_FNAME)
+        with open(path, "w"):
+            pass
+
+    def test_latest_checkpoint_path(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            self.assertIsNone(get_latest_checkpoint_path(temp_dir))
+
+        with tempfile.TemporaryDirectory() as temp_dir:
+            latest_path = os.path.join(temp_dir, "epoch_0_step_0")
+            os.mkdir(latest_path)
+            self.assertEqual(
+                get_latest_checkpoint_path(temp_dir),
+                latest_path,
+            )
+            self.assertEqual(
+                get_latest_checkpoint_path(temp_dir, METADATA_FNAME),
+                None,
+            )
+            self._create_snapshot_metadata(latest_path)
+            self.assertEqual(
+                get_latest_checkpoint_path(temp_dir, METADATA_FNAME),
+                latest_path,
+            )
+
+        with tempfile.TemporaryDirectory() as temp_dir:
+            path_1 = os.path.join(temp_dir, "epoch_0_step_0")
+            os.mkdir(path_1)
+            self._create_snapshot_metadata(path_1)
+            path_2 = os.path.join(temp_dir, "epoch_0_step_100")
+            os.mkdir(path_2)
+            self._create_snapshot_metadata(path_2)
+
+            # Missing metadata file
+            path_3 = os.path.join(temp_dir, "epoch_1_step_100")
+            os.mkdir(path_3)
+
+            # Ill-formatted name
+            path_4 = os.path.join(temp_dir, "epoch_700")
+            os.mkdir(path_4)
+            self.assertEqual(
+                get_latest_checkpoint_path(temp_dir, METADATA_FNAME), path_2
+            )
+
+    @unittest.skipUnless(
+        condition=distributed_available, reason="Torch distributed is needed to run"
+    )
+    def test_latest_checkpoint_path_distributed(self) -> None:
+        config = get_pet_launch_config(2)
+        launcher.elastic_launch(
+            config, entrypoint=self._latest_checkpoint_path_distributed
+        )()
+
+    @staticmethod
+    def _latest_checkpoint_path_distributed() -> None:
+        tc = unittest.TestCase()
+        is_rank0 = get_global_rank() == 0
+
+        if is_rank0:
+            temp_dir = tempfile.mkdtemp()
+        else:
+            temp_dir = ""
+        tc.assertIsNone(get_latest_checkpoint_path(temp_dir))
+        if is_rank0:
+            shutil.rmtree(temp_dir)  # delete temp directory
+
+        if is_rank0:
+            temp_dir = tempfile.mkdtemp()
+            path_1 = os.path.join(temp_dir, "epoch_0_step_0")
+            os.mkdir(path_1)
+            CheckpointUtilsTest._create_snapshot_metadata(path_1)
+            path_2 = os.path.join(temp_dir, "epoch_0_step_100")
+            os.mkdir(path_2)
+            CheckpointUtilsTest._create_snapshot_metadata(path_2)
+
+            # Missing metadata file
+            path_3 = os.path.join(temp_dir, "epoch_1_step_100")
+            os.mkdir(path_3)
+
+            # Ill-formatted name
+            path_4 = os.path.join(temp_dir, "epoch_700")
+            os.mkdir(path_4)
+        else:
+            temp_dir = ""
+            path_2 = ""
+
+        pg = PGWrapper(dist.group.WORLD)
+        path_container = [path_2] if is_rank0 else [None]
+        pg.broadcast_object_list(path_container, 0)
+        expected_path = path_container[0]
+        tc.assertEqual(
+            get_latest_checkpoint_path(temp_dir, METADATA_FNAME), expected_path
+        )
+
+        if is_rank0:
+            shutil.rmtree(temp_dir)  # delete temp directory
+
+    @patch("torchtnt.framework.callbacks._checkpoint_utils.get_filesystem")
+    def test_retrieve_checkpoint_dirpaths(self, mock_get_filesystem: MagicMock) -> None:
+        """
+        Tests retrieving checkpoint directories from a given root directory
+        """
+        paths = [
+            {"name": "tmp/epoch_0_step_10", "type": "directory"},
+            {"name": "tmp/epoch_1_step_10", "type": "directory"},
+            {"name": "tmp/epoch_2_step_10", "type": "directory"},
+            {"name": "tmp/epoch_0_step_5", "type": "directory"},
+            {"name": "tmp/epoch_0_step_3", "type": "file"},
+        ]
+
+        mock_get_filesystem.return_value.ls.return_value = paths
+        returned_paths = _retrieve_checkpoint_dirpaths("foo")
+        self.assertEqual(
+            returned_paths,
+            [
+                "tmp/epoch_0_step_5",
+                "tmp/epoch_0_step_10",
+                "tmp/epoch_1_step_10",
+                "tmp/epoch_2_step_10",
+            ],
+        )
+
+    def test_delete_checkpoint(self) -> None:
+        """
+        Tests removing checkpoint directories
+        """
+        app_state = {"module": nn.Linear(2, 2)}
+        with tempfile.TemporaryDirectory() as temp_dir:
+            dirpath = os.path.join(temp_dir, "checkpoint")
+            Snapshot.take(dirpath, app_state=app_state)
+            self.assertTrue(os.path.exists(dirpath))
+            # check that error is thrown if .snapshot_metadata is not found in the directory when deleting
+            os.remove(os.path.join(dirpath, SNAPSHOT_METADATA_FNAME))
+            with self.assertRaisesRegex(
+                RuntimeError, f"{temp_dir} does not contain .snapshot_metadata"
+            ):
+                _delete_checkpoint(temp_dir, SNAPSHOT_METADATA_FNAME)
+            _delete_checkpoint(dirpath)
+            self.assertFalse(os.path.exists(dirpath))

--- a/torchtnt/framework/callbacks/_checkpoint_utils.py
+++ b/torchtnt/framework/callbacks/_checkpoint_utils.py
@@ -1,0 +1,157 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+import logging
+import os
+import re
+from typing import List, Optional, Pattern
+
+from pyre_extensions import none_throws
+from torch import distributed as dist
+from torchtnt.utils.distributed import get_global_rank, PGWrapper
+
+from torchtnt.utils.fsspec import get_filesystem
+
+logger: logging.Logger = logging.getLogger(__name__)
+
+
+def get_latest_checkpoint_path(
+    dirpath: str,
+    metadata_fname: Optional[str] = None,
+    process_group: Optional[dist.ProcessGroup] = None,
+) -> Optional[str]:
+    """
+    Given a parent directory where checkpoints are saved, return the latest checkpoint subdirectory.
+
+    Args:
+        dirpath: parent directory where checkpoints are saved.
+        metadata_fname: Checks if metadata file is present in checkpoint, disregards if it does not exist.
+        process_group: the process group on which the ranks will communicate on. default: ``None`` (the entire world)
+
+    Raises:
+        AssertionError if the checkpoint subdirectories are not named in the format epoch_{epoch}_step_{step}.
+    """
+
+    ret = None
+    rank = get_global_rank()
+    # Do all filesystem reads from rank 0 only
+    if rank == 0:
+        ret = _latest_checkpoint_path(dirpath, metadata_fname)
+
+    # If not running in a distributed setting, return as is
+    if not (dist.is_available() and dist.is_initialized()):
+        return ret
+
+    # Otherwise, broadcast result from rank 0 to all ranks
+    pg = PGWrapper(process_group)
+    path_container = [ret] if rank == 0 else [None]
+    pg.broadcast_object_list(path_container, 0)
+    val = path_container[0]
+    return val
+
+
+def _latest_checkpoint_path(
+    dirpath: str, metadata_fname: Optional[str]
+) -> Optional[str]:
+    if dirpath[-1] == "/":
+        # removes trailing forward slash if present
+        # required for regex search to work
+        dirpath = dirpath[:-1]
+
+    fs = get_filesystem(dirpath)
+
+    if not fs.exists(dirpath):
+        logger.warning(f"Input dirpath doesn't exist: {dirpath}")
+        return None
+
+    contents = fs.ls(dirpath, detail=True)
+    contents = [item["name"] for item in contents if item["type"] == "directory"]
+    if len(contents) == 0:
+        logger.warning(f"Input dirpath doesn't contain any subdirectories: {dirpath}")
+        return None
+
+    # Define the regex pattern to match the directory names
+    pattern = rf"^{dirpath}/epoch_\d+_step_\d+"
+    snapshot_dirpath_pattern: Pattern[str] = re.compile(pattern)
+    candidate_dirpaths = list(filter(snapshot_dirpath_pattern.match, contents))
+
+    if len(candidate_dirpaths) == 0:
+        logger.warning(
+            f"No valid checkpoint directories were found in input dirpath: {dirpath}"
+        )
+        return None
+
+    # Initialize variables to store the largest epoch and step numbers
+    largest_subdirectory = None
+    largest_epoch = -1
+    largest_step = -1
+
+    # Iterate through all files and directories in the specified directory
+    for candidate in candidate_dirpaths:
+        if metadata_fname:
+            dir_contents = fs.ls(candidate, False)
+            if not any(metadata_fname == os.path.basename(f) for f in dir_contents):
+                logger.warning(
+                    f"Snapshot metadata is missing from {candidate}! Skipping this path"
+                )
+                continue
+
+        # Extract the epoch and step numbers from the directory name
+        dirname = os.path.basename(candidate)
+
+        # dirname will be of the format epoch_N_step_M
+        # where N is the epoch number and M is the step number as integers
+        split = dirname.split("_")
+        if len(split) != 4:
+            raise AssertionError(
+                f"Expected exactly 4 elements for pattern of epoch_N_step_M, but received {split})"
+            )
+
+        epoch_num, step_num = int(split[1]), int(split[3])
+        # Check if the current epoch and step numbers are larger than the largest ones found so far
+        if epoch_num > largest_epoch:
+            largest_epoch = epoch_num
+            largest_step = step_num
+            largest_subdirectory = dirname
+        elif largest_epoch == epoch_num and step_num > largest_step:
+            largest_step = step_num
+            largest_subdirectory = dirname
+
+    if largest_subdirectory is None:
+        return None
+
+    # Rejoin with the parent directory path and return the largest subdirectory
+    return os.path.join(dirpath, none_throws(largest_subdirectory))
+
+
+def _retrieve_checkpoint_dirpaths(dirpath: str) -> List[str]:
+    """
+    Given a parent directory where checkpoints are saved, return the sorted checkpoint subdirectories
+    from oldest to newest.
+
+    Args:
+        dirpath: parent directory where checkpoints are saved.
+    """
+    fs = get_filesystem(dirpath)
+
+    contents = fs.ls(dirpath, detail=True)
+    contents = [item["name"] for item in contents if item["type"] == "directory"]
+    ckpt_dirpaths = []
+    for path in contents:
+        match = re.search(r"epoch_(\d+)_step_(\d+)", path)
+        if match:
+            ckpt_dirpaths.append(path)
+
+    # sorts by epoch, then step
+    ckpt_dirpaths.sort(key=lambda x: (int(x.split("_")[1]), int(x.split("_")[3])))
+    return ckpt_dirpaths
+
+
+def _delete_checkpoint(dirpath: str, metadata_fname: Optional[str] = None) -> None:
+    fs = get_filesystem(dirpath)
+    if metadata_fname and not fs.exists(os.path.join(dirpath, metadata_fname)):
+        raise RuntimeError(f"{dirpath} does not contain {metadata_fname}")
+    fs.rm(dirpath, recursive=True)

--- a/torchtnt/framework/callbacks/torchsnapshot_saver.py
+++ b/torchtnt/framework/callbacks/torchsnapshot_saver.py
@@ -6,26 +6,19 @@
 
 import logging
 import os
-import re
 from contextlib import contextmanager, ExitStack
-from typing import (
-    Any,
-    cast,
-    Dict,
-    Generator,
-    Iterable,
-    List,
-    Optional,
-    Pattern,
-    Set,
-    Union,
-)
+from typing import Any, cast, Dict, Generator, Iterable, List, Optional, Set, Union
 
 import torch.distributed as dist
 
 from pyre_extensions import none_throws
 
 from torchtnt.framework.callback import Callback
+from torchtnt.framework.callbacks._checkpoint_utils import (
+    _delete_checkpoint,
+    _retrieve_checkpoint_dirpaths,
+    get_latest_checkpoint_path,
+)
 from torchtnt.framework.callbacks.checkpointer_types import KnobOptions, RestoreOptions
 from torchtnt.framework.state import EntryPoint, State
 from torchtnt.framework.unit import (
@@ -335,7 +328,7 @@ class TorchSnapshotSaver(Callback):
         with get_timing_context(state, f"{self.__class__.__name__}.delete_snapshot"):
             if self._pg_wrapper.get_rank() == 0:
                 # only delete on rank 0
-                _delete_snapshot(oldest_ckpt_path)
+                _delete_checkpoint(oldest_ckpt_path, SNAPSHOT_METADATA_FNAME)
             self._pg_wrapper.barrier()
 
     def _wait(self) -> None:
@@ -503,7 +496,9 @@ class TorchSnapshotSaver(Callback):
         Returns:
             True if the latest snapshot directory was found and successfully restored, otherwise False.
         """
-        path = get_latest_checkpoint_path(dirpath, process_group=process_group)
+        path = get_latest_checkpoint_path(
+            dirpath, SNAPSHOT_METADATA_FNAME, process_group=process_group
+        )
         if path is None:
             return False
         logger.info(f"Restoring from path: {path}")
@@ -517,108 +512,6 @@ class TorchSnapshotSaver(Callback):
             knob_options=knob_options,
         )
         return True
-
-
-def get_latest_checkpoint_path(
-    dirpath: str, process_group: Optional[dist.ProcessGroup] = None
-) -> Optional[str]:
-    """
-    Given a parent directory where checkpoints are saved, return the latest checkpoint subdirectory.
-
-    Args:
-        dirpath: parent directory where checkpoints are saved.
-        process_group: the process group on which the ranks will communicate on. default: ``None`` (the entire world)
-
-    Raises:
-        AssertionError if the checkpoint subdirectories are not named in the format epoch_{epoch}_step_{step}.
-    """
-
-    ret = None
-    rank = get_global_rank()
-    # Do all filesystem reads from rank 0 only
-    if rank == 0:
-        ret = _latest_checkpoint_path(dirpath)
-
-    # If not running in a distributed setting, return as is
-    if not (dist.is_available() and dist.is_initialized()):
-        return ret
-
-    # Otherwise, broadcast result from rank 0 to all ranks
-    pg = PGWrapper(process_group)
-    path_container = [ret] if rank == 0 else [None]
-    pg.broadcast_object_list(path_container, 0)
-    val = path_container[0]
-    return val
-
-
-def _latest_checkpoint_path(dirpath: str) -> Optional[str]:
-    if dirpath[-1] == "/":
-        # removes trailing forward slash if present
-        # required for regex search to work
-        dirpath = dirpath[:-1]
-
-    fs = get_filesystem(dirpath)
-
-    if not fs.exists(dirpath):
-        logger.warning(f"Input dirpath doesn't exist: {dirpath}")
-        return None
-
-    contents = fs.ls(dirpath, detail=True)
-    contents = [item["name"] for item in contents if item["type"] == "directory"]
-    if len(contents) == 0:
-        logger.warning(f"Input dirpath doesn't contain any subdirectories: {dirpath}")
-        return None
-
-    # Define the regex pattern to match the directory names
-    pattern = rf"^{dirpath}/epoch_\d+_step_\d+"
-    snapshot_dirpath_pattern: Pattern[str] = re.compile(pattern)
-    candidate_dirpaths = list(filter(snapshot_dirpath_pattern.match, contents))
-
-    if len(candidate_dirpaths) == 0:
-        logger.warning(
-            f"No valid checkpoint directories were found in input dirpath: {dirpath}"
-        )
-        return None
-
-    # Initialize variables to store the largest epoch and step numbers
-    largest_subdirectory = None
-    largest_epoch = -1
-    largest_step = -1
-
-    # Iterate through all files and directories in the specified directory
-    for candidate in candidate_dirpaths:
-        dir_contents = fs.ls(candidate, False)
-        if not any(
-            SNAPSHOT_METADATA_FNAME == os.path.basename(f) for f in dir_contents
-        ):
-            logger.warning(
-                f"Snapshot metadata is missing from {candidate}! Skipping this path"
-            )
-            continue
-
-        # Extract the epoch and step numbers from the directory name
-        dirname = os.path.basename(candidate)
-
-        # dirname will be of the format epoch_N_step_M
-        # where N is the epoch number and M is the step number as integers
-        split = dirname.split("_")
-        if len(split) != 4:
-            raise AssertionError(
-                f"Expected exactly 4 elements for pattern of epoch_N_step_M, but received {split})"
-            )
-
-        epoch_num, step_num = int(split[1]), int(split[3])
-        # Check if the current epoch and step numbers are larger than the largest ones found so far
-        if epoch_num > largest_epoch:
-            largest_epoch = epoch_num
-            largest_step = step_num
-            largest_subdirectory = dirname
-        elif largest_epoch == epoch_num and step_num > largest_step:
-            largest_step = step_num
-            largest_subdirectory = dirname
-
-    # Rejoin with the parent directory path and return the largest subdirectory
-    return os.path.join(dirpath, none_throws(largest_subdirectory))
 
 
 def _validate_snapshot_available() -> None:
@@ -691,33 +584,3 @@ def _override_knobs(
         for mgr in knobs:
             stack.enter_context(mgr)
         yield
-
-
-def _retrieve_checkpoint_dirpaths(dirpath: str) -> List[str]:
-    """
-    Given a parent directory where checkpoints are saved, return the sorted checkpoint subdirectories
-    from oldest to newest.
-
-    Args:
-        dirpath: parent directory where checkpoints are saved.
-    """
-    fs = get_filesystem(dirpath)
-
-    contents = fs.ls(dirpath, detail=True)
-    contents = [item["name"] for item in contents if item["type"] == "directory"]
-    ckpt_dirpaths = []
-    for path in contents:
-        match = re.search(r"epoch_(\d+)_step_(\d+)", path)
-        if match:
-            ckpt_dirpaths.append(path)
-
-    # sorts by epoch, then step
-    ckpt_dirpaths.sort(key=lambda x: (int(x.split("_")[1]), int(x.split("_")[3])))
-    return ckpt_dirpaths
-
-
-def _delete_snapshot(dirpath: str) -> None:
-    fs = get_filesystem(dirpath)
-    if not fs.exists(os.path.join(dirpath, ".snapshot_metadata")):
-        raise RuntimeError(f"{dirpath} does not contain .snapshot_metadata")
-    fs.rm(dirpath, recursive=True)


### PR DESCRIPTION
Summary:
# Context
We want to share few directory i/o related utils with future checkpointers. Currently most of these sit in TSS

# This Diff
Moves few utils like `get_latest_checkpoint_path`, `_latest_checkpoint_path`,
`_retrieve_checkpoint_dirpaths`, and
`_delete_snapshot` to `_checkpoint_utils.py` and moves unit tests from `test_torchsnapshot_saver.py` to `test_checkpoint_utils.py` accordingly

Also adds `metadata_fname` arg to `_delete_snapshot` and `get_latest_checkpoint_path` since currently these are hardcoded for TorchSnapshot use case

finally renames `_delete_snapshot` to `_delete_checkpoint` to maintain same naming scheme

Reviewed By: galrotem

Differential Revision: D51817876


