### PR TITLE
Set evaluate_every_epoch value based on number of train epochs completed

### DIFF
--- a/tests/framework/test_state.py
+++ b/tests/framework/test_state.py
@@ -52,3 +52,20 @@ class StateTest(unittest.TestCase):
 
         predict_phase = ActivePhase.PREDICT
         self.assertEqual(predict_phase.into_phase(), Phase.PREDICT)
+
+    def test_set_evaluate_every_n_steps_or_epochs(self) -> None:
+        state = PhaseState(dataloader=[], evaluate_every_n_steps=2)
+        state.evaluate_every_n_steps = None
+        state.evaluate_every_n_steps = 100
+        with self.assertRaisesRegex(
+            ValueError, "Invalid value provided for evaluate_every_n_steps"
+        ):
+            state.evaluate_every_n_steps = -2
+
+        state = PhaseState(dataloader=[], evaluate_every_n_epochs=2)
+        state.evaluate_every_n_epochs = None
+        state.evaluate_every_n_epochs = 100
+        with self.assertRaisesRegex(
+            ValueError, "Invalid value provided for evaluate_every_n_epochs"
+        ):
+            state.evaluate_every_n_epochs = -2

--- a/torchtnt/framework/state.py
+++ b/torchtnt/framework/state.py
@@ -133,10 +133,20 @@ class PhaseState(Generic[TData, TStepOutput]):
         """Frequency with which to evaluate in terms of training steps, when running :func:`~torchtnt.framework.fit`. Defined by the user."""
         return self._evaluate_every_n_steps
 
+    @evaluate_every_n_steps.setter
+    def evaluate_every_n_steps(self, value: Optional[int]) -> None:
+        _check_loop_condition("evaluate_every_n_steps", value)
+        self._evaluate_every_n_steps = value
+
     @property
     def evaluate_every_n_epochs(self) -> Optional[int]:
         """Frequency with which to evaluate in terms of training epochs, when running :func:`~torchtnt.framework.fit`. Defined by the user."""
         return self._evaluate_every_n_epochs
+
+    @evaluate_every_n_epochs.setter
+    def evaluate_every_n_epochs(self, value: Optional[int]) -> None:
+        _check_loop_condition("evaluate_every_n_epochs", value)
+        self._evaluate_every_n_epochs = value
 
     @property
     def step_output(self) -> Optional[TStepOutput]:


### PR DESCRIPTION
Summary:
- `evaluate_every_n_epoch` until having trained for a certain amount of epochs, after which we evaluate every epoch forcefully
- Save time

Differential Revision: D68933995


