### PR TITLE
Fix typos in get_next_train_batch and get_next_eval_batch in auto_unit

### DIFF
--- a/torchtnt/framework/auto_unit.py
+++ b/torchtnt/framework/auto_unit.py
@@ -876,7 +876,7 @@ class AutoUnit(
     def get_next_train_batch(
         self, state: State, data_iter: Iterator[TData]
     ) -> Union[Iterator[TData], TData]:
-        # Override the default behavior from PredictUnit in order to enable prefetching if possible.
+        # Override the default behavior from TrainUnit in order to enable prefetching if possible.
         pass_data_iter_to_step = _step_requires_iterator(self.train_step)
         if pass_data_iter_to_step:
             return data_iter
@@ -885,7 +885,7 @@ class AutoUnit(
     def get_next_eval_batch(
         self, state: State, data_iter: Iterator[TData]
     ) -> Union[Iterator[TData], TData]:
-        # Override the default behavior from PredictUnit in order to enable prefetching if possible.
+        # Override the default behavior from EvalUnit in order to enable prefetching if possible.
         pass_data_iter_to_step = _step_requires_iterator(self.eval_step)
         if pass_data_iter_to_step:
             return data_iter


### PR DESCRIPTION
In `torchtnt.framework.auto_unit.py`,

The old comments have "PredictUnit" in `get_next_train_batch` and `get_next_eval_batch`, which could be a copy-pasta typo from `get_next_predict_batch`. 

The new comments change from "PredictUnit" to "TrainUnit" in  `get_next_train_batch` and "EvalUnit" in `get_next_eval_batch`.
