### PR TITLE
enable storage optimization by default

### DIFF
--- a/torchtnt/framework/callbacks/checkpointer_types.py
+++ b/torchtnt/framework/callbacks/checkpointer_types.py
@@ -25,9 +25,9 @@ class KnobOptions:
     # use a more conservative number of concurrent IO operations per rank in Checkpointing
     # the default value of 16 is too bandwidth hungry for most users
     max_per_rank_io_concurrency: Optional[int] = None
-    # This is a no-op and for future use. This would enable storage efficiency optimizations:
+    # This would enable storage efficiency optimizations (model store):
     # e.g. Compression, Batching, Quantization etc.
-    enable_storage_optimization: bool = False
+    enable_storage_optimization: bool = True
 
 
 @dataclass


### PR DESCRIPTION
Summary:
Let's enable storage optimizations by default in TorchTNT in preparation of upcoming DCP guidance post

We don't need to change anything in Mitra as the default knob option sets it to False:
https://www.internalfb.com/code/fbsource/[99acb2db7d2b]/fbcode/content_understanding/framework/training/types.py?lines=40-47

Reviewed By: saumishr

Differential Revision: D64205385


