### PR TITLE
Syntactic sugar for FSDPStrategy

### DIFF
--- a/tests/utils/test_precision.py
+++ b/tests/utils/test_precision.py
@@ -8,7 +8,6 @@
 # pyre-strict
 
 import unittest
-from unittest.mock import patch
 
 import torch
 from torch.cuda.amp.grad_scaler import GradScaler
@@ -43,17 +42,14 @@ class PrecisionTest(unittest.TestCase):
 
     def test_get_grad_scaler_from_precision(self) -> None:
         grad_scaler = get_grad_scaler_from_precision(
-            torch.float32, torch.nn.Linear(2, 2)
+            torch.float32, is_fsdp_module=False
         )
         self.assertIsNone(grad_scaler)
 
         grad_scaler = get_grad_scaler_from_precision(
-            torch.float16, torch.nn.Linear(2, 2)
+            torch.float16, is_fsdp_module=False
         )
         self.assertTrue(isinstance(grad_scaler, GradScaler))
 
-        with patch("torchtnt.utils.precision._is_fsdp_module", return_value=True):
-            grad_scaler = get_grad_scaler_from_precision(
-                torch.float16, torch.nn.Linear(2, 2)
-            )
-            self.assertTrue(isinstance(grad_scaler, ShardedGradScaler))
+        grad_scaler = get_grad_scaler_from_precision(torch.float16, is_fsdp_module=True)
+        self.assertTrue(isinstance(grad_scaler, ShardedGradScaler))

