### PR TITLE
Resolve logger library warnings

### DIFF
--- a/torchtnt/framework/callbacks/dcp_saver.py
+++ b/torchtnt/framework/callbacks/dcp_saver.py
@@ -221,7 +221,7 @@ class DistributedCheckpointSaver(BaseCheckpointer):
         computes and logs the time spent waiting on the previous checkpoint to finish, and a toggable warning
         for the user to modify checkpointing frequency.
 
-        If the previous checkpoing has already finished, this is a no-op.
+        If the previous checkpoint has already finished, this is a no-op.
 
         Args:
             log_warning: Toggle for logging a warning to the user to modify checkpointing frequency. Sometimes
@@ -323,7 +323,7 @@ class DistributedCheckpointSaver(BaseCheckpointer):
                             Note: If torch.distributed is available and a process group is initialized, dcp assumes the intention is to save/load checkpoints in distributed fashion.
             restore_options: Controls what to  filter when restoring the state.
             knob_options: Additional keyword options for StorageWriter and StorageReader
-            planner: Instance of LoadPlanner. If this is not specificed, the default planner will be used. (Default: ``None``)
+            planner: Instance of LoadPlanner. If this is not specified, the default planner will be used. (Default: ``None``)
             storage_reader: Instance of StorageReader used to perform reads. If this is not specified, it will automatically infer
                             the reader based on the checkpoint_id. If checkpoint_id is also None, an exception will be raised. (Default: ``None``)
         """
@@ -419,7 +419,7 @@ class DistributedCheckpointSaver(BaseCheckpointer):
                 ignore_phases.add(phase)
 
             elif not isinstance(dl, Stateful):
-                logger.warn(
+                logger.warning(
                     f"dataloader for {phase} phase was passed to `restore` but it does not implement the Stateful protocol to load states"
                 )
                 ignore_phases.add(phase)
@@ -448,7 +448,7 @@ class DistributedCheckpointSaver(BaseCheckpointer):
             for phase in candidate_dataloaders.keys()
             if _PHASE_DL_STATE_KEY_MAPPING[phase] not in app_state
         ]:
-            logger.warn(
+            logger.warning(
                 f"dataloader ({','.join(str(k) for k in dl_missing_in_ckpt)}) was passed to `restore` "
                 "but no dataloader exists in checkpoint metadata."
             )

--- a/torchtnt/utils/memory_snapshot_profiler.py
+++ b/torchtnt/utils/memory_snapshot_profiler.py
@@ -147,7 +147,7 @@ class MemorySnapshotProfiler(MemorySnapshotProfilerBase):
         if self.is_started:
             return
         if not torch.cuda.is_available():
-            logger.warn("CUDA unavailable. Not recording memory history.")
+            logger.warning("CUDA unavailable. Not recording memory history.")
             return
 
         logger.info("Starting to record memory history.")
@@ -158,7 +158,7 @@ class MemorySnapshotProfiler(MemorySnapshotProfilerBase):
         if not self.is_started:
             return
         if not torch.cuda.is_available():
-            logger.warn("CUDA unavailable. Not recording memory history.")
+            logger.warning("CUDA unavailable. Not recording memory history.")
             return
 
         logger.info("Stopping recording memory history.")


### PR DESCRIPTION
## Summary
This small PR resolves the annoying deprecation warnings of the `logger` library:
```python
DeprecationWarning: The 'warn' method is deprecated, use 'warning' instead
```


