### PR TITLE
add mem / oom debug guide

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -73,6 +73,7 @@ Documentation
       :glob:
 
       meta/checkpointing_FAQ
+      meta/mem_debug
 
 .. toctree::
    :maxdepth: 1

--- a/torchtnt/utils/device.py
+++ b/torchtnt/utils/device.py
@@ -286,6 +286,9 @@ def get_psutil_cpu_stats() -> CPUStats:
             - 'cpu_vm_percent'
             - 'cpu_percent'
             - 'cpu_swap_percent'
+            - 'worker_cpu_time_user'
+            - 'worker_cpu_time_system'
+            - 'worker_rss'
     """
     try:
         import psutil


### PR DESCRIPTION
Summary:
Adds overview of all the ways to debug memory / ooms using TorchTNT utils

also adds `meta/assets` folder to move all images to

Reviewed By: galrotem

Differential Revision: D54381023
