### PR TITLE
allow grad norm to be loggable in AutoUnit

### DIFF
--- a/examples/auto_unit_example.py
+++ b/examples/auto_unit_example.py
@@ -17,7 +17,7 @@ import torch.nn as nn
 from torch.distributed import launcher as pet
 from torch.utils.data.dataset import Dataset, TensorDataset
 from torcheval.metrics import BinaryAccuracy
-from torchtnt.framework.auto_unit import AutoUnit, Strategy, SWAParams
+from torchtnt.framework.auto_unit import AutoUnit, Strategy, SWAParams, TrainStepResults
 from torchtnt.framework.fit import fit
 from torchtnt.framework.state import EntryPoint, State
 from torchtnt.utils import init_from_env, seed, TLRScheduler
@@ -128,9 +128,9 @@ class MyUnit(AutoUnit[Batch]):
         state: State,
         data: Batch,
         step: int,
-        loss: torch.Tensor,
-        outputs: torch.Tensor,
+        results: TrainStepResults,
     ) -> None:
+        loss, outputs = results.loss, results.outputs
         _, targets = data
         self.train_accuracy.update(outputs, targets)
         tb_logger = self.tb_logger

--- a/examples/mingpt/main.py
+++ b/examples/mingpt/main.py
@@ -22,7 +22,7 @@ from torchtnt.examples.mingpt.model import (
     GPTConfig,
     OptimizerConfig,
 )
-from torchtnt.framework.auto_unit import AutoUnit
+from torchtnt.framework.auto_unit import AutoUnit, TrainStepResults
 from torchtnt.framework.fit import fit
 from torchtnt.framework.state import State
 from torchtnt.utils import init_from_env, seed, TLRScheduler
@@ -103,9 +103,9 @@ class MinGPTUnit(AutoUnit[Batch]):
         state: State,
         data: Batch,
         step: int,
-        loss: torch.Tensor,
-        outputs: object,
+        results: TrainStepResults,
     ) -> None:
+        loss = results.loss
         if step % self.log_every_n_steps == 0:
             self.tb_logger.log("loss", loss, step)
 

--- a/examples/mnist/main.py
+++ b/examples/mnist/main.py
@@ -18,7 +18,7 @@ from torch.optim import Adadelta
 from torch.optim.lr_scheduler import StepLR
 from torch.utils.data import DataLoader
 from torcheval.metrics import MulticlassAccuracy
-from torchtnt.framework.auto_unit import AutoUnit
+from torchtnt.framework.auto_unit import AutoUnit, TrainStepResults
 from torchtnt.framework.fit import fit
 from torchtnt.framework.state import State
 from torchtnt.utils import init_from_env, seed, TLRScheduler
@@ -111,9 +111,9 @@ class MyUnit(AutoUnit[Batch]):
         state: State,
         data: Batch,
         step: int,
-        loss: torch.Tensor,
-        outputs: torch.Tensor,
+        results: TrainStepResults,
     ) -> None:
+        loss, outputs = results.loss, results.outputs
         _, targets = data
         self.train_accuracy.update(outputs, targets)
         if step % self.log_every_n_steps == 0:

--- a/tests/framework/test_auto_unit.py
+++ b/tests/framework/test_auto_unit.py
@@ -11,6 +11,7 @@ from unittest.mock import MagicMock, patch
 
 import torch
 from torch.distributed.fsdp.sharded_grad_scaler import ShardedGradScaler
+from torchtnt.framework.auto_unit import TrainStepResults
 
 from torchtnt.utils.version import is_torch_version_geq_1_13
 
@@ -1078,8 +1079,7 @@ class TimingAutoUnit(AutoUnit[Batch]):
         state: State,
         data: Batch,
         step: int,
-        loss: torch.Tensor,
-        outputs: torch.Tensor,
+        results: TrainStepResults,
     ) -> None:
         assert state.train_state
         if self.train_progress.num_steps_completed_in_epoch == 1:


### PR DESCRIPTION
Summary:
Adds `TrainStepResult` dataclass as param to AutoUnit's `on_train_step_end` which contains loss, grad loss, and outputs for users to log.
```
def on_train_step_end(
        self,
        state: State,
        data: TData,
        step: int,
        --> results: TrainStepResults
    ) -> None:
    pass
```
In case future results need to be logged, they can be added to the dataclass without disrupting existing use cases

Differential Revision: D51921449


