### PR TITLE
Revert D64379847: Multisect successfully blamed "D64379847: [AIInfra][DCP] Fix the load state dict in case of partial loading" for one test failure

### DIFF
--- a/torchtnt/framework/_test_utils.py
+++ b/torchtnt/framework/_test_utils.py
@@ -297,39 +297,3 @@ class DummyMeanMetric:
     def load_state_dict(self, state_dict: Dict[str, Any]) -> None:
         self.sum = state_dict["sum"]
         self.count = state_dict["count"]
-
-
-class DummyStatefulConfig:
-    def __init__(
-        self,
-        storage_path: str,
-        lazy_loading: bool,
-        num_workers_per_gpu: int,
-        max_batch_length: int,
-    ) -> None:
-        self.storage_path = storage_path
-        self.lazy_loading = lazy_loading
-        self.num_workers_per_gpu = num_workers_per_gpu
-        self.max_batch_length = max_batch_length
-
-    def state_dict(self) -> Dict[str, Any]:
-        return {
-            "storage_path": self.storage_path,
-            "data": {
-                "lazy_loading": self.lazy_loading,
-                "train": {
-                    "num_workers_per_gpu": self.num_workers_per_gpu,
-                    "dynamic_batch_config": {
-                        "max_batch_length": self.max_batch_length,
-                    },
-                },
-            },
-        }
-
-    def load_state_dict(self, state_dict: Dict[str, Any]) -> None:
-        self.storage_path = state_dict["storage_path"]
-        self.lazy_loading = state_dict["data"]["lazy_loading"]
-        self.num_workers_per_gpu = state_dict["data"]["train"]["num_workers_per_gpu"]
-        self.max_batch_length = state_dict["data"]["train"]["dynamic_batch_config"][
-            "max_batch_length"
-        ]


### PR DESCRIPTION
Summary:
This diff reverts D64379847
D64379847: [AIInfra][DCP] Fix the load state dict in case of partial loading by saumishr causes the following test failure:

Tests affected:
- [cogwheel:cogwheel_py_predictor_apps_mgp_non_hero_ocr_ocr_pipeline_test#main](https://www.internalfb.com/intern/test/844425109859400/)

Here's the Multisect link:
https://www.internalfb.com/multisect/12282180
Here are the tasks that are relevant to this breakage:
T198471974: 10+ tests failing for mgenai_ml_infra

The backout may land if someone accepts it.

If this diff has been generated in error, you can Commandeer and Abandon it.

Reviewed By: saumishr

Differential Revision: D64448222


