### PR TITLE
Rank local checkpointing in DCP internal without collectives

### DIFF
--- a/tests/framework/callbacks/test_dcp_saver.py
+++ b/tests/framework/callbacks/test_dcp_saver.py
@@ -991,7 +991,9 @@ class DummyStorageWriter(FileSystemWriter):
     def __init__(self, path: str) -> None:
         super().__init__(path)
 
-    def set_up_storage_writer(self, is_coordinator: bool) -> None:
+    def set_up_storage_writer(
+        self, is_coordinator: bool, *args: Any, **kwargs: Any
+    ) -> None:
         pass
 
 
@@ -999,5 +1001,7 @@ class DummyStorageReader(FileSystemReader):
     def __init__(self, path: str) -> None:
         super().__init__(path)
 
-    def set_up_storage_writer(self, is_coordinator: bool) -> None:
+    def set_up_storage_reader(
+        self, is_coordinator: bool, *args: Any, **kwargs: Any
+    ) -> None:
         pass


### PR DESCRIPTION
Summary:
### Context
DCP metadata collectives become prohibitively expensive as the job scale grows. This PR introduces rank-local checkpointing (XLFormers style checkpointing) which basically saves and loads the checkpoint without any collective. The trade off for now is the dedupe and re-sharding. Support for these would be introduced soon.

Differential Revision: D72390326


