### PR TITLE
bump TorchTNT to version 2.1.1

### DIFF
--- a/torchtnt/__init__.py
+++ b/torchtnt/__init__.py
@@ -4,4 +4,4 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
-__version__ = "0.2.1"
+__version__ = "0.2.2"


### PR DESCRIPTION
Summary: bump to new version as overdue since last release in Sept 2023

Differential Revision: D52862524


