### PR TITLE
added a stateful dictionary

### DIFF
--- a/torchtnt/utils/stateful.py
+++ b/torchtnt/utils/stateful.py
@@ -75,3 +75,14 @@ class MetricStateful(Protocol):
     def state_dict(self) -> Dict[str, Any]: ...
 
     def load_state_dict(self, state_dict: Dict[str, Any]) -> None: ...
+
+
+class DictStateful(Stateful, Dict[str, Any]):
+    """A dictionary that implements the stateful interface that can be saved and loaded from checkpoints."""
+
+    def state_dict(self) -> Dict[str, Any]:
+        return self
+
+    def load_state_dict(self, state_dict: Dict[str, Any]) -> None:
+        self.clear()
+        self.update(state_dict)


### PR DESCRIPTION
Summary:
Added a stateful dictionary object that implements the stateful interface for checkpoint saving and loading and also extends dict.

This object can be used to store key/value pairs of arbitrary value objects (for example, computed metrics or any other object that we require to be saved to the unit state)

Reviewed By: diego-urgell

Differential Revision: D71051443


