### PR TITLE
Pass in `strict` flag to allow non-strict state_dict loading

### DIFF
--- a/tests/framework/callbacks/test_torchsnapshot_saver.py
+++ b/tests/framework/callbacks/test_torchsnapshot_saver.py
@@ -374,7 +374,7 @@ class DummyStatefulDataLoader:
         self.state_dict_call_count += 1
         return {}
 
-    def load_state_dict(self, state_dict: Dict[str, Any]) -> None:
+    def load_state_dict(self, state_dict: Dict[str, Any], strict: bool = True) -> None:
         self.load_state_dict_call_count += 1
         return None
 


### PR DESCRIPTION
Summary:
This allows users to ignore keys in the state_dict that aren't part of
the given module, or part of the module that aren't in the state_dict.

The default value for the flag (true) keeps the status quo and what the pytorch
interface uses.

Differential Revision: D53066198


