### PR TITLE
[DCP][TNT] Avoid splitting files if num_threads is 1

### DIFF
--- a/torchtnt/framework/callbacks/dcp_saver.py
+++ b/torchtnt/framework/callbacks/dcp_saver.py
@@ -272,7 +272,8 @@ class DistributedCheckpointSaver(BaseCheckpointer):
         dcp_options = {
             "thread_count": self._knob_options.max_per_rank_io_concurrency or 16,
             "sync_files": False,
-            "single_file_per_rank": False,
         }
+        if dcp_options["thread_count"] > 1:
+            dcp_options["single_file_per_rank"] = False
 
         return dcp_options


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #788
* __->__ #787

Splitting files only provides performance gains in the threaded case, additionally it's been noted that splitting files increases likelihood of hitting manifold quotas

Differential Revision: [D56065261](https://our.internmc.facebook.com/intern/diff/D56065261/)

**NOTE FOR REVIEWERS**: This PR has internal Meta-specific changes or comments, please review them on [Phabricator](https://our.internmc.facebook.com/intern/diff/D56065261/)!