### PR TITLE
Use TNT's ManifoldPathHandler for listing checkpoints internally

### DIFF
--- a/tests/utils/test_checkpoint.py
+++ b/tests/utils/test_checkpoint.py
@@ -1422,18 +1422,10 @@ class CheckpointUtilsTest(unittest.TestCase):
             dirpath = os.path.join(temp_dir, "checkpoint")
             Snapshot.take(dirpath, app_state=app_state)
 
-            self.assertTrue(
-                CheckpointManager.does_checkpoint_metadata_exist(
-                    dirpath, SNAPSHOT_METADATA_FNAME
-                )
-            )
+            self.assertTrue(does_checkpoint_exist(dirpath, SNAPSHOT_METADATA_FNAME))
 
             os.remove(os.path.join(dirpath, SNAPSHOT_METADATA_FNAME))
-            self.assertFalse(
-                CheckpointManager.does_checkpoint_metadata_exist(
-                    dirpath, SNAPSHOT_METADATA_FNAME
-                )
-            )
+            self.assertFalse(does_checkpoint_exist(dirpath, SNAPSHOT_METADATA_FNAME))
 
     def test_does_checkpoint_exist(self) -> None:
         with tempfile.TemporaryDirectory() as temp_dir:


### PR DESCRIPTION
Summary:
We've faced multiple issues in the past where users register incompatible implementations of Manifold path handlers to fsspec, causing errors when listing and even loading the checkpoints.

Currently [one user is facing an error because of this](https://fb.workplace.com/groups/277527419809135/permalink/1625534775008386/), and it's tricky to debug because the error is not reproducible outside of that particular project (because of the specific dependencies being used)

Most internal customers should be using storage optimizations and then use modelstore components within DCP APIs, but we still use fsspec for listing latest and best checkpoints.

We need to make sure that our own implementation is used to list the checkpoints. Note we can't modify directly on checkpoint utils because it's OSS, while filesystem is internal.

Differential Revision: D65370757


