### PR TITLE
support recursive torch compile

### DIFF
--- a/tests/utils/test_precision.py
+++ b/tests/utils/test_precision.py
@@ -42,14 +42,16 @@ class PrecisionTest(unittest.TestCase):
 
     def test_get_grad_scaler_from_precision(self) -> None:
         grad_scaler = get_grad_scaler_from_precision(
-            torch.float32, is_fsdp_module=False
+            torch.float32, is_fsdp1_module=False
         )
         self.assertIsNone(grad_scaler)
 
         grad_scaler = get_grad_scaler_from_precision(
-            torch.float16, is_fsdp_module=False
+            torch.float16, is_fsdp1_module=False
         )
         self.assertIsInstance(grad_scaler, GradScaler)
 
-        grad_scaler = get_grad_scaler_from_precision(torch.float16, is_fsdp_module=True)
+        grad_scaler = get_grad_scaler_from_precision(
+            torch.float16, is_fsdp1_module=True
+        )
         self.assertIsInstance(grad_scaler, ShardedGradScaler)

--- a/torchtnt/framework/auto_unit.py
+++ b/torchtnt/framework/auto_unit.py
@@ -43,8 +43,8 @@ from torchtnt.utils.precision import (
     GradScaler,
 )
 from torchtnt.utils.prepare_module import (
+    _is_fsdp1_module,
     _is_fsdp2_module,
-    _is_fsdp_module,
     ActivationCheckpointParams,
     FSDPStrategy,
     prepare_fsdp,
@@ -560,7 +560,7 @@ class AutoUnit(
         if self.precision:
             self.grad_scaler = get_grad_scaler_from_precision(
                 self.precision,
-                is_fsdp_module=_is_fsdp_module(self.module),
+                is_fsdp1_module=_is_fsdp1_module(self.module),
             )
 
         self.step_lr_interval = step_lr_interval

--- a/torchtnt/utils/precision.py
+++ b/torchtnt/utils/precision.py
@@ -38,22 +38,23 @@ def convert_precision_str_to_dtype(precision: str) -> Optional[torch.dtype]:
 
 
 def get_grad_scaler_from_precision(
-    precision: torch.dtype, *, is_fsdp_module: Optional[bool] = False
+    precision: torch.dtype, *, is_fsdp1_module: Optional[bool] = False
 ) -> Optional[GradScaler]:
     """
     Returns the correct grad scaler to use based on the precision and whether
-    or not the model is FSDP.
+    or not the model is FSDP. FSDP required it's own sharded grad scaler. FSDP2 uses
+    the original grad scaler (amp.grad_scaler). See https://github.com/pytorch/torchtitan/blob/main/docs/fsdp.md
 
     Args:
         precision: the precision being used
-        is_fsdp_module: whether the grad scaler is for an FSDP module
+        is_fsdp1_module: whether the grad scaler is for an FSDP1 module
 
     Returns:
         The appropriate grad scaler to use, ``None`` if no grad scaler should be used.
     """
 
     if precision == torch.float16:
-        if is_fsdp_module:
+        if is_fsdp1_module:
             from torch.distributed.fsdp.sharded_grad_scaler import ShardedGradScaler
 
             return ShardedGradScaler()

--- a/torchtnt/utils/prepare_module.py
+++ b/torchtnt/utils/prepare_module.py
@@ -619,7 +619,7 @@ def prepare_module(
 
 def convert_str_to_strategy(
     strategy: str,
-) -> Union[DDPStrategy, FSDPStrategy, NOOPStrategy]:
+) -> Union[DDPStrategy, FSDPStrategy, FSDP2Strategy, NOOPStrategy]:
     """
     Converts strategy as a string to a default instance of the Strategy dataclass.
 
@@ -633,6 +633,7 @@ def convert_str_to_strategy(
     string_to_strategy_mapping = {
         "ddp": DDPStrategy(),
         "fsdp": FSDPStrategy(),
+        "fsdp2": FSDP2Strategy(),
         "noop": NOOPStrategy(),
     }
 


### PR DESCRIPTION
Summary:
# Context
Applying torch compile recursively on submodules (rather than once at the top-level module) is a common application, especially when targetting llama architectures where only the self attention layer(s) should be compiled.

# This Diff
Adds `recursive_module_types` flag to TorchCompileParams. Will recursively apply torch compile on any submodules matching the name

Reviewed By: galrotem

Differential Revision: D74410717


