### PR TITLE
AutoUnit non_blocking=True

### DIFF
--- a/torchtnt/framework/auto_unit.py
+++ b/torchtnt/framework/auto_unit.py
@@ -259,7 +259,7 @@ class _AutoUnitMixin(Generic[TData]):
     def _get_next_batch(self, state: State, data: Iterator[TData]) -> TData:
         if not self._enable_prefetch:
             batch = next(data)
-            return self.move_data_to_device(state, batch, non_blocking=False)
+            return self.move_data_to_device(state, batch, non_blocking=True)
 
         active_phase = state.active_phase
         if not self._phase_to_prefetched[active_phase]:


### PR DESCRIPTION
Summary:
# Context
When adding flag which disabled prefetch from AutoUnit, I made the default `non_blocking=False` when moving batch from cpu->gpu.

User here: https://fb.workplace.com/groups/1323951304836028/permalink/1718731732024648/ makes good point to make these async

# This DIff
Changes to `non_blocking=True`

Differential Revision: D61831174
