### PR TITLE
fix OSS doc build

### DIFF
--- a/.github/workflows/build_docs.yaml
+++ b/.github/workflows/build_docs.yaml
@@ -27,9 +27,9 @@ jobs:
           conda activate test
           pip install -r requirements.txt
           pip install -r dev-requirements.txt
+          conda install pytorch cpuonly -c pytorch-nightly
           python setup.py sdist bdist_wheel
           pip install dist/*.whl
-          conda install pytorch cpuonly -c pytorch-nightly
       - name: Build docs
         shell: bash -l {0}
         run: |


### PR DESCRIPTION
Summary:
# Context
TorchTNT public doc builds have been failing for some time. This is due to an import issue when retrieving TorchTNT's version for the docs

# This Diff
Moves the pytorch installation to occur after installing dependencies but before installing TorchTNT itself.

Differential Revision: D52447611


