### PR TITLE
Don't erase types in torchtnt decorators

### DIFF
--- a/tests/utils/test_checkpoint.py
+++ b/tests/utils/test_checkpoint.py
@@ -1425,6 +1425,8 @@ class CheckpointUtilsTest(unittest.TestCase):
             ckpt_1 = os.path.join(temp_dir, "checkpoint_1")
             os.mkdir(ckpt_1)
 
+            # pyre-fixme[6]: For 2nd argument expected `Union[List[str], str]` but
+            #  got `None`.
             self.assertFalse(does_checkpoint_exist(ckpt_1, metadata_fname=None))
 
             with open(os.path.join(ckpt_1, ".metadata"), "w"):

--- a/tests/utils/test_checkpoint_gpu.py
+++ b/tests/utils/test_checkpoint_gpu.py
@@ -56,7 +56,9 @@ class TestCheckpointUtilsGPU(unittest.TestCase):
             tc.assertIsNone(temp_dir)
 
         ckpt_dirpaths = get_checkpoint_dirpaths(
-            temp_dir, process_group=dist.group.WORLD
+            # pyre-fixme[6]: For 1st argument expected `str` but got `Optional[str]`.
+            temp_dir,
+            process_group=dist.group.WORLD,
         )
 
         # Broadcast temp_dir to verify successful execution


### PR DESCRIPTION
Summary:
This:

* Replaces `pyre_extensions.ParameterSpecification` with `typing.ParamSpec` which is now an upstream standard
* Changes the implementation of `rank_zero_read_and_broadcast` to avoid type-erasing the parameters

Differential Revision: D64353428


