### PR TITLE
make retrieve checkpoint util rank 0 only

### DIFF
--- a/tests/framework/callbacks/test_base_checkpointer.py
+++ b/tests/framework/callbacks/test_base_checkpointer.py
@@ -338,7 +338,7 @@ class BaseCheckpointerTest(unittest.TestCase):
                 shutil.rmtree(temp_dir)  # delete temp directory
 
     @patch(
-        "torchtnt.framework.callbacks.base_checkpointer._retrieve_checkpoint_dirpaths",
+        "torchtnt.framework.callbacks.base_checkpointer.get_checkpoint_dirpaths",
         return_value=["epoch_1_step_10", "epoch_2_step_20"],
     )
     def test_ckpt_dirpaths(self, _: MagicMock) -> None:

--- a/torchtnt/framework/callbacks/base_checkpointer.py
+++ b/torchtnt/framework/callbacks/base_checkpointer.py
@@ -14,7 +14,7 @@ import torch.distributed as dist
 from torchtnt.framework.callback import Callback
 from torchtnt.framework.callbacks._checkpoint_utils import (
     _delete_checkpoint,
-    _retrieve_checkpoint_dirpaths,
+    get_checkpoint_dirpaths,
     get_latest_checkpoint_path,
 )
 from torchtnt.framework.callbacks.checkpointer_types import RestoreOptions
@@ -84,7 +84,7 @@ class BaseCheckpointer(Callback, metaclass=abc.ABCMeta):
         self._keep_last_n_checkpoints = keep_last_n_checkpoints
         self._ckpt_dirpaths: List[str] = []
         if self._keep_last_n_checkpoints:
-            self._ckpt_dirpaths = _retrieve_checkpoint_dirpaths(dirpath)
+            self._ckpt_dirpaths = get_checkpoint_dirpaths(dirpath)
         self._process_group = process_group
         self._pg_wrapper = PGWrapper(process_group)
 


### PR DESCRIPTION
Summary:
# Context
The `get_latest_checkpoint_path()` util reads only on rank 0 and broadcasts. We want an equivalent for `_retrieve_checkpoint_dirpaths()` as currently it is called, it will do I/O on all ranks

# This Diff
1. Extracts the "read on rank 0 and broadcast" logic into decorator function `rank_zero_read_and_broadcast`
2. Creates new function `get_checkpoint_dirpaths()` which is decorated by `rank_zero_read_and_broadcast` and inside just calls `_retrieve_checkpoint_dirpaths()` 
3. Replaces `_retrieve_checkpoint_dirpaths()`  usage in `BaseCheckpointer` with `get_checkpoint_dirpaths()` and updates respective unit test

Differential Revision: D51948398


