### PR TITLE
Configurable load planner and storage reader in the dcp_saver restore API

### DIFF
--- a/torchtnt/framework/callbacks/checkpointer_types.py
+++ b/torchtnt/framework/callbacks/checkpointer_types.py
@@ -14,13 +14,18 @@ from typing import Optional
 @dataclass
 class KnobOptions:
     """
-    Controls the knobs in TorchSnapshot.
+    Controls the knobs for Checkpoints.
 
     Args:
-        max_per_rank_io_concurrency: Maximum number of concurrent IO operations per rank. Defaults to 16.
+        max_per_rank_io_concurrency: Maximum number of concurrent IO operations per rank in checkpointing.
+                                     Defaults to 16.
+        enable_storage_optimization: Enable storage efficiency optimizations for Distributed Checkpointing.
     """
 
+    # use a more conservative number of concurrent IO operations per rank in TorchSnapshot
+    # the default value of 16 is too bandwidth hungry for most users
     max_per_rank_io_concurrency: Optional[int] = None
+    enable_storage_optimization: bool = False
 
 
 @dataclass


### PR DESCRIPTION
Summary:
Configurable load planner and storage reader in the dcp_saver restore API

# This Stack
DCP saver is the TorchTNT callback which allows checkpointing via the Distributed Checkpointing APIs. Current implementation for the Restore API doesn't expose the Load Planner and Storage Reader in the API for clients to plug in their implementations. It enforces the default planner and FsspecReader.


# This diff
DCP saver Restore API now supports planner and storage reader allowing clients to plug in their implementations.

Differential Revision: D56922769


