### PR TITLE
improve logging at epoch boundary

### DIFF
--- a/torchtnt/framework/_loop_utils.py
+++ b/torchtnt/framework/_loop_utils.py
@@ -43,6 +43,27 @@ def _is_epoch_done(
     )
 
 
+def _reason_epoch_completed(
+    progress: Progress,
+    max_steps_per_epoch: Optional[int],
+    max_steps: Optional[int],
+    stop_iteration_reached: bool,
+) -> str:
+    current_epoch = progress.num_epochs_completed
+    if stop_iteration_reached:
+        return (
+            f"Train epoch {current_epoch} ended as it reached end of train dataloader"
+        )
+    elif (
+        max_steps_per_epoch is not None
+        and progress.num_steps_completed_in_epoch >= max_steps_per_epoch
+    ):
+        return f"Train epoch {current_epoch} ended as max steps per epoch reached: {max_steps_per_epoch}"
+    elif max_steps is not None and progress.num_steps_completed >= max_steps:
+        return f"Train epoch {current_epoch} ended as max steps reached: {max_steps}"
+    return f"Unable to determine reason for stopping train epoch {current_epoch}"
+
+
 @runtime_checkable
 class _DistributedSampler(Protocol):
     def set_epoch(self, epoch: int) -> None: ...

--- a/torchtnt/framework/evaluate.py
+++ b/torchtnt/framework/evaluate.py
@@ -137,6 +137,7 @@ def _evaluate_impl(
 
     prev_steps_in_epoch = eval_unit.eval_progress.num_steps_completed_in_epoch
 
+    stop_iteration_reached = False
     while not (
         state.should_stop
         or _is_epoch_done(
@@ -162,7 +163,17 @@ def _evaluate_impl(
                 # clear step_output to avoid retaining extra memory
                 eval_state._step_output = None
         except StopIteration:
+            stop_iteration_reached = True
             break
+
+    if stop_iteration_reached:
+        entry_point = "evaluation"
+        if state.entry_point == EntryPoint.FIT:
+            entry_point = "fit"
+        logger.info(f"Reached end of eval dataloader during {entry_point}")
+    logger.info(
+        f"Finished evaluation epoch in {eval_unit.eval_progress.num_steps_completed_in_epoch} steps"
+    )
 
     # Possibly warn about an empty dataloader
     any_steps_completed = (

--- a/torchtnt/framework/predict.py
+++ b/torchtnt/framework/predict.py
@@ -143,6 +143,7 @@ def _predict_impl(
 
     prev_steps_in_epoch = predict_unit.predict_progress.num_steps_completed_in_epoch
 
+    stop_iteration_reached = False
     while not (
         state.should_stop
         or _is_epoch_done(
@@ -170,7 +171,14 @@ def _predict_impl(
                 # clear step_output to avoid retaining extra memory
                 predict_state._step_output = None
         except StopIteration:
+            stop_iteration_reached = True
             break
+
+    if stop_iteration_reached:
+        logger.info("Reached end of predict dataloader")
+    logger.info(
+        f"Finished prediction in {predict_unit.predict_progress.num_steps_completed_in_epoch} steps"
+    )
 
     # Possibly warn about an empty dataloader
     any_steps_completed = (


### PR DESCRIPTION
Summary:
# Context
For debugging purposes, we want to know for what reason the train epoch ends

# This Diff
Logs the reason for train epoch ending. Also adds logs in evaluate epoch if dataloader is exhausted

Differential Revision: D59661508
