### PR TITLE
[DCP] fix broken dcp_saver test

### DIFF
--- a/tests/framework/callbacks/test_dcp_saver.py
+++ b/tests/framework/callbacks/test_dcp_saver.py
@@ -298,7 +298,7 @@ class DummyStatefulDataLoader:
 
     def state_dict(self) -> Dict[str, Any]:
         self.state_dict_call_count += 1
-        return {}
+        return {"some_data": 1}
 
     def load_state_dict(self, state_dict: Dict[str, Any]) -> None:
         self.load_state_dict_call_count += 1


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #828

If keys are empty, it seems they are removed during flattening (a step in dcp.save).

Accounting for this change fixes the test

Differential Revision: [D57126080](https://our.internmc.facebook.com/intern/diff/D57126080/)

**NOTE FOR REVIEWERS**: This PR has internal Meta-specific changes or comments, please review them on [Phabricator](https://our.internmc.facebook.com/intern/diff/D57126080/)!