### PR TITLE
pin numpy version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 torch
-numpy
+numpy==1.24.4
 fsspec
 tensorboard
 packaging


### PR DESCRIPTION
Summary: pin numpy to 1.26.4

Differential Revision: D58888864
