### PR TITLE
Enable memory snapshot support upload to manifold and zoomer

### DIFF
--- a/tests/framework/callbacks/test_memory_snapshot.py
+++ b/tests/framework/callbacks/test_memory_snapshot.py
@@ -10,13 +10,14 @@ from unittest.mock import MagicMock, Mock
 
 from torchtnt.framework.callbacks.memory_snapshot import MemorySnapshot
 from torchtnt.framework.state import EntryPoint
+from torchtnt.utils.memory_snapshot_profiler import MemorySnapshotProfiler
 
 
 class TestMemorySnapshot(unittest.TestCase):
     def test_on_train_step_end(self) -> None:
         with tempfile.TemporaryDirectory() as temp_dir:
             memory_snapshot = MemorySnapshot(
-                output_dir=temp_dir,
+                memory_snapshot_profiler=MemorySnapshotProfiler(output_dir=temp_dir),
             )
             memory_snapshot.memory_snapshot_profiler = Mock()
 
@@ -28,7 +29,7 @@ class TestMemorySnapshot(unittest.TestCase):
     def test_on_eval_step_end(self) -> None:
         with tempfile.TemporaryDirectory() as temp_dir:
             memory_snapshot = MemorySnapshot(
-                output_dir=temp_dir,
+                memory_snapshot_profiler=MemorySnapshotProfiler(output_dir=temp_dir),
             )
             memory_snapshot.memory_snapshot_profiler = Mock()
 
@@ -41,7 +42,7 @@ class TestMemorySnapshot(unittest.TestCase):
     def test_on_predict_step_end(self) -> None:
         with tempfile.TemporaryDirectory() as temp_dir:
             memory_snapshot = MemorySnapshot(
-                output_dir=temp_dir,
+                memory_snapshot_profiler=MemorySnapshotProfiler(output_dir=temp_dir),
             )
             memory_snapshot.memory_snapshot_profiler = Mock()
 

--- a/torchtnt/framework/callbacks/memory_snapshot.py
+++ b/torchtnt/framework/callbacks/memory_snapshot.py
@@ -5,15 +5,11 @@
 # LICENSE file in the root directory of this source tree.
 
 import logging
-from typing import Optional
 
 from torchtnt.framework.callback import Callback
 from torchtnt.framework.state import State
 from torchtnt.framework.unit import TEvalUnit, TPredictUnit, TTrainUnit
-from torchtnt.utils.memory_snapshot_profiler import (
-    MemorySnapshotParams,
-    MemorySnapshotProfiler,
-)
+from torchtnt.utils.memory_snapshot_profiler import MemorySnapshotProfilerBase
 
 logger: logging.Logger = logging.getLogger(__name__)
 
@@ -25,8 +21,7 @@ class MemorySnapshot(Callback):
     Uses `Memory Snapshots <https://zdevito.github.io/2022/08/16/memory-snapshots.html>`.
 
     Args:
-        output_dir: Directory where to save the memory snapshots.
-        memory_snapshot_params: Instance of MemorySnapshotParams which will be passed to MemorySnapshotProfiler.
+        memory_snapshot_profiler: Instance of MemorySnapshotProfilerBase, controls when and where to save the memory snapshots.
 
     Note: It is recommended to instantiate this callback **as early as possible** in your training/eval/prediction script,
         ideally before model initialization, to make sure all memory allocation is captured.
@@ -36,12 +31,9 @@ class MemorySnapshot(Callback):
     def __init__(
         self,
         *,
-        output_dir: str,
-        memory_snapshot_params: Optional[MemorySnapshotParams] = None,
+        memory_snapshot_profiler: MemorySnapshotProfilerBase,
     ) -> None:
-        self.memory_snapshot_profiler = MemorySnapshotProfiler(
-            output_dir=output_dir, memory_snapshot_params=memory_snapshot_params
-        )
+        self.memory_snapshot_profiler = memory_snapshot_profiler
 
     def on_train_step_end(self, state: State, unit: TTrainUnit) -> None:
         self.memory_snapshot_profiler.step()


### PR DESCRIPTION
Summary:
This change adds the support to upload memory snapshot to manifold and shown in zoomer with following changes:
1. Add a zoomer specific memory snapshot profiler wrapper;
2. Internally call the memory_snapshot API from `unitrace`.

Differential Revision: D53997537


