### PR TITLE
Lazily create TQDM progress bars in on_*_step_end for DCP-resumed loops (#1059)

### DIFF
--- a/tests/framework/callbacks/test_tqdm_progress_bar.py
+++ b/tests/framework/callbacks/test_tqdm_progress_bar.py
@@ -115,6 +115,96 @@ class TQDMProgressBarTest(unittest.TestCase):
             none_throws(progress_bar._predict_progress_bar).total, expected_total
         )
 
+    def test_progress_bar_train_create_on_step_end_when_epoch_start_skipped(
+        self,
+    ) -> None:
+        """
+        Test that the train progress bar is created on the first on_train_step_end
+        when on_train_epoch_start was skipped (DCP-resume scenario).
+        """
+        input_dim = 2
+        dataset_len = 10
+        batch_size = 2
+        max_epochs = 1
+        expected_total = dataset_len / batch_size
+
+        dataloader = generate_random_dataloader(dataset_len, input_dim, batch_size)
+        state = State(
+            entry_point=EntryPoint.TRAIN,
+            train_state=PhaseState(
+                dataloader=dataloader,
+                max_epochs=max_epochs,
+            ),
+        )
+
+        my_unit = DummyTrainUnit(2)
+        progress_bar = TQDMProgressBar()
+        self.assertIsNone(progress_bar._train_progress_bar)
+        progress_bar.on_train_step_end(state, my_unit)
+        self.assertEqual(
+            none_throws(progress_bar._train_progress_bar).total, expected_total
+        )
+
+    def test_progress_bar_evaluate_create_on_step_end_when_epoch_start_skipped(
+        self,
+    ) -> None:
+        """
+        Test that the eval progress bar is created on the first on_eval_step_end
+        when on_eval_epoch_start was skipped (DCP-resume scenario).
+        """
+        input_dim = 2
+        dataset_len = 10
+        batch_size = 2
+        max_epochs = 1
+        expected_total = dataset_len / batch_size
+
+        dataloader = generate_random_dataloader(dataset_len, input_dim, batch_size)
+        state = State(
+            entry_point=EntryPoint.EVALUATE,
+            eval_state=PhaseState(
+                dataloader=dataloader,
+                max_epochs=max_epochs,
+            ),
+        )
+
+        my_unit = DummyEvalUnit(2)
+        progress_bar = TQDMProgressBar()
+        self.assertIsNone(progress_bar._eval_progress_bar)
+        progress_bar.on_eval_step_end(state, my_unit)
+        self.assertEqual(
+            none_throws(progress_bar._eval_progress_bar).total, expected_total
+        )
+
+    def test_progress_bar_predict_create_on_step_end_when_epoch_start_skipped(
+        self,
+    ) -> None:
+        """
+        Test that the predict progress bar is created on the first on_predict_step_end
+        when on_predict_epoch_start was skipped (DCP-resume scenario).
+        """
+        input_dim = 2
+        dataset_len = 10
+        batch_size = 2
+        max_epochs = 1
+        expected_total = dataset_len / batch_size
+
+        dataloader = generate_random_dataloader(dataset_len, input_dim, batch_size)
+        state = State(
+            entry_point=EntryPoint.PREDICT,
+            predict_state=PhaseState(
+                dataloader=dataloader,
+                max_epochs=max_epochs,
+            ),
+        )
+
+        my_unit = DummyPredictUnit(2)
+        progress_bar = TQDMProgressBar()
+        self.assertIsNone(progress_bar._predict_progress_bar)
+        progress_bar.on_predict_step_end(state, my_unit)
+        self.assertEqual(
+            none_throws(progress_bar._predict_progress_bar).total, expected_total
+        )
+
     def test_progress_bar_mid_progress(self) -> None:
         """
         Test TQDMProgressBar callback when progress already has occurred (can occur when loading checkpoint)

--- a/torchtnt/framework/callbacks/tqdm_progress_bar.py
+++ b/torchtnt/framework/callbacks/tqdm_progress_bar.py
@@ -7,6 +7,7 @@
 # pyre-strict
 
 import io
+import logging
 from typing import Optional, TextIO, Union
 
 from pyre_extensions import none_throws
@@ -21,11 +22,20 @@ from torchtnt.utils.tqdm import (
 )
 from tqdm.auto import tqdm
 
+logger: logging.Logger = logging.getLogger(__name__)
+
 
 class TQDMProgressBar(Callback):
     """
     A callback for progress bar visualization in training, evaluation, and prediction.
     It is initialized only on rank 0 in distributed environments.
