### PR TITLE
Use `torch.amp` instead of `torch.cuda.amp`

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-torch
+torch>=2.3.0
 numpy==1.24.4
 fsspec
 tensorboard

--- a/tests/framework/test_app_state_mixin.py
+++ b/tests/framework/test_app_state_mixin.py
@@ -32,7 +32,7 @@ class Dummy(AppStateMixin):
         self.lr_scheduler_d = torch.optim.lr_scheduler.StepLR(
             self.optimizer_c, step_size=30, gamma=0.1
         )
-        self.grad_scaler_e = torch.cuda.amp.GradScaler()
+        self.grad_scaler_e = torch.amp.GradScaler("cuda")
         self.optimizer_class_f = torch.optim.SGD
 
 
@@ -218,7 +218,7 @@ class AppStateMixinTest(unittest.TestCase):
                 self.lr_2 = torch.optim.lr_scheduler.StepLR(
                     self.optimizer_placeholder, step_size=50, gamma=0.3
                 )
-                self.grad_scaler_e = torch.cuda.amp.GradScaler()
+                self.grad_scaler_e = torch.amp.GradScaler("cuda")
 
             def tracked_modules(self) -> Dict[str, nn.Module]:
                 ret = super().tracked_modules()
@@ -235,7 +235,7 @@ class AppStateMixinTest(unittest.TestCase):
 
             def tracked_misc_statefuls(self) -> Dict[str, Any]:
                 ret = super().tracked_misc_statefuls()
-                ret["another_scaler"] = torch.cuda.amp.GradScaler()
+                ret["another_scaler"] = torch.amp.GradScaler("cuda")
                 return ret
 
         o = Override()
@@ -266,6 +266,6 @@ class AppStateMixinTest(unittest.TestCase):
         ):
             result = auto_unit._construct_tracked_optimizers_and_schedulers()
 
-        self.assertTrue(isinstance(result["optimizer"], FSDPOptimizerWrapper))
-        self.assertTrue(isinstance(result["optim2"], torch.optim.Optimizer))
-        self.assertTrue(isinstance(result["lr_scheduler"], TLRScheduler))
+        self.assertIsInstance(result["optimizer"], FSDPOptimizerWrapper)
+        self.assertIsInstance(result["optim2"], torch.optim.Optimizer)
+        self.assertIsInstance(result["lr_scheduler"], TLRScheduler)

--- a/tests/framework/test_auto_unit.py
+++ b/tests/framework/test_auto_unit.py
@@ -62,11 +62,9 @@ class TestAutoUnit(unittest.TestCase):
         )
 
         self.assertEqual(auto_unit.tracked_modules()["module"], my_module)
-        self.assertTrue(
-            isinstance(
-                auto_unit.tracked_misc_statefuls()["grad_scaler"],
-                torch.cuda.amp.GradScaler,
-            )
+        self.assertIsInstance(
+            auto_unit.tracked_misc_statefuls()["grad_scaler"],
+            torch.amp.GradScaler,
         )
         for key in ("module", "optimizer", "lr_scheduler", "grad_scaler"):
             self.assertIn(key, auto_unit.app_state())

--- a/tests/utils/test_precision.py
+++ b/tests/utils/test_precision.py
@@ -10,7 +10,7 @@
 import unittest
 
 import torch
-from torch.cuda.amp.grad_scaler import GradScaler
+from torch.amp.grad_scaler import GradScaler
 from torch.distributed.fsdp.sharded_grad_scaler import ShardedGradScaler
 
 from torchtnt.utils.precision import (
@@ -49,7 +49,7 @@ class PrecisionTest(unittest.TestCase):
         grad_scaler = get_grad_scaler_from_precision(
             torch.float16, is_fsdp_module=False
         )
-        self.assertTrue(isinstance(grad_scaler, GradScaler))
+        self.assertIsInstance(grad_scaler, GradScaler)
 
         grad_scaler = get_grad_scaler_from_precision(torch.float16, is_fsdp_module=True)
-        self.assertTrue(isinstance(grad_scaler, ShardedGradScaler))
+        self.assertIsInstance(grad_scaler, ShardedGradScaler)

--- a/torchtnt/utils/precision.py
+++ b/torchtnt/utils/precision.py
@@ -10,12 +10,7 @@
 from typing import Mapping, Optional
 
 import torch
-from torch.cuda.amp.grad_scaler import GradScaler as CudaGradScaler
-
-try:
-    from torch.amp.grad_scaler import GradScaler
-except Exception:
-    GradScaler = CudaGradScaler
+from torch.amp.grad_scaler import GradScaler
 
 _DTYPE_STRING_TO_DTYPE_MAPPING: Mapping[str, Optional[torch.dtype]] = {
     "fp16": torch.float16,
@@ -63,5 +58,5 @@ def get_grad_scaler_from_precision(
 
             return ShardedGradScaler()
         else:
-            return CudaGradScaler()
+            return GradScaler("cuda")
     return None


### PR DESCRIPTION
Summary:
`torch.cuda.amp` throws up some deprecation warnings, so let's jus use `torch.amp` instead.

This requires Pytorch 2.3+, so I've also modified the requirements.txt to add a minimum supported torch version.

Differential Revision: D61151603
