### PR TITLE
Fix progress bar new line issue in create_progress_bar

### DIFF
--- a/torchtnt/utils/tqdm.py
+++ b/torchtnt/utils/tqdm.py
@@ -49,7 +49,7 @@ def create_progress_bar(
         desc=f"{desc} {current_epoch}",
         total=total,
         initial=num_steps_completed,
-        bar_format="{l_bar}{bar}{r_bar}\n",
+        bar_format="{l_bar}{bar}{r_bar}",
         file=file,
     )
 


### PR DESCRIPTION
- Removed the trailing newline character (\n) from bar_format in tqdm.
- This ensures the progress bar remains on the same line during updates, improving terminal output readability.

Please read through our [contribution guide](https://github.com/pytorch/tnt/blob/main/CONTRIBUTING.md) prior to creating your pull request.

Summary:
<!-- Change Summary -->

Test plan:
<!--  How you tested the change, ideally with a unit test :) -->

Fixes #{issue number}
<!-- Link the issue this pull request fixes -->