+
+    The progress bar is lazily created on whichever phase callback fires first
+    (``on_*_epoch_start`` or ``on_*_step_end``). This means that when a loop is
+    re-entered mid-epoch — for example, after restoring from a Distributed
+    Checkpoint (DCP) where ``on_*_epoch_start`` is skipped because the epoch is
+    already in progress — the progress bar is still created on the first
+    ``on_*_step_end`` call and per-step updates are emitted as expected.
 
     Args:
         refresh_rate: Determines at which rate (in number of steps) the progress bars get updated.
@@ -48,21 +58,81 @@ class TQDMProgressBar(Callback):
         self._eval_progress_bar: Optional[tqdm] = None
         self._predict_progress_bar: Optional[tqdm] = None
 
-    def on_train_epoch_start(self, state: State, unit: TTrainUnit) -> None:
+    def _ensure_train_bar(self, state: State, unit: TTrainUnit) -> None:
+        if self._train_progress_bar is not None:
+            return
+        if get_global_rank() != 0:
+            return
+        if state.train_state is None:
+            return
         train_state = none_throws(state.train_state)
-        if get_global_rank() == 0:
-            self._train_progress_bar = create_progress_bar(
-                train_state.dataloader,
-                desc="Train Epoch",
-                num_epochs_completed=unit.train_progress.num_epochs_completed,
-                num_steps_completed=unit.train_progress.num_steps_completed_in_epoch,
-                max_steps=train_state.max_steps,
-                max_steps_per_epoch=train_state.max_steps_per_epoch,
-                file=self._file,
-                mininterval=self._mininterval,
-            )
+        self._train_progress_bar = create_progress_bar(
+            train_state.dataloader,
+            desc="Train Epoch",
+            num_epochs_completed=unit.train_progress.num_epochs_completed,
+            num_steps_completed=unit.train_progress.num_steps_completed_in_epoch,
+            max_steps=train_state.max_steps,
+            max_steps_per_epoch=train_state.max_steps_per_epoch,
+            file=self._file,
+            mininterval=self._mininterval,
+        )
+        logger.info(
+            "[TQDMProgressBar] train bar created "
+            f"(num_steps_completed_in_epoch={unit.train_progress.num_steps_completed_in_epoch})"
+        )
+
+    def _ensure_eval_bar(self, state: State, unit: TEvalUnit) -> None:
+        if self._eval_progress_bar is not None:
+            return
+        if get_global_rank() != 0:
+            return
+        if state.eval_state is None:
+            return
+        eval_state = none_throws(state.eval_state)
+        self._eval_progress_bar = create_progress_bar(
+            eval_state.dataloader,
+            desc="Eval Epoch",
+            num_epochs_completed=unit.eval_progress.num_epochs_completed,
+            num_steps_completed=unit.eval_progress.num_steps_completed_in_epoch,
+            max_steps=eval_state.max_steps,
+            max_steps_per_epoch=eval_state.max_steps_per_epoch,
+            file=self._file,
+            mininterval=self._mininterval,
+        )
+        logger.info(
+            "[TQDMProgressBar] eval bar created "
+            f"(num_steps_completed_in_epoch={unit.eval_progress.num_steps_completed_in_epoch})"
+        )
+
+    def _ensure_predict_bar(self, state: State, unit: TPredictUnit) -> None:
+        if self._predict_progress_bar is not None:
+            return
+        if get_global_rank() != 0:
+            return
+        if state.predict_state is None:
+            return
+        predict_state = none_throws(state.predict_state)
+        self._predict_progress_bar = create_progress_bar(
+            predict_state.dataloader,
+            desc="Predict Epoch",
+            num_epochs_completed=unit.predict_progress.num_epochs_completed,
+            num_steps_completed=unit.predict_progress.num_steps_completed,
+            max_steps=predict_state.max_steps,
+            max_steps_per_epoch=predict_state.max_steps_per_epoch,
+            file=self._file,
+            mininterval=self._mininterval,
+        )
+        logger.info(
+            "[TQDMProgressBar] predict bar created "
+            f"(num_steps_completed={unit.predict_progress.num_steps_completed}, "
+            f"num_steps_completed_in_epoch={unit.predict_progress.num_steps_completed_in_epoch})"
+        )
+
+    def on_train_epoch_start(self, state: State, unit: TTrainUnit) -> None:
+        self._ensure_train_bar(state, unit)
 
     def on_train_step_end(self, state: State, unit: TTrainUnit) -> None:
+        self._ensure_train_bar(state, unit)
         pbar = self._train_progress_bar
         if pbar is not None:
             update_progress_bar(
@@ -79,22 +149,13 @@ class TQDMProgressBar(Callback):
                 unit.train_progress.num_steps_completed_in_epoch,
                 self._refresh_rate,
             )
+            self._train_progress_bar = None
 
     def on_eval_epoch_start(self, state: State, unit: TEvalUnit) -> None:
