### PR TITLE
Fixing relative threshold mode early stopping working on DDP

### DIFF
--- a/torchtnt/utils/early_stop_checker.py
+++ b/torchtnt/utils/early_stop_checker.py
@@ -180,7 +180,7 @@ class EarlyStopChecker:
         improvement_threshold = self.min_delta
         if self._threshold_mode == "rel":
             base_val = self._best_value if torch.isfinite(self._best_value) else 0.0
-            improvement_threshold = self.min_delta * base_val
+            improvement_threshold = self.min_delta.to(val.device) * base_val
 
         improvement_threshold = improvement_threshold.to(val.device)
 


### PR DESCRIPTION
Summary:
`min_delta` needs to be moved to the same device as the metrics to allow multi-device training with relative threshold mode. Without it getting the following error:

```
RuntimeError:Expected all tensors to be on the same device, but found at least two devices, cuda:0 and cpu!
```

Differential Revision: D65969422


