### PR TITLE
delete unused code from auto_unit

### DIFF
--- a/torchtnt/framework/auto_unit.py
+++ b/torchtnt/framework/auto_unit.py
@@ -54,10 +54,6 @@ from typing_extensions import Literal
 
 TData = TypeVar("TData")
 
-TSWA_avg_fn = Callable[[torch.Tensor, torch.Tensor, int], torch.Tensor]
-# pyre-ignore Invalid type parameters [24]: Generic type `Callable` expects 2 type parameters.
-TSWA_multi_avg_fn = Callable
-
 
 @dataclass
 class SWALRParams:


### PR DESCRIPTION
Summary: this definition already exists in swa.py, I think we forgot to delete it after creating swa.py

Differential Revision: D52890778


