### PR TITLE
moves grad scaler util from autounit to precision utils

### DIFF
--- a/tests/utils/test_precision.py
+++ b/tests/utils/test_precision.py
@@ -6,10 +6,16 @@
 # LICENSE file in the root directory of this source tree.
 
 import unittest
+from unittest.mock import patch
 
 import torch
+from torch.cuda.amp.grad_scaler import GradScaler
+from torch.distributed.fsdp.sharded_grad_scaler import ShardedGradScaler
 
-from torchtnt.utils.precision import convert_precision_str_to_dtype
+from torchtnt.utils.precision import (
+    convert_precision_str_to_dtype,
+    get_grad_scaler_from_precision,
+)
 
 
 class PrecisionTest(unittest.TestCase):
@@ -32,3 +38,20 @@ class PrecisionTest(unittest.TestCase):
             "Precision foo not supported. Please use one of .*",
         ):
             convert_precision_str_to_dtype("foo")
+
+    def test_get_grad_scaler_from_precision(self) -> None:
+        grad_scaler = get_grad_scaler_from_precision(
+            torch.float32, torch.nn.Linear(2, 2)
+        )
+        self.assertIsNone(grad_scaler)
+
+        grad_scaler = get_grad_scaler_from_precision(
+            torch.float16, torch.nn.Linear(2, 2)
+        )
+        self.assertTrue(isinstance(grad_scaler, GradScaler))
+
+        with patch("torchtnt.utils.precision._is_fsdp_module", return_value=True):
+            grad_scaler = get_grad_scaler_from_precision(
+                torch.float16, torch.nn.Linear(2, 2)
+            )
+            self.assertTrue(isinstance(grad_scaler, ShardedGradScaler))


### PR DESCRIPTION
Summary: Moves grad scaler util from `framework/auto_unit.py` to `utils/precision.py`, adds docstring, and new test

Differential Revision: D52264512


