### PR TITLE
wiki nit: AutoUnit make session optional string

### DIFF
--- a/docs/source/overview.rst
+++ b/docs/source/overview.rst
@@ -144,7 +144,7 @@ The :class:`~torchtnt.framework.auto_unit.AutoUnit` implements the TrainUnit, Ev
             self,
             module: torch.nn.Module,
             device: torch.device,
-            strategy: str,
+            strategy: Optional[str],
             precision: Optional[str],
             gradient_accumulation_steps: int,
             *,


### PR DESCRIPTION
Summary:
nit for TorchTNT wiki: https://www.internalfb.com/intern/staticdocs/torchtnt/overview.html

for n00bs like me, it’s likely much better to start with strategy=None
{F1482904808}

Reviewed By: galrotem

Differential Revision: D55947333


