### PR TITLE
Make `test_utils.py` `fork`-safe for `torchelastic` 

### DIFF
--- a/torchtnt/utils/test_utils.py
+++ b/torchtnt/utils/test_utils.py
@@ -93,11 +93,16 @@ def captured_output() -> Generator[Tuple[TextIO, TextIO], None, None]:
 
 
 """Decorator for tests to ensure running on a GPU."""
-skip_if_not_gpu: Callable[..., Callable[..., object]] = unittest.skipUnless(
-    torch.cuda.is_available(), "Skipping test since GPU is not available"
-)
+def skip_if_not_gpu(func: Callable) -> Callable:
+    """Decorator that checks for GPU availability at decoration time."""
+    return unittest.skipUnless(
+        torch.cuda.is_available(),
+        "Skipping test since GPU is not available"
+    )(func)
 
-"""Decorator for tests to ensure running when distributed is available."""
-skip_if_not_distributed: Callable[..., Callable[..., object]] = unittest.skipUnless(
-    torch.distributed.is_available(), "Skipping test since distributed is not available"
-)
+def skip_if_not_distributed(func: Callable) -> Callable:
+    """Decorator that checks for distributed availability at decoration time."""
+    return unittest.skipUnless(
+        torch.distributed.is_available(),
+        "Skipping test since distributed is not available"
+    )(func)


### PR DESCRIPTION
Please read through our [contribution guide](https://github.com/pytorch/tnt/blob/main/CONTRIBUTING.md) prior to creating your pull request.

Summary:
Makes `test_utils.py` (and `torchtnt` in general) safe to use `start_method=fork` for multi-GPU training with `torchelastic`. An example of a project that would benefit from this change is `fairchem`, which uses both `torchelastic` and `torchntn` in conjunction for multi-GPU training.

Test plan:
I verified that making this change allows me to train models within the `fairchem` codebase when `start_method=fork`.

Fixes #{issue number}
Together with [this fairchem PR](https://github.com/facebookresearch/fairchem/pull/1476), this will fix crashes related to multi-GPU (local, not SLURM) model training using the `fairchem` codebase when `start_method=fork`.
