### PR TITLE
FlopTensorDispatchMode docs amendment unsupported ops

### DIFF
--- a/torchtnt/utils/flops.py
+++ b/torchtnt/utils/flops.py
@@ -179,6 +179,10 @@ class FlopTensorDispatchMode(TorchDispatchMode):
     Flop count implementation based on
     https://dev-discuss.pytorch.org/t/the-ideal-pytorch-flop-counter-with-torch-dispatch/505
 
+    Note that not all operators are supported.
+    Unsupported operations will be logged as debug messages but will not contribute
+    to the FLOP count.
+
     Examples::
 
         >>> import copy


### PR DESCRIPTION
Summary:
Amends docs to mention that not all operations are supported and that the unsupported ops are logged in debug mode.
Should prevent surprises for users that only read the documentation but not the actual implementation.

