### PR TITLE
Decouple precision util from prepare_module

### DIFF
--- a/tests/utils/test_precision.py
+++ b/tests/utils/test_precision.py
@@ -8,7 +8,6 @@
 # pyre-strict
 
 import unittest
-from unittest.mock import patch
 
 import torch
 from torch.cuda.amp.grad_scaler import GradScaler
@@ -43,17 +42,14 @@ class PrecisionTest(unittest.TestCase):
 
     def test_get_grad_scaler_from_precision(self) -> None:
         grad_scaler = get_grad_scaler_from_precision(
-            torch.float32, torch.nn.Linear(2, 2)
+            torch.float32, is_fsdp_module=False
         )
         self.assertIsNone(grad_scaler)
 
         grad_scaler = get_grad_scaler_from_precision(
-            torch.float16, torch.nn.Linear(2, 2)
+            torch.float16, is_fsdp_module=False
         )
         self.assertTrue(isinstance(grad_scaler, GradScaler))
 
-        with patch("torchtnt.utils.precision._is_fsdp_module", return_value=True):
-            grad_scaler = get_grad_scaler_from_precision(
-                torch.float16, torch.nn.Linear(2, 2)
-            )
-            self.assertTrue(isinstance(grad_scaler, ShardedGradScaler))
+        grad_scaler = get_grad_scaler_from_precision(torch.float16, is_fsdp_module=True)
+        self.assertTrue(isinstance(grad_scaler, ShardedGradScaler))

--- a/torchtnt/framework/auto_unit.py
+++ b/torchtnt/framework/auto_unit.py
@@ -494,7 +494,7 @@ class AutoUnit(
         if self.precision:
             self.grad_scaler = get_grad_scaler_from_precision(
                 self.precision,
-                self.module,
+                is_fsdp_module=_is_fsdp_module(self.module),
             )
 
         self.step_lr_interval = step_lr_interval

--- a/torchtnt/utils/precision.py
+++ b/torchtnt/utils/precision.py
@@ -11,7 +11,6 @@ from typing import Mapping, Optional
 
 import torch
 from torch.cuda.amp.grad_scaler import GradScaler
-from torchtnt.utils.prepare_module import _is_fsdp_module
 
 _DTYPE_STRING_TO_DTYPE_MAPPING: Mapping[str, Optional[torch.dtype]] = {
     "fp16": torch.float16,
@@ -39,7 +38,7 @@ def convert_precision_str_to_dtype(precision: str) -> Optional[torch.dtype]:
 
 
 def get_grad_scaler_from_precision(
-    precision: torch.dtype, module: torch.nn.Module
+    precision: torch.dtype, *, is_fsdp_module: Optional[bool] = False
 ) -> Optional[torch.amp.GradScaler]:
     """
     Returns the correct grad scaler to use based on the precision and whether
@@ -47,14 +46,14 @@ def get_grad_scaler_from_precision(
 
     Args:
         precision: the precision being used
-        module: the module being trained
+        is_fsdp_module: whether the grad scaler is for an FSDP module
 
     Returns:
         The appropriate grad scaler to use, ``None`` if no grad scaler should be used.
     """
 
     if precision == torch.float16:
-        if _is_fsdp_module(module):
+        if is_fsdp_module:
             from torch.distributed.fsdp.sharded_grad_scaler import ShardedGradScaler
 
             return ShardedGradScaler()


### PR DESCRIPTION
Summary:
This is so I can use a precision util in prepare_module without
circular dependencies. (see next change in stack)

Differential Revision: D54568547