--- a/torchtnt/framework/auto_unit.py
+++ b/torchtnt/framework/auto_unit.py
@@ -494,7 +494,7 @@ class AutoUnit(
         if self.precision:
             self.grad_scaler = get_grad_scaler_from_precision(
                 self.precision,
-                self.module,
+                is_fsdp_module=_is_fsdp_module(self.module),
             )
 
         self.step_lr_interval = step_lr_interval

--- a/torchtnt/utils/fsdp_utils.py
+++ b/torchtnt/utils/fsdp_utils.py
@@ -1,0 +1,126 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+import importlib
+
+from dataclasses import dataclass
+from typing import List, Optional, Sequence, Type
+
+import torch
+
+from torch.distributed.fsdp import StateDictType as _StateDictType
+
+from torch.distributed.fsdp.fully_sharded_data_parallel import (
+    BackwardPrefetch as _BackwardPrefetch,
+    MixedPrecision as _MixedPrecision,
+    ShardingStrategy as _ShardingStrategy,
+)
+from torchtnt.utils.precision import convert_precision_str_to_dtype
+
+
+class ShardingStrategy:
+    """Supported values for `ShardingStrategy <https://pytorch.org/docs/stable/fsdp.html#torch.distributed.fsdp.ShardingStrategy>`_"""
+
+    FULL_SHARD = "FULL_SHARD"
+    SHARD_GRAD_OP = "SHARD_GRAD_OP"
+    NO_SHARD = "NO_SHARD"
+    HYBRID_SHARD = "HYBRID_SHARD"
+    _HYBRID_SHARD_ZERO2 = "_HYBRID_SHARD_ZERO2"
+
+    @staticmethod
+    def to_native_sharding_strategy(value: str) -> _ShardingStrategy:
+        """Convert a string to its PyTorch native ShardingStrategy."""
+        if value not in [
+            ShardingStrategy.FULL_SHARD,
+            ShardingStrategy.SHARD_GRAD_OP,
+            ShardingStrategy.NO_SHARD,
+            ShardingStrategy.HYBRID_SHARD,
+            ShardingStrategy._HYBRID_SHARD_ZERO2,
+        ]:
+            raise ValueError(f"Invalid ShardingStrategy '{value}'")
+
+        return _ShardingStrategy[value]
+
+
+class BackwardPrefetch:
+    """Supported values for `BackwardPrefetch <https://pytorch.org/docs/stable/fsdp.html#torch.distributed.fsdp.BackwardPrefetch>`_"""
+
+    BACKWARD_PRE = "BACKWARD_PRE"
+    BACKWARD_POST = "BACKWARD_POST"
+
+    @staticmethod
+    def to_native_backward_prefetch(value: str) -> _BackwardPrefetch:
+        """Convert a string to its PyTorch native BackwardPrefetch."""
+        if value not in [
+            BackwardPrefetch.BACKWARD_PRE,
+            BackwardPrefetch.BACKWARD_POST,
+        ]:
+            raise ValueError(f"Invalid BackwardPrefetch '{value}'")
+
+        return _BackwardPrefetch[value]
+
+
+class StateDictType:
+    """Supported values for `StateDictType <https://pytorch.org/docs/stable/fsdp.html>`_"""
+
+    FULL_STATE_DICT = "FULL_STATE_DICT"
+    LOCAL_STATE_DICT = "LOCAL_STATE_DICT"
+    SHARDED_STATE_DICT = "SHARDED_STATE_DICT"
+
+    @staticmethod
+    def to_native_state_dict_type(value: str) -> _StateDictType:
+        """Convert a string to its PyTorch native StateDictType."""
+        if value not in [
+            StateDictType.FULL_STATE_DICT,
+            StateDictType.LOCAL_STATE_DICT,
+            StateDictType.SHARDED_STATE_DICT,
+        ]:
+            raise ValueError(f"Invalid StateDictType '{value}'")
+
+        return _StateDictType[value]
+
+
+def _to_dtype_or_none(x: Optional[str]) -> Optional[torch.dtype]:
+    return convert_precision_str_to_dtype(x) if x else None
+
+
+@dataclass
+class MixedPrecision:
+    """Supported values for `MixedPrecision <https://pytorch.org/docs/stable/fsdp.html#torch.distributed.fsdp.MixedPrecision>`_"""
+
+    param_dtype: Optional[str] = None
+    reduce_dtype: Optional[str] = None
+    buffer_dtype: Optional[str] = None
+    keep_low_precision_grads: bool = False
+    cast_forward_inputs: bool = False
+    cast_root_forward_inputs: bool = True
+    _module_classes_to_ignore: Sequence[str] = (
+        "torch.nn.modules.batchnorm._BatchNorm",
+    )
+
+    def to_native_mixed_precision(self) -> _MixedPrecision:
+        """Convert this instance to its PyTorch native MixedPrecision."""
+
+        # Convert string module classes to their corresponding types
+        # e.g. "torch.nn.modules.batchnorm._BatchNorm" -> torch.nn.modules.batchnorm._BatchNorm
+        target_types: List[Type[torch.nn.Module]] = []
+        for type_str in self._module_classes_to_ignore:
+            path, _, attr = type_str.rpartition(".")
+            try:
+                target_types.append(getattr(importlib.import_module(path), attr))
+            except (AttributeError, ModuleNotFoundError) as e:
+                raise ValueError(f"Invalid module class '{type_str}': {e}")
+        module_classes_to_ignore: Sequence[Type[torch.nn.Module]] = target_types
+
+        return _MixedPrecision(
+            param_dtype=_to_dtype_or_none(self.param_dtype),
+            reduce_dtype=_to_dtype_or_none(self.reduce_dtype),
+            buffer_dtype=_to_dtype_or_none(self.buffer_dtype),
+            keep_low_precision_grads=self.keep_low_precision_grads,
+            cast_forward_inputs=self.cast_forward_inputs,
+            cast_root_forward_inputs=self.cast_root_forward_inputs,
+            _module_classes_to_ignore=module_classes_to_ignore,
+        )

--- a/torchtnt/utils/precision.py
+++ b/torchtnt/utils/precision.py
@@ -11,7 +11,6 @@ from typing import Mapping, Optional
 
 import torch
 from torch.cuda.amp.grad_scaler import GradScaler
-from torchtnt.utils.prepare_module import _is_fsdp_module
 
 _DTYPE_STRING_TO_DTYPE_MAPPING: Mapping[str, Optional[torch.dtype]] = {
     "fp16": torch.float16,
@@ -39,7 +38,7 @@ def convert_precision_str_to_dtype(precision: str) -> Optional[torch.dtype]:
 
 
 def get_grad_scaler_from_precision(
-    precision: torch.dtype, module: torch.nn.Module
+    precision: torch.dtype, *, is_fsdp_module: Optional[bool] = False
 ) -> Optional[torch.amp.GradScaler]:
     """
     Returns the correct grad scaler to use based on the precision and whether
@@ -47,14 +46,14 @@ def get_grad_scaler_from_precision(
 
     Args:
         precision: the precision being used
-        module: the module being trained
+        is_fsdp_module: whether the grad scaler is for an FSDP module
 
     Returns:
         The appropriate grad scaler to use, ``None`` if no grad scaler should be used.
     """
 
     if precision == torch.float16:
-        if _is_fsdp_module(module):
+        if is_fsdp_module:
             from torch.distributed.fsdp.sharded_grad_scaler import ShardedGradScaler
 
             return ShardedGradScaler()


### PR DESCRIPTION
Summary:
In addition to using torch.distributed enum classes, use standard
classes and strings, then convert them to allow simpler instantiation of
FSDPStrategy.

Differential Revision: D54568599


