### PR TITLE
pin torchvision version to 0.16.2 in dev-requirements

### DIFF
--- a/examples/mnist/requirements.txt
+++ b/examples/mnist/requirements.txt
@@ -1,4 +1,4 @@
 torch
 torcheval
 torchtnt
-torchvision
+torchvision==0.15.2


### PR DESCRIPTION
Summary:
# Context
We are seeing failed unit test, caused by torchvision error
{F1452783880}
Torchvision recently updated to 0.17, which is when I suspect this issue occurred. 
# This Diff
For now, pinning the version to the last 0.16.x one, as there were no failing unit tests before

Differential Revision: D53456248


