### PR TITLE
Move `torchtnt` to `arc pyre`

### DIFF
--- a/tests/framework/callbacks/test_csv_writer.py
+++ b/tests/framework/callbacks/test_csv_writer.py
@@ -26,7 +26,6 @@ class CustomCSVWriter(BaseCSVWriter):
         self,
         state: State,
         unit: PredictUnit[TPredictData],
-        # pyre-fixme[2]: Parameter annotation cannot be `Any`.
         step_output: Any,
     ) -> Union[List[str], List[List[str]]]:
         return [["1"], ["2"]]
@@ -37,7 +36,6 @@ class CustomCSVWriterSingleRow(BaseCSVWriter):
         self,
         state: State,
         unit: PredictUnit[TPredictData],
-        # pyre-fixme[2]: Parameter annotation cannot be `Any`.
         step_output: Any,
     ) -> Union[List[str], List[List[str]]]:
         return ["1"]

--- a/tests/framework/test_auto_unit.py
+++ b/tests/framework/test_auto_unit.py
@@ -15,7 +15,6 @@ import torch
 
 from pyre_extensions import none_throws, ParameterSpecification as ParamSpec
 from torch import nn
-
 from torch.distributed import GradBucket
 from torchtnt.framework._test_utils import (
     DummyAutoUnit,
@@ -456,7 +455,6 @@ class TestAutoUnit(unittest.TestCase):
         ) -> torch.futures.Future[torch.Tensor]:
             nonlocal custom_noop_hook_called
 
-            # pyre-fixme[29]: `Type[torch.futures.Future]` is not a function.
             fut: torch.futures.Future[torch.Tensor] = torch.futures.Future()
             fut.set_result(bucket.buffer())
             custom_noop_hook_called = True

--- a/tests/utils/test_memory.py
+++ b/tests/utils/test_memory.py
@@ -220,16 +220,17 @@ class MemoryTest(unittest.TestCase):
             len(tensor_map), 2 * len(inputs.metric_list[0].window_buffer.buffers) + 6
         )
         for metric in inputs.metric_list:
-            self.assertTrue(metric.x in tensor_map)
+            metric = cast(RandomModule, metric)
+            self.assertIn(metric.x, tensor_map)
             self.assertEqual(
                 tensor_map[metric.x], metric.x.size().numel() * metric.x.element_size()
             )
-            self.assertTrue(metric.y[0] in tensor_map)
+            self.assertIn(metric.y[0], tensor_map)
             self.assertEqual(
                 tensor_map[metric.y[0]],
                 metric.y[0].size().numel() * metric.y[0].element_size(),
             )
-            self.assertTrue(metric.y[1] in tensor_map)
+            self.assertIn(metric.y[1], tensor_map)
             self.assertEqual(
                 tensor_map[metric.y[1]],
                 metric.y[1].size().numel() * metric.y[1].element_size(),

--- a/torchtnt/framework/auto_unit.py
+++ b/torchtnt/framework/auto_unit.py
@@ -131,7 +131,6 @@ class TrainStepResults:
 
     loss: torch.Tensor
     total_grad_norm: Optional[torch.Tensor]
-    # pyre-fixme[4]: Attribute `outputs` of class `TrainStepResults` must have a type other than `Any`.
     outputs: Any
 
 
@@ -371,7 +370,6 @@ class AutoPredictUnit(_AutoUnitMixin[TPredictData], PredictUnit[TPredictData]):
             global_mesh=global_mesh,
         )
 
-    # pyre-fixme[3]: Return annotation cannot be `Any`.
     def predict_step(self, state: State, data: TPredictData) -> Any:
         # if detect_anomaly is true, run forward pass under detect_anomaly context
         detect_anomaly = self.detect_anomaly
@@ -394,7 +392,6 @@ class AutoPredictUnit(_AutoUnitMixin[TPredictData], PredictUnit[TPredictData]):
         state: State,
         data: TPredictData,
         step: int,