-        eval_state = none_throws(state.eval_state)
-        if get_global_rank() == 0:
-            self._eval_progress_bar = create_progress_bar(
-                eval_state.dataloader,
-                desc="Eval Epoch",
-                num_epochs_completed=unit.eval_progress.num_epochs_completed,
-                num_steps_completed=unit.eval_progress.num_steps_completed_in_epoch,
-                max_steps=eval_state.max_steps,
-                max_steps_per_epoch=eval_state.max_steps_per_epoch,
-                file=self._file,
-                mininterval=self._mininterval,
-            )
+        self._ensure_eval_bar(state, unit)
 
     def on_eval_step_end(self, state: State, unit: TEvalUnit) -> None:
+        self._ensure_eval_bar(state, unit)
         pbar = self._eval_progress_bar
         if pbar is not None:
             update_progress_bar(
@@ -105,27 +166,20 @@ class TQDMProgressBar(Callback):
 
     def on_eval_epoch_end(self, state: State, unit: TEvalUnit) -> None:
         pbar = self._eval_progress_bar
-        if pbar is not None and state.eval_state:
-            close_progress_bar(
-                pbar,
-                unit.eval_progress.num_steps_completed_in_epoch,
-                self._refresh_rate,
-            )
+        if pbar is not None:
+            if state.eval_state:
+                close_progress_bar(
+                    pbar,
+                    unit.eval_progress.num_steps_completed_in_epoch,
+                    self._refresh_rate,
+                )
+            self._eval_progress_bar = None
 
     def on_predict_epoch_start(self, state: State, unit: TPredictUnit) -> None:
-        predict_state = none_throws(state.predict_state)
-        if get_global_rank() == 0:
-            self._predict_progress_bar = create_progress_bar(
-                predict_state.dataloader,
-                desc="Predict Epoch",
-                num_epochs_completed=unit.predict_progress.num_epochs_completed,
-                num_steps_completed=unit.predict_progress.num_steps_completed,
-                max_steps=predict_state.max_steps,
-                max_steps_per_epoch=predict_state.max_steps_per_epoch,
-                file=self._file,
-            )
+        self._ensure_predict_bar(state, unit)
 
     def on_predict_step_end(self, state: State, unit: TPredictUnit) -> None:
+        self._ensure_predict_bar(state, unit)
         pbar = self._predict_progress_bar
         if pbar is not None:
             update_progress_bar(
@@ -142,3 +196,4 @@ class TQDMProgressBar(Callback):
                 unit.predict_progress.num_steps_completed_in_epoch,
                 self._refresh_rate,
             )
+            self._predict_progress_bar = None


### PR DESCRIPTION
Summary:

`TQDMProgressBar` only created its train/eval/predict progress bars inside
`on_*_epoch_start`. When a loop is re-entered mid-epoch — e.g., after
restoring from a Distributed Checkpoint where `num_steps_completed > 0` and
torchtnt skips the epoch-start callback — the bar stayed `None` for the
entire attempt, so `on_*_step_end` short-circuited via its
`if pbar is not None` gate and **no** `Train/Eval/Predict Epoch X: NN/MM`
TQDM lines were ever emitted.

This change lifts the bar-creation gate so the bar is created lazily on
whichever phase callback fires first (`on_*_epoch_start` *or*
`on_*_step_end`). Concretely:

- New private helpers `_ensure_train_bar`, `_ensure_eval_bar`,
  `_ensure_predict_bar` perform the creation behind three early-returns
  (bar already exists, non-rank-0, no `*_state`) and use the same
  `create_progress_bar` arg list as the old inlined epoch-start sites.
- `on_*_epoch_start` now delegates to the helper. Behavior on the happy
  path (no resume) is bit-identical: the bar is `None` → helper creates it.
- `on_*_step_end` now calls the helper *before* the existing
  `if pbar is not None` gate. On Attempt-0 this is a no-op (bar already
  exists from epoch-start). On a DCP-resumed Attempt-N, the bar is `None`
  on entry; the helper creates it on the first step-end and the existing
  `update_progress_bar` path runs unchanged.
- One-shot `logger.info(...)` line per phase prints "<phase> bar lazily
  created" so the lifted-filter path can be confirmed in MAST stderr.

Strictly additive: in Attempt-0, behavior is identical to before. In
Attempt-1+ (DCP resume mid-epoch), the bar shows up and per-step TQDM
lines are emitted. No distributed-coordination concerns — the rank-0
gate is preserved. No new imports beyond `logging`.

Motivation: external watchdogs that grep MAST stderr for
`Predict Epoch 0: NN/447` to drive K≥2 preempt-recovery testing
currently see zero matches in Attempt-1, breaking the test harness. With
this fix, those watchdogs see the same TQDM cadence in every attempt.

Reviewed By: galrotem

Differential Revision: D105989633


