### PR TITLE
remove DDP + static_graph=True check for torch compile

### DIFF
--- a/torchtnt/utils/__init__.py
+++ b/torchtnt/utils/__init__.py
@@ -83,6 +83,7 @@ from .version import (
     is_torch_version_geq_1_8,
     is_torch_version_geq_1_9,
     is_torch_version_geq_2_0,
+    is_torch_version_geq_2_1,
     is_windows,
 )
 
@@ -161,6 +162,7 @@ __all__ = [
     "is_torch_version_geq_1_8",
     "is_torch_version_geq_1_9",
     "is_torch_version_geq_2_0",
+    "is_torch_version_geq_2_1",
     "is_windows",
     "get_pet_launch_config",
     "spawn_multi_process",

--- a/torchtnt/utils/version.py
+++ b/torchtnt/utils/version.py
@@ -90,3 +90,7 @@ def is_torch_version_geq_1_14() -> bool:
 
 def is_torch_version_geq_2_0() -> bool:
     return get_torch_version() >= Version("2.0.0")
+
+
+def is_torch_version_geq_2_1() -> bool:
+    return get_torch_version() >= Version("2.1.0")


### PR DESCRIPTION
Summary: torch compile with DDP + static_graph=True actually works, so removing the check in `prepare_module`

Differential Revision: D52064353


