### PR TITLE
enable prefetch in autounit

### DIFF
--- a/tests/framework/test_auto_unit.py
+++ b/tests/framework/test_auto_unit.py
@@ -642,6 +642,17 @@ class TestAutoUnit(unittest.TestCase):
             },
         )
 
+    def test_enable_prefetch(self) -> None:
+        data = [1, 2, 3]
+        auto_unit = DummyAutoUnit(module=torch.nn.Linear(2, 2), enable_prefetch=True)
+
+        _ = auto_unit._get_next_batch(get_dummy_train_state(), iter(data))
+        self.assertEqual(auto_unit._phase_to_next_batch[ActivePhase.TRAIN], 2)
+
+        auto_unit = DummyAutoUnit(module=torch.nn.Linear(2, 2), enable_prefetch=False)
+        _ = auto_unit._get_next_batch(get_dummy_train_state(), iter(data))
+        self.assertIsNone(auto_unit._phase_to_next_batch[ActivePhase.TRAIN])
+
 
 Batch = Tuple[torch.Tensor, torch.Tensor]
 


### PR DESCRIPTION
Summary:
# Context
Users cannot disable prefetch in auto unit

# This diff
Adds `enable_prefetch` flag to auto unit which can be used to disable if needed.

Differential Revision: D59980065
