### PR TITLE
Grant write permission to doc build jobs running on GH runners

### DIFF
--- a/.github/workflows/build_and_publish_docs.yaml
+++ b/.github/workflows/build_and_publish_docs.yaml
@@ -12,6 +12,9 @@ concurrency:
 jobs:
   build_and_publish_docs:
     runs-on: ubuntu-latest
+    permissions:
+      # Grant write permission here so that the doc can be pushed to gh-pages branch
+      contents: write
     steps:
       - name: Check out repo
         uses: actions/checkout@v2

--- a/.github/workflows/release_build.yaml
+++ b/.github/workflows/release_build.yaml
@@ -68,6 +68,9 @@ jobs:
           twine upload --username "$PYPI_USER" --password "$PYPI_TOKEN" dist/* --verbose
   build_docs:
     runs-on: ubuntu-latest
+    permissions:
+      # Grant write permission here so that the doc can be pushed to gh-pages branch
+      contents: write
     steps:
       - name: Check out repo
         uses: actions/checkout@v2


### PR DESCRIPTION
Similar to https://github.com/pytorch/torchrec/pull/1639 and many other, this is to fix the doc build failures after we revoke the default write permission