### PR TITLE
pin python version to 3.10 in build docs

### DIFF
--- a/.github/workflows/build_and_publish_docs.yaml
+++ b/.github/workflows/build_and_publish_docs.yaml
@@ -23,6 +23,7 @@ jobs:
         with:
           miniconda-version: "latest"
           activate-environment: test
+          python-version: "3.10"
       - name: Install dependencies
         shell: bash -l {0}
         run: |

--- a/.github/workflows/build_docs.yaml
+++ b/.github/workflows/build_docs.yaml
@@ -19,6 +19,7 @@ jobs:
         with:
           miniconda-version: "latest"
           activate-environment: test
+          python-version: "3.10"
       - name: Install dependencies
         shell: bash -l {0}
         run: |


### PR DESCRIPTION
Summary:
# Context
Were seeing following error
```
The HTML pages are in build/html.
Exception in thread Thread-1:
Traceback (most recent call last):
  File "/usr/share/miniconda3/envs/test/lib/python3.12/threading.py", line 1073, in _bootstrap_inner
    self.run()
  File "/usr/share/miniconda3/envs/test/lib/python3.12/concurrent/futures/process.py", line 389, in run
    self.join_executor_internals()
  File "/usr/share/miniconda3/envs/test/lib/python3.12/concurrent/futures/process.py", line 576, in join_executor_internals
    self._join_executor_internals()
  File "/usr/share/miniconda3/envs/test/lib/python3.12/concurrent/futures/process.py", line 581, in _join_executor_internals
    self.shutdown_workers()
  File "/usr/share/miniconda3/envs/test/lib/python3.12/concurrent/futures/process.py", line 569, in shutdown_workers
    self.call_queue.put_nowait(None)
  File "/usr/share/miniconda3/envs/test/lib/python3.12/multiprocessing/queues.py", line 138, in put_nowait
    return self.put(obj, False)
           ^^^^^^^^^^^^^^^^^^^^
  File "/usr/share/miniconda3/envs/test/lib/python3.12/multiprocessing/queues.py", line 94, in put
    self._start_thread()
  File "/usr/share/miniconda3/envs/test/lib/python3.12/multiprocessing/queues.py", line 192, in _start_thread
    self._thread.start()
  File "/usr/share/miniconda3/envs/test/lib/python3.12/threading.py", line 992, in start
    _start_new_thread(self._bootstrap, ())
RuntimeError: can't create new thread at interpreter shutdown
Error: The operation was canceled.
```
when docs were building. As explained [here](https://stackoverflow.com/questions/77738120/runtimeerror-cant-create-new-thread-at-interpreter-shutdown), caused by 3.12 not allowing new thread to spawn after main thread is finished.

# This Diff
Pins python version to 3.10 when buliding docs

Differential Revision: D54773246


