### PR TITLE
call on_checkpoint_save on the unit object after saving a checkpoint

### DIFF
--- a/torchtnt/framework/callbacks/base_checkpointer.py
+++ b/torchtnt/framework/callbacks/base_checkpointer.py
@@ -215,6 +215,9 @@ class BaseCheckpointer(Callback, metaclass=abc.ABCMeta):
         # 4) track checkpoint and clean up surplus if needed
         self._checkpoint_manager.append_checkpoint(checkpoint_path)
 
+        # 5) invoke on_checkpoint_save callback on the unit since checkpoint was saved successfully
+        unit.on_checkpoint_save(state, checkpoint_id=checkpoint_path.path)
+
         return True
 
     def _does_checkpoint_exist(

--- a/torchtnt/framework/unit.py
+++ b/torchtnt/framework/unit.py
@@ -341,6 +341,16 @@ class TrainUnit(AppStateMixin, _OnExceptionMixin, Generic[TTrainData], ABC):
         """
         pass
 
+    def on_checkpoint_save(self, state: State, checkpoint_id: str) -> None:
+        """Hook called after successfully saving a checkpoint.
+
+        Args:
+            state: a :class:`~torchtnt.framework.state.State` object containing metadata about the training run.
+            checkpoint_id: the ID of the checkpoint that was saved. Depending on the storage type, this may be
+                           a path, a URL or a unique identifier.
+        """
+        pass
+
     def get_next_train_batch(
         self,
         state: State,
@@ -444,6 +454,16 @@ class EvalUnit(AppStateMixin, _OnExceptionMixin, Generic[TEvalData], ABC):
 
         Args:
             state: a :class:`~torchtnt.framework.state.State` object containing metadata about the evaluation run.
+        """
+        pass
+
+    def on_checkpoint_save(self, state: State, checkpoint_id: str) -> None:
+        """Hook called after successfully saving a checkpoint.
+
+        Args:
+            state: a :class:`~torchtnt.framework.state.State` object containing metadata about the training run.
+            checkpoint_id: the ID of the checkpoint that was saved. Depending on the storage type, this may be
+                           a path, a URL or a unique identifier.
         """
         pass
 


### PR DESCRIPTION
Summary: In this diff we are adding a `on_checkpoint_save` method in `TrainUnit` and `EvalUnit`. This method would be invoked by the checkpointer when it saves a checkpoint successfully.

Differential Revision: D61256660
