### PR TITLE
Handle scientific notation in metric values

### DIFF
--- a/tests/utils/test_checkpoint.py
+++ b/tests/utils/test_checkpoint.py
@@ -251,6 +251,15 @@ class CheckpointPathTest(unittest.TestCase):
                     metric_data=MetricData("mean_loss_squared", 0.0),
                 ),
             ),
+            (
+                "foo/bar/epoch_1_train_step_2_eval_step_3_eval_loss=6.486097566010406e+18",
+                CheckpointPath(
+                    "foo/bar/",
+                    epoch=1,
+                    step={Phase.TRAIN: 2, Phase.EVALUATE: 3},
+                    metric_data=MetricData("eval_loss", 6.486097566010406e18),
+                ),
+            ),
         ]
         for path, expected_ckpt in valid_paths:
             parsed_ckpt = CheckpointPath.from_str(path)

--- a/torchtnt/utils/checkpoint.py
+++ b/torchtnt/utils/checkpoint.py
@@ -80,12 +80,14 @@ class CheckpointPath:
     - phase-aware and metric-aware- <dirpath>/epoch_<epoch>_train_step_<train_step>_eval_step_<eval_step>_<metric_name>=<metric_value>
     """
 
+    _FLOAT_REGEX: str = r"-?\d+\.?\d*(?:e[\+\-]\d+)?"
+
     PHASE_NAIVE_REGEX: Pattern = re.compile(
-        r"^(.+)epoch_(\d+)_step_(\d+)(?:_(\w+)=(-?\d+\.?\d*))?\/?$"
+        rf"^(.+)epoch_(\d+)_step_(\d+)(?:_(\w+)=({_FLOAT_REGEX}))?\/?$"
     )
 
     PHASE_AWARE_REGEX: Pattern = re.compile(
-        r"^(.+)epoch_(\d+)(?:_train_step_(\d+))?(?:_eval_step_(\d+))?(?:_predict_step_(\d+))?(?:_(\w+)=(-?\d+\.?\d*))?\/?$"
+        rf"^(.+)epoch_(\d+)(?:_train_step_(\d+))?(?:_eval_step_(\d+))?(?:_predict_step_(\d+))?(?:_(\w+)=({_FLOAT_REGEX}))?\/?$"
     )
 
     def __init__(


### PR DESCRIPTION
Summary:
Previously, this code would crash if the metric value had scientific notation (like `6.486097566010406e+18`), which can cause job crashes (like https://www.internalfb.com/mlhub/pipelines/runs/mast/f676386628-alandu-hpo_mast_3342b13186?job_attempt=7&version=0&tab=debug&env=PRODUCTION).

This updates the regex to handle scientific notation and adds a test case.

Reviewed By: JKSenthil

Differential Revision: D67541312


