### PR TITLE
Fix the PyTorch Profiler link in staticdocs

### DIFF
--- a/torchtnt/framework/callbacks/dcp_saver.py
+++ b/torchtnt/framework/callbacks/dcp_saver.py
@@ -59,7 +59,7 @@ except ModuleNotFoundError:
 
 class DistributedCheckpointSaver(BaseCheckpointer):
     """
-    A callback which periodically saves the application state during training using `Distributed Checkpoint <https://pytorch.org/docs/stable/distributed.checkpoint.html/>`_.
+    A callback which periodically saves the application state during training using `Distributed Checkpoint <https://pytorch.org/docs/stable/distributed.checkpoint.html>`_.
 
     This callback supplements the application state provided by :class:`torchtnt.unit.AppStateMixin`
     with the train progress, and train dataloader (if applicable).

--- a/torchtnt/framework/callbacks/pytorch_profiler.py
+++ b/torchtnt/framework/callbacks/pytorch_profiler.py
@@ -15,7 +15,7 @@ from torchtnt.framework.unit import TEvalUnit, TPredictUnit, TTrainUnit
 
 class PyTorchProfiler(Callback):
     """
-    A callback which profiles user code using `PyTorch Profiler <https://pytorch.org/docs/stable/profiler.html/>`_.
+    A callback which profiles user code using `PyTorch Profiler <https://pytorch.org/docs/stable/profiler.html>`_.
 
     Args:
         profiler: a torch.profiler.profile context manager which will be used


### PR DESCRIPTION
Summary: The extra `/` causes a 404 error if you actually click on the link

Differential Revision: D56848751
