### PR TITLE
Configurable planner and storage writer in the dcp saver save API

### DIFF
--- a/torchtnt/framework/callbacks/checkpointer_types.py
+++ b/torchtnt/framework/callbacks/checkpointer_types.py
@@ -14,13 +14,20 @@ from typing import Optional
 @dataclass
 class KnobOptions:
     """
-    Controls the knobs in TorchSnapshot.
+    Controls the knobs for Checkpoints.
 
     Args:
-        max_per_rank_io_concurrency: Maximum number of concurrent IO operations per rank. Defaults to 16.
+        max_per_rank_io_concurrency: Maximum number of concurrent IO operations per rank in checkpointing.
+                                     Defaults to 16.
+        enable_storage_optimization: Enable storage efficiency optimizations for Distributed Checkpointing.
     """
 
+    # use a more conservative number of concurrent IO operations per rank in Checkpointing
+    # the default value of 16 is too bandwidth hungry for most users
     max_per_rank_io_concurrency: Optional[int] = None
+    # This is a no-op and for future use. This would enable storage efficiency optimizations:
+    # e.g. Compression, Batching, Quantization etc.
+    enable_storage_optimization: bool = False
 
 
 @dataclass


### PR DESCRIPTION
Summary:
Configurable planner and storage writer in the DCP saver save API.

# This Stack
DCP saver is the TorchTNT callback which allows checkpointing via the Distributed Checkpointing APIs. Current implementation doesn't expose the Save Planner and Storage Writer in the API for clients to plug in their implementations. It enforces the default planner and FsspecWriter. 


# This diff
- DCP save and async save APIs now support planner and storage writer allowing clients to plug in their implementations.
- Introduces a knob option to plug in storage writer component with storage efficiency optimizations

Differential Revision: D56921724


