### PR TITLE
Name the forward pass thread in the trainer loop

### DIFF
--- a/torchtnt/framework/predict.py
+++ b/torchtnt/framework/predict.py
@@ -24,6 +24,7 @@ from torchtnt.framework.state import ActivePhase, EntryPoint, PhaseState, State
 from torchtnt.framework.unit import TPredictData, TPredictUnit
 from torchtnt.framework.utils import get_timing_context
 from torchtnt.utils.timer import get_timer_summary, TimerProtocol
+from torchtnt.utils.version import is_torch_version_geq
 
 logger: logging.Logger = logging.getLogger(__name__)
 
@@ -170,6 +171,21 @@ def _predict_impl(
 
                 # clear step_output to avoid retaining extra memory
                 predict_state._step_output = None
+
+            if (
+                predict_unit.predict_progress.num_steps_completed_in_epoch
+                - prev_steps_in_epoch
+                == 5
+            ):
+                # Set the trainer thread name to improve debuggability. We do it after
+                # 5 iterations to make sure that all the processes or thread pools
+                # spawned / forked from the current process have already been created
+                # and the trainer_main characterizes only the CPU thread that runs the
+                # forward pass and schedules GPU work.
+                if is_torch_version_geq("2.5.0"):
+                    if torch.multiprocessing._get_thread_name() != "trainer_main":
+                        torch.multiprocessing._set_thread_name("trainer_main")
+
         except StopIteration:
             stop_iteration_reached = True
             break

--- a/torchtnt/framework/train.py
+++ b/torchtnt/framework/train.py
@@ -27,6 +27,7 @@ from torchtnt.framework.state import ActivePhase, EntryPoint, PhaseState, State
 from torchtnt.framework.unit import TTrainData, TTrainUnit
 from torchtnt.framework.utils import get_timing_context
 from torchtnt.utils.timer import get_timer_summary, TimerProtocol
+from torchtnt.utils.version import is_torch_version_geq
 
 logger: logging.Logger = logging.getLogger(__name__)
 
@@ -220,6 +221,20 @@ def _train_epoch_impl(
 
                 # clear step_output to avoid retaining extra memory
                 train_state._step_output = None
+
+            if (
+                train_unit.train_progress.num_steps_completed_in_epoch
+                - prev_steps_in_epoch
+                == 5
+            ):
+                # Set the trainer thread name to improve debuggability. We do it after
+                # 5 iterations to make sure that all the processes or thread pools
+                # spawned / forked from the current process have already been created
+                # and the trainer_main characterizes only the CPU thread that runs the
+                # forward pass and schedules GPU work.
+                if is_torch_version_geq("2.5.0"):
+                    if torch.multiprocessing._get_thread_name() != "trainer_main":
+                        torch.multiprocessing._set_thread_name("trainer_main")
 
             if (
                 evaluate_every_n_steps


### PR DESCRIPTION
Summary:
Internal
# Context
With the sched_ext effort we are trying to build custom Linux schedulers that provide a small performance boost to AI training and improve the resource isolation on the trainer hosts. The latter is necessary to avoid cases when noisy neighbor processes, like data loaders, slow down the GPU training.

More details in this note: https://fb.workplace.com/notes/1118655556176038

By naming the forward pass thread we can use its name and assign it a higher priority at the linux scheduler level. The backward pass is named inside the Pytorch implementation but the forward pass needs to be named at the application level.

We did the same thing in PyPer, APS, MVAI which are the largest trainer frameworks for reco models, consuming 70%+ of fleet level GPU hours for recommender systems.

# This Diff
Adds core lines
```
if torch.multiprocessing._get_thread_name() != "trainer_main":
    torch.multiprocessing._set_thread_name("trainer_main")
```
to train/eval/predict scripts. We can check the preexisting name to avoid renaming the same thread.

Reviewed By: diego-urgell

Differential Revision: D61924982
