### PR TITLE
add loss_backward_retain_graph to __init__()

### DIFF
--- a/torchtnt/framework/auto_unit.py
+++ b/torchtnt/framework/auto_unit.py
@@ -434,6 +434,10 @@ class AutoUnit(
         activation_checkpoint_params: params for enabling activation checkpointing
         training: if True, the optimizer and optionally LR scheduler will be created after the class is initialized.
         enable_compiled_autograd: if True, `compiled_autograd` will be used to compile the backward, this is an experimental flag.
+        loss_backward_retain_graph:  If ``None`` or ``False``, the graph used to compute
+        the grads will be freed during loss backward pass. Note that in nearly all cases setting
+        this option to True is not needed and often can be worked around
+        in a much more efficient way.
 
     Note:
         Certain strategies, like :class:`~torchtnt.utils.prepare_module.FSDPStrategy` also support mixed precision as an argument, so can be configured through that class as well.
@@ -463,6 +467,7 @@ class AutoUnit(
         activation_checkpoint_params: Optional[ActivationCheckpointParams] = None,
         training: bool = True,
         enable_compiled_autograd: bool = False,
+        loss_backward_retain_graph: Optional[bool] = None,
     ) -> None:
         super().__init__(
             module=module,
@@ -526,6 +531,7 @@ class AutoUnit(
 
         self.enable_compiled_autograd = enable_compiled_autograd
         self.training = training
+        self.loss_backward_retain_graph = loss_backward_retain_graph
 
         self.optimizer: Optional[torch.optim.Optimizer] = None
         self.lr_scheduler: Optional[TLRScheduler] = None
@@ -625,7 +631,7 @@ class AutoUnit(
                     with get_timing_context(
                         state, f"{self.__class__.__name__}.backward"
                     ):
-                        loss.backward()
+                        loss.backward(retain_graph=self.loss_backward_retain_graph)
 
         total_grad_norm = None
         if should_update_weights:


### PR DESCRIPTION
Summary:
Mask2Former (M2F) Executorch QAT model has its 5 top-level submodules prepared separately (https://fburl.com/code/44qk8qu3).
This is because the model graph during a) QAT training b) QAT evaluation c) ET model export time are different.
- We empirically find to train such ET QAT model, we need to turn on **loss.backward(retain_graph=True)** in train step. Otherwise, the training step will fail as in P1447579952.
- Thus, we add a new **loss_backward_retain_graph** to AutoUnit.__init__() to allow the user to have control on **retain_graph** kwargs.
- Note this change is back-compatible.

Differential Revision: D58901158