-        # pyre-fixme[2]: Parameter annotation cannot be `Any`.
         outputs: Any,
     ) -> None:
         """
@@ -645,7 +642,6 @@ class AutoUnit(
         ...
 
     @abstractmethod
-    # pyre-fixme[3]: Return annotation cannot contain `Any`.
     def compute_loss(self, state: State, data: TData) -> Tuple[torch.Tensor, Any]:
         """
         The user should implement this method with their loss computation. This will be called every ``train_step``/``eval_step``.
@@ -662,7 +658,6 @@ class AutoUnit(
         """
         ...
 
-    # pyre-fixme[3]: Return annotation cannot contain `Any`.
     def train_step(self, state: State, data: TData) -> Tuple[torch.Tensor, Any]:
         should_update_weights = (
             self.train_progress.num_steps_completed_in_epoch + 1
@@ -779,7 +774,6 @@ class AutoUnit(
 
         self._is_last_batch = False
 
-    # pyre-fixme[3]: Return annotation cannot contain `Any`.
     def eval_step(self, state: State, data: TData) -> Tuple[torch.Tensor, Any]:
         with self.maybe_autocast_precision:
             # users must override this
@@ -800,7 +794,6 @@ class AutoUnit(
         data: TData,
         step: int,
         loss: torch.Tensor,
-        # pyre-fixme[2]: Parameter annotation cannot be `Any`.
         outputs: Any,
     ) -> None:
         """
@@ -816,7 +809,6 @@ class AutoUnit(
         """
         pass
 
-    # pyre-fixme[3]: Return annotation cannot contain `Any`.
     def predict_step(self, state: State, data: TData) -> Any:
         with self.maybe_autocast_precision:
             with get_timing_context(state, f"{self.__class__.__name__}.forward"):
@@ -835,7 +827,6 @@ class AutoUnit(
         state: State,
         data: TData,
         step: int,
-        # pyre-fixme[2]: Parameter annotation cannot be `Any`.
         outputs: Any,
     ) -> None:
         """

--- a/torchtnt/framework/callbacks/base_csv_writer.py
+++ b/torchtnt/framework/callbacks/base_csv_writer.py
@@ -12,7 +12,6 @@ from abc import ABC, abstractmethod
 from typing import Any, List, TextIO, Union
 
 from pyre_extensions import none_throws
-
 from torchtnt.framework.callback import Callback
 from torchtnt.framework.state import EntryPoint, State
 from torchtnt.framework.unit import TEvalUnit, TPredictUnit, TTrainUnit
@@ -61,7 +60,6 @@ class BaseCSVWriter(Callback, ABC):
         self,
         state: State,
         unit: TPredictUnit,
-        # pyre-fixme: Missing parameter annotation [2]
         step_output: Any,
     ) -> Union[List[str], List[List[str]]]: ...
 

--- a/torchtnt/framework/callbacks/module_summary.py
+++ b/torchtnt/framework/callbacks/module_summary.py
@@ -45,7 +45,6 @@ class ModuleSummary(Callback):
         process_fn: Callable[
             [List[ModuleSummaryObj]], None
         ] = _log_module_summary_tables,
-        # pyre-fixme
         module_inputs: Optional[
             MutableMapping[str, Tuple[Tuple[Any, ...], Dict[str, Any]]]
         ] = None,

--- a/torchtnt/framework/train.py
+++ b/torchtnt/framework/train.py
@@ -247,6 +247,8 @@ def _train_epoch_impl(
             ):
                 _evaluate_impl(
                     state,
+                    # pyre-fixme[6]: For 2nd argument expected `EvalUnit[Any]` but
+                    #  got `TrainUnit[Any]`.
                     train_unit,
                     callback_handler,
                 )
@@ -293,6 +295,8 @@ def _train_epoch_impl(
     ):
         _evaluate_impl(
             state,
+            # pyre-fixme[6]: For 2nd argument expected `EvalUnit[Any]` but got
+            #  `TrainUnit[Any]`.
             train_unit,
             callback_handler,
         )

--- a/torchtnt/framework/unit.py
+++ b/torchtnt/framework/unit.py
@@ -362,7 +362,6 @@ class TrainUnit(AppStateMixin, _OnExceptionMixin, Generic[TTrainData], ABC):
         pass
 
     @abstractmethod
-    # pyre-fixme[3]: Return annotation cannot be `Any`.
     def train_step(self, state: State, data: TTrainData) -> Any:
         """Core required method for user to implement. This method will be called at each iteration of the
         train dataloader, and can return any data the user wishes.
@@ -476,7 +475,6 @@ class EvalUnit(AppStateMixin, _OnExceptionMixin, Generic[TEvalData], ABC):
         pass
 
     @abstractmethod
-    # pyre-fixme[3]: Return annotation cannot be `Any`.
     def eval_step(self, state: State, data: TEvalData) -> Any:
         """
         Core required method for user to implement. This method will be called at each iteration of the
@@ -597,7 +595,6 @@ class PredictUnit(
         pass
 
     @abstractmethod
-    # pyre-fixme[3]: Return annotation cannot be `Any`.
     def predict_step(self, state: State, data: TPredictData) -> Any:
         """
         Core required method for user to implement. This method will be called at each iteration of the

--- a/torchtnt/utils/data/iterators.py
+++ b/torchtnt/utils/data/iterators.py
@@ -32,7 +32,6 @@ from typing import (
 from python.migrations.py310 import StrEnum310
 
 try:
-    # pyre-ignore[21]: Could not find name `StrEnum` in `enum`
     from enum import StrEnum
 except ImportError:
 

--- a/torchtnt/utils/flops.py
+++ b/torchtnt/utils/flops.py
@@ -147,7 +147,6 @@ def _conv_backward_flop_jit(
     return flop_count
 
 
-# pyre-fixme [5]
 flop_mapping: Dict[Callable[..., Any], Callable[[Tuple[Any], Tuple[Any]], Number]] = {
     aten.mm: _matmul_flop_jit,
     aten.matmul: _matmul_flop_jit,
@@ -224,8 +223,8 @@ class FlopTensorDispatchMode(TorchDispatchMode):
 
     def __torch_dispatch__(
         self,
-        func: Callable[..., Any],  # pyre-fixme [2] func can be any func
-        types: Tuple[Any],  # pyre-fixme [2]
+        func: Callable[..., Any],
+        types: Tuple[Any],
         args=(),  # pyre-fixme [2]
         kwargs=None,  # pyre-fixme [2]
     ) -> PyTree:
@@ -242,7 +241,6 @@ class FlopTensorDispatchMode(TorchDispatchMode):
 
         return rs
 
-    # pyre-fixme [3]
     def _create_backwards_push(self, name: str) -> Callable[..., Any]:
         class PushState(torch.autograd.Function):
             @staticmethod
@@ -265,7 +263,6 @@ class FlopTensorDispatchMode(TorchDispatchMode):
         # using a function parameter.
         return PushState.apply
 
-    # pyre-fixme [3]
     def _create_backwards_pop(self, name: str) -> Callable[..., Any]:
         class PopState(torch.autograd.Function):
             @staticmethod
@@ -289,9 +286,8 @@ class FlopTensorDispatchMode(TorchDispatchMode):
         # using a function parameter.
         return PopState.apply
 
-    # pyre-fixme [3] Return a callable function
     def _enter_module(self, name: str) -> Callable[..., Any]:
-        # pyre-fixme [2, 3]
+        # pyre-fixme [3]
         def f(module: torch.nn.Module, inputs: Tuple[Any]):
             parents = self._parents
             parents.append(name)
@@ -301,9 +297,8 @@ class FlopTensorDispatchMode(TorchDispatchMode):
 
         return f
 
-    # pyre-fixme [3] Return a callable function
     def _exit_module(self, name: str) -> Callable[..., Any]:
-        # pyre-fixme [2, 3]
+        # pyre-fixme [3]
         def f(module: torch.nn.Module, inputs: Tuple[Any], outputs: Tuple[Any]):
             parents = self._parents
             assert parents[-1] == name

--- a/torchtnt/utils/module_summary.py
+++ b/torchtnt/utils/module_summary.py
@@ -31,7 +31,6 @@ from torch.nn.parameter import UninitializedParameter
 from torch.utils._pytree import PyTree, tree_flatten
 from torch.utils.hooks import RemovableHandle
 from torchtnt.utils.flops import FlopTensorDispatchMode
-
 from typing_extensions import Literal
 
 _ATTRIB_TO_COL_HEADER = {
@@ -211,9 +210,7 @@ def _clean_flops(flop: DefaultDict[str, DefaultDict[str, int]], N: int) -> None:
 
 def _get_module_flops_and_activation_sizes(
     module: torch.nn.Module,
-    # pyre-fixme
     module_args: Optional[Tuple[Any, ...]] = None,
-    # pyre-fixme
     module_kwargs: Optional[MutableMapping[str, Any]] = None,
 ) -> _ModuleSummaryData:
     # a mapping from module name to activation size tuple (in_size, out_size)
@@ -301,9 +298,7 @@ def _has_tensor(item: Optional[PyTree]) -> bool:
 
 def get_module_summary(
     module: torch.nn.Module,
-    # pyre-fixme
     module_args: Optional[Tuple[Any, ...]] = None,
-    # pyre-fixme
     module_kwargs: Optional[MutableMapping[str, Any]] = None,
 ) -> ModuleSummary:
     """
@@ -663,11 +658,9 @@ def _activation_size_hook(
     ],
     # pyre-fixme: Invalid type parameters [24]
 ) -> Callable[[str], Callable]:
-    # pyre-fixme: Missing parameter annotation [2]
     def intermediate_hook(
         module_name: str,
     ) -> Callable[[torch.nn.Module, Any, Any], None]:
-        # pyre-fixme
         def hook(_: torch.nn.Module, inp: Any, out: Any) -> None:
             if len(inp) == 1:
                 inp = inp[0]
@@ -684,7 +677,6 @@ def _forward_time_pre_hook(
     timer_mapping: Dict[str, float]
     # pyre-fixme: Invalid type parameters [24]
 ) -> Callable[[str], Callable]:
-    # pyre-fixme: Missing parameter annotation [2]
     def intermediate_hook(
         module_name: str,
     ) -> Callable[[torch.nn.Module, Any], None]:
@@ -701,7 +693,6 @@ def _forward_time_hook(
     elapsed_times: Dict[str, float],
     # pyre-fixme: Invalid type parameters [24]
 ) -> Callable[[str], Callable]:
-    # pyre-fixme: Missing parameter annotation [2]
     def intermediate_hook(
         module_name: str,
     ) -> Callable[[torch.nn.Module, Any, Any], None]:

--- a/torchtnt/utils/stateful.py
+++ b/torchtnt/utils/stateful.py
@@ -12,7 +12,6 @@ import torch
 from torchtnt.utils.lr_scheduler import TLRScheduler
 from torchtnt.utils.prepare_module import FSDP2OptimizerWrapper, FSDPOptimizerWrapper
 from torchtnt.utils.progress import Progress
-
 from typing_extensions import Protocol, runtime_checkable
 
 
@@ -69,7 +68,6 @@ class MetricStateful(Protocol):
 
     def update(self, *_: Any, **__: Any) -> None: ...
 
-    # pyre-ignore[3]: Metric computation may return any type depending on the implementation
     def compute(self) -> Any: ...
 
     def state_dict(self) -> Dict[str, Any]: ...

--- a/torchtnt/utils/swa.py
+++ b/torchtnt/utils/swa.py
@@ -106,7 +106,6 @@ class AveragedModel(PyTorchAveragedModel):
                 use_buffers=use_buffers,
             )
 
-    # pyre-ignore: Missing return annotation [3]: Return type must be specified as type other than `Any`
     def forward(self, *args: Any, **kwargs: Any) -> Any:
         output = self.module(*args, **kwargs)
 


### PR DESCRIPTION
Summary:
Turn `python.set_typing(True)` on and remove the old pyre configuration. This opts into the per-target type-checking (e.g. `arc pyre check-changed-targets`).

See https://www.internalfb.com/wiki/Python/Type-annotations-in-python/How_To%3A_Migrate_to_Pyre_Fast_By_Default_Per_Target_Type_Checking/

Differential Revision: D78682161


