### PR TITLE
Fix flop.py type annotation for Python<3.9

### DIFF
--- a/torchtnt/utils/flops.py
+++ b/torchtnt/utils/flops.py
@@ -22,7 +22,7 @@ from torch.utils._pytree import PyTree, tree_map
 
 aten: torch._ops._OpNamespace = torch.ops.aten
 T = TypeVar("T")
-InputType = Union[torch.Tensor, bool, tuple[bool]]
+InputType = Union[torch.Tensor, bool, Tuple[bool]]
 
 
 def _matmul_flop_jit(inputs: Tuple[torch.Tensor], _outputs: Tuple[Any]) -> Number:


### PR DESCRIPTION
Differential Revision: D55031656


