### PR TITLE
Attempt to extend nccl collective timeout

### DIFF
--- a/tests/utils/test_checkpoint_gpu.py
+++ b/tests/utils/test_checkpoint_gpu.py
@@ -24,9 +24,7 @@ class TestCheckpointUtilsGPU(unittest.TestCase):
     @skip_if_not_gpu
     def test_get_checkpoint_dirpaths_distributed(self) -> None:
         spawn_multi_process(
-            2,
-            "nccl",
-            self._test_get_checkpoint_dirpaths,
+            2, "nccl", self._test_get_checkpoint_dirpaths, timeout_s=180
         )
 
     @staticmethod

--- a/tests/utils/test_distributed_gpu.py
+++ b/tests/utils/test_distributed_gpu.py
@@ -52,6 +52,7 @@ class DistributedGPUTest(unittest.TestCase):
             2,
             "nccl",
             self._test_pg_wrapper_scatter_object_list,
+            timeout_s=180,
         )
 
     @classmethod


### PR DESCRIPTION
Summary:
We have two remaining tests that are still failing, with the following error message:

```
[Rank 1] Watchdog caught collective operation timeout: WorkNCCL(SeqNum=1, OpType=BROADCAST, NumelIn=2, NumelOut=2, Timeout(ms)=60000) ran for 60033 milliseconds before timing out.
```

Let's attempt to increase the collective timeout for those tests. There's no guarantee this will work, but it's worth trying. Otherwise we may consider deleting the failing tests to avoid flakyness.

Reviewed By: galrotem

Differential Revision: D59342738
