### PR TITLE
add best metric support checkpoint

### DIFF
--- a/torchtnt/framework/callbacks/checkpointer_types.py
+++ b/torchtnt/framework/callbacks/checkpointer_types.py
@@ -5,7 +5,7 @@
 # LICENSE file in the root directory of this source tree.
 
 from dataclasses import dataclass
-from typing import Optional
+from typing import Literal, Optional
 
 # TODO: eventually support overriding all knobs
 @dataclass
@@ -36,3 +36,17 @@ class RestoreOptions:
     restore_eval_progress: bool = True
     restore_optimizers: bool = True
     restore_lr_schedulers: bool = True
+
+
+@dataclass
+class BestCheckpointConfig:
+    """
+    Config for saving the best checkpoints.
+
+    Args:
+        monitored_metric: Metric to monitor for saving best checkpoints. Must be an numerical or tensor attribute on the unit.
+        mode: One of `min` or `max`. The save file is overwritten based the max or min of the monitored metric.
+    """
+
+    monitored_metric: str
+    mode: Literal["min", "max"] = "min"


### PR DESCRIPTION
Summary:
# Context
This diff stack is aimed to implement best metric checkpoint support. 

# This Diff
This diff adds the best metric support checkpoint functionality to the base checkpointer.

1. Adds `BestCheckpointConfig` struct to configure how to checkpoint best metric. It takes a metric name and mode (ie min or max) which indicates which is used to determine best value
2. In the BaseCheckpointer constructor:
* Adds `save_every_n_eval_epochs` to BaseCheckpointer, which can be used to save at end of eval epoch during fit
*  If best checkpoint config is used, will sort existing checkpoint paths by metric value, as opposed to recency
3. Adds `self._should_save_checkpoint()` to check if checkpoint needs to be saved or not (is used for both normal and best checkpoint configs)
4. Augments `self._generate_checkpoint_and_upkeep()` to consider best checkpoint config and calls appropriate logic

# Next Diff
Forwards these args for best metric checkpoint to the derivative checkpointers (TSS and DCPSaver)

# Future
Can consider case of passing lambda function instead of reading the metric value from the unit

Differential Revision: D52739597


