### PR TITLE
redo torchvision dependency fix

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -3,4 +3,4 @@ pytest
 pytest-cov
 torchsnapshot-nightly
 pyre-check
-torchvision
+torchvision==0.16.2

--- a/examples/mnist/requirements.txt
+++ b/examples/mnist/requirements.txt
@@ -1,4 +1,4 @@
 torch
 torcheval
 torchtnt
-torchvision==0.15.2
+torchvision


### PR DESCRIPTION
Summary:
previous diff D53456248 mistakenly pinned the torchvision version in the mnist example. We want to pin the version in the dev-requirements instead to fix the following error:
```
==================================== ERRORS ====================================
__________________ ERROR collecting tests/utils/test_flops.py __________________
tests/utils/test_flops.py:11: in <module>
    import torchvision.models as models
/usr/share/miniconda3/envs/test/lib/python3.9/site-packages/torchvision/__init__.py:6: in <module>
    from torchvision import _meta_registrations, datasets, io, models, ops, transforms, utils
/usr/share/miniconda3/envs/test/lib/python3.9/site-packages/torchvision/_meta_registrations.py:164: in <module>
    def meta_nms(dets, scores, iou_threshold):
/usr/share/miniconda3/envs/test/lib/python3.9/site-packages/torch/library.py:467: in inner
    handle = entry.abstract_impl.register(func_to_register, source)
/usr/share/miniconda3/envs/test/lib/python3.9/site-packages/torch/_library/abstract_impl.py:30: in register
    if torch._C._dispatch_has_kernel_for_dispatch_key(self.qualname, "Meta"):
E   RuntimeError: operator torchvision::nms does not exist
_____________ ERROR collecting tests/utils/test_module_summary.py ______________
tests/utils/test_module_summary.py:18: in <module>
    from torchvision import models
/usr/share/miniconda3/envs/test/lib/python3.9/site-packages/torchvision/__init__.py:6: in <module>
    from torchvision import _meta_registrations, datasets, io, models, ops, transforms, utils
/usr/share/miniconda3/envs/test/lib/python3.9/site-packages/torchvision/_meta_registrations.py:26: in <module>
    def meta_roi_align(input, rois, spatial_scale, pooled_height, pooled_width, sampling_ratio, aligned):
/usr/share/miniconda3/envs/test/lib/python3.9/site-packages/torchvision/_meta_registrations.py:18: in wrapper
    if torchvision.extension._has_ops():
E   AttributeError: partially initialized module 'torchvision' has no attribute 'extension' (most likely due to a circular import)
=============================== warnings summary ===============================
torchtnt/utils/version.py:10
  /home/runner/work/tnt/tnt/torchtnt/utils/version.py:10: DeprecationWarning: pkg_resources is deprecated as an API. See https://setuptools.pypa.io/en/latest/pkg_resources.html
    import pkg_resources

tests/framework/test_unit.py:18
  /home/runner/work/tnt/tnt/tests/framework/test_unit.py:18: PytestCollectionWarning: cannot collect test class 'TestUnit' because it has a __init__ constructor (from: tests/framework/test_unit.py)
    class TestUnit(

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html

---------- coverage: platform linux, python 3.9.18-final-0 -----------
Coverage XML written to file coverage.xml

=========================== short test summary info ============================
ERROR tests/utils/test_flops.py - RuntimeError: operator torchvision::nms does not exist
ERROR tests/utils/test_module_summary.py - AttributeError: partially initialized module 'torchvision' has no attribute 'extension' (most likely due to a circular import)
!!!!!!!!!!!!!!!!!!! Interrupted: 2 errors during collection !!!!!!!!!!!!!!!!!!!!
======================== 2 warnings, 2 errors in 3.40s =========================
Error: Process completed with exit code 2.
```

Differential Revision: D53720066


