### PR TITLE
Fix mid-eval fit resume by catching up pending eval at loop entry (#1060)

### DIFF
--- a/tests/framework/test_fit.py
+++ b/tests/framework/test_fit.py
@@ -385,6 +385,111 @@ class FitTest(unittest.TestCase):
         self.assertEqual(mock_get_thread_name.call_count, 2)
         mock_set_thread_name.assert_called_once()
 
+    def test_fit_resume_mid_eval_runs_pending_eval(self) -> None:
+        """
+        Regression test for the ``tnt_fit_skips_eval_on_resume`` bug.
+
+        Simulates a fit job that was preempted mid-eval by pre-populating
+        ``train_progress.num_epochs_completed`` to ``max_epochs`` while
+        leaving ``eval_progress.num_epochs_completed`` one step behind. The
+        outer fit loop's ``_is_done`` check exits the train loop immediately
+        in this state; the post-loop catch-up in ``_train_impl`` should
+        then detect the pending eval and run it to completion before
+        ``on_train_end`` fires.
+        """
+        input_dim = 2
+        train_dataset_len = 8
+        eval_dataset_len = 4
+        batch_size = 2
+        max_epochs = 1
+        expected_eval_steps_per_epoch = eval_dataset_len / batch_size
+
+        my_unit = DummyFitUnit(input_dim=input_dim)
+
+        # Simulate state restored from a mid-eval EPHEMERAL_PREEMPTION
+        # checkpoint: train completed for the (only) epoch, eval did not.
+        my_unit.train_progress._num_epochs_completed = max_epochs
+        my_unit.train_progress._num_steps_completed = (
+            train_dataset_len // batch_size
+        ) * max_epochs
+
+        train_dataloader = generate_random_dataloader(
+            train_dataset_len, input_dim, batch_size
+        )
+        eval_dataloader = generate_random_dataloader(
+            eval_dataset_len, input_dim, batch_size
+        )
+
+        # Spy on eval_step to confirm eval actually ran.
+        with patch.object(
+            my_unit, "eval_step", wraps=my_unit.eval_step
+        ) as mock_eval_step:
+            fit(
+                my_unit,
+                train_dataloader=train_dataloader,
+                eval_dataloader=eval_dataloader,
+                max_epochs=max_epochs,
+                evaluate_every_n_epochs=1,
+            )
+
+        # Eval should have run to completion despite ``_is_done`` returning
+        # True at loop entry.
+        self.assertEqual(mock_eval_step.call_count, int(expected_eval_steps_per_epoch))
+        self.assertEqual(my_unit.eval_progress.num_epochs_completed, 1)
+        # Train should NOT have re-run; the catch-up runs eval only.
+        self.assertEqual(my_unit.train_progress.num_epochs_completed, max_epochs)
+
+    def test_fit_resume_mid_eval_with_evaluate_every_n_steps(self) -> None:
+        input_dim = 2
+        train_dataset_len = 4
+        eval_dataset_len = 4
+        batch_size = 2
+        max_epochs = 1
+        train_steps_per_epoch = train_dataset_len // batch_size  # 2
+        eval_steps_per_epoch = eval_dataset_len // batch_size  # 2
+
+        my_unit = DummyFitUnit(input_dim=input_dim)
+
+        # Simulate state restored from a mid-(epoch-end-eval)
+        # EPHEMERAL_PREEMPTION checkpoint when evaluate_every_n_steps=1
+        # was also configured:
+        #   * train phase fully completed for the (only) epoch
+        #   * 2 step-triggered evals completed during the epoch
+        #   * the epoch-end eval was interrupted before completing
+        my_unit.train_progress._num_epochs_completed = max_epochs
+        my_unit.train_progress._num_steps_completed = train_steps_per_epoch * max_epochs
+        my_unit.eval_progress._num_epochs_completed = train_steps_per_epoch
+
+        train_dataloader = generate_random_dataloader(
+            train_dataset_len, input_dim, batch_size
+        )
+        eval_dataloader = generate_random_dataloader(
+            eval_dataset_len, input_dim, batch_size
+        )
+
+        with patch.object(
+            my_unit, "eval_step", wraps=my_unit.eval_step
+        ) as mock_eval_step:
+            fit(
+                my_unit,
+                train_dataloader=train_dataloader,
+                eval_dataloader=eval_dataloader,
+                max_epochs=max_epochs,
+                evaluate_every_n_epochs=1,
+                evaluate_every_n_steps=1,
+            )
+
+        # Catch-up SHOULD fire and run the pending epoch-end eval.
+        self.assertEqual(mock_eval_step.call_count, eval_steps_per_epoch)
+        # eval_progress should advance by exactly one epoch (the missing
+        # epoch-end eval), reaching train_steps_per_epoch + 1 = 3.
+        self.assertEqual(
+            my_unit.eval_progress.num_epochs_completed,
+            train_steps_per_epoch + 1,
+        )
+        # Train should NOT have re-run.
+        self.assertEqual(my_unit.train_progress.num_epochs_completed, max_epochs)
+
 
 class UnitWithError(TrainUnit[int], EvalUnit[int]):
     def train_step(self, state: State, data: int) -> None:

--- a/torchtnt/framework/_loop_utils.py
+++ b/torchtnt/framework/_loop_utils.py
@@ -48,6 +48,37 @@ def _is_done(
     )
 
 
+def _has_pending_fit_eval(
+    train_progress: Progress,
+    eval_progress: Progress,
+    evaluate_every_n_epochs: Optional[int],
+    evaluate_every_n_steps: Optional[int],
+) -> bool:
+    """For FIT only: returns True iff a scheduled eval epoch was interrupted
+    (e.g. by mid-eval preemption) and ``eval_progress`` lags
+    ``train_progress``. See ``tnt_fit_skips_eval_on_resume.bug.md``.
+
+    Each call to ``_evaluate_impl`` advances
+    ``eval_progress.num_epochs_completed`` by 1, regardless of whether eval
+    was triggered by ``evaluate_every_n_steps`` (mid-train-epoch) or
+    ``evaluate_every_n_epochs`` (end-of-train-epoch). The expected total is
+    the sum of step-triggered and epoch-triggered fires; a deficit means
+    a preemption interrupted the most recent scheduled eval.
+    """
+    if not evaluate_every_n_epochs and not evaluate_every_n_steps:
+        return False
+    expected_eval_epochs = 0
+    if evaluate_every_n_steps:
+        expected_eval_epochs += (
+            train_progress.num_steps_completed // evaluate_every_n_steps
+        )
+    if evaluate_every_n_epochs:
+        expected_eval_epochs += (
+            train_progress.num_epochs_completed // evaluate_every_n_epochs
+        )
+    return eval_progress.num_epochs_completed < expected_eval_epochs
+
+
 def _is_epoch_done(
     progress: Progress, max_steps_per_epoch: Optional[int], max_steps: Optional[int]
 ) -> bool:

--- a/torchtnt/framework/train.py
+++ b/torchtnt/framework/train.py
@@ -13,6 +13,7 @@ import torch
 from pyre_extensions import none_throws
 from torchtnt.framework._callback_handler import CallbackHandler
 from torchtnt.framework._loop_utils import (
+    _has_pending_fit_eval,
     _is_done,
     _is_epoch_done,
     _log_api_usage,
@@ -154,6 +155,13 @@ def _train_impl(
             f"num_steps_completed = {train_unit.train_progress.num_steps_completed}"
         )
 
+    # Catch-up for fit jobs preempted mid-eval: see
+    # ``tnt_fit_skips_eval_on_resume.bug.md`` and ``_has_pending_fit_eval``.
+    # No-op on the happy path. Runs after the train loop exits via the
+    # natural-completion path (``_is_done`` true) so that eval-phase
+    # callbacks fire before ``on_train_end``, matching happy-path ordering.
+    _maybe_run_pending_fit_eval(state, train_unit, callback_handler)
+
     train_unit.on_train_end(state)
     callback_handler.on_train_end(state, train_unit)
 
@@ -161,6 +169,58 @@ def _train_impl(
     # This ensures that side-effects made by the loop are reset before
     # returning back to the user
     _reset_module_training_mode(tracked_modules, prior_module_train_states)
+
+
+def _maybe_run_pending_fit_eval(
+    state: State,
+    train_unit: TTrainUnit,
+    callback_handler: CallbackHandler,
+) -> None:
+    """For FIT only: drain a scheduled eval epoch that was interrupted by
+    mid-eval preemption.
+
+    Fires only when:
+      * we're in a FIT entry point with eval configured,
+      * the train loop terminated naturally (``_is_done`` is True and
+        ``state.should_stop`` is False),
+      * ``eval_progress`` lags ``train_progress`` on an eval-trigger
+        boundary (``_has_pending_fit_eval``).
+
+    No-op on the happy path. See ``tnt_fit_skips_eval_on_resume.bug.md``.
+    """
+    if state.entry_point != EntryPoint.FIT or state.eval_state is None:
+        return
+    if state.should_stop:
+        return
+    train_state = none_throws(state.train_state)
+    eval_state = none_throws(state.eval_state)
+    if not _is_done(
+        train_unit.train_progress, train_state.max_epochs, train_state.max_steps
+    ):
+        return
+    if not _has_pending_fit_eval(
+        train_unit.train_progress,
+        # pyre-fixme[6]: For 2nd argument expected `Progress` but got `object`.
+        train_unit.eval_progress,
+        eval_state.evaluate_every_n_epochs,
+        eval_state.evaluate_every_n_steps,
+    ):
+        return
+    logger.info(
+        "Detected pending eval after train loop termination "
+        f"(train_epochs={train_unit.train_progress.num_epochs_completed}, "
+        # pyre-fixme[16]: ``object`` has no attribute ``num_epochs_completed``.
+        f"eval_epochs={train_unit.eval_progress.num_epochs_completed}); "
+        "running eval before on_train_end fires."
+    )
+    _evaluate_impl(
+        state,
+        # pyre-fixme[6]: For 2nd argument expected `EvalUnit[Any]` but got
+        #  `TrainUnit[Any]`.
+        train_unit,
+        callback_handler,
+    )
+    state._active_phase = ActivePhase.TRAIN
 
 
 def _train_epoch_impl(


### PR DESCRIPTION
Summary:

Upstream fix for the mid-eval preemption-recovery bug tracked in
`tnt_fit_skips_eval_on_resume.bug.md` (preemption_recovery brain).

## The bug

In `torchtnt/framework/train.py`, after each train epoch completes,
`train_progress.increment_epoch()` fires before the optional eval phase
runs. So when a `fit` job is preempted mid-eval, the persisted
`EPHEMERAL_PREEMPTION` checkpoint has `num_epochs_completed == max_epochs`
while `eval_progress` is still one short. On resume, the outer fit
loop's `_is_done` check evaluates to True and the loop exits without
re-entering eval — eval is silently skipped, defeating the purpose of
preemption recovery.

## The fix

**Strategy: catch up the pending eval at fit-loop entry; do NOT reorder
`_train_epoch_impl`.**

Earlier revisions (V1–V4) attempted to fix the bug by moving
`train_progress.increment_epoch()` to *after* `_evaluate_impl` so the
mid-eval preempt save would persist `num_epochs_completed = N` instead
of `N+1`. That reordering broke six land-blocking unit tests in
`test_base_checkpointer.py`, `test_dcp_saver.py`, and `test_fit.py`,
because eval-phase callbacks (`on_eval_epoch_end`, `on_eval_step_end`,
the fit error logger) read `train_progress.num_epochs_completed` and
silently shifted by one — a user-visible change to checkpoint path
naming for any user with `save_every_n_eval_epochs` set.

This revision keeps `_train_epoch_impl` exactly as it was pre-V1
(`increment_epoch -> on_train_epoch_end -> eval`), so happy-path
callback semantics (including checkpoint path naming during eval) are
bit-identical to the pre-diff baseline. The fix moves into the outer
fit loop in `_train_impl`:

1. New helper `_has_pending_fit_eval(train_progress, eval_progress,
   evaluate_every_n_epochs)` in `_loop_utils.py` returns `True` iff a
   scheduled eval was interrupted by mid-eval preemption — i.e. the
   latest train epoch is an eval-trigger boundary
   (`train_epochs % evaluate_every_n_epochs == 0`) but `eval_progress`
   has not advanced to the matching eval count.
2. Before `_train_impl`'s `while not _is_done(...)` check, and gated on
   `state.entry_point == EntryPoint.FIT`, the loop inspects this helper.
   If a pending eval is detected, it runs `_evaluate_impl` once to drain
   the interrupted eval epoch and resets `_active_phase` back to
   `TRAIN` before falling into the normal loop.
3. On the happy path (no resume), `eval_progress` is in sync with
   `train_progress` at fit entry, so the helper returns `False` and the
   catch-up is a no-op.

This delivers the user-visible contract (no silent eval skip on resume)
without the V4 trade-offs:

- **No re-running of the train phase on resume.** The catch-up runs
  eval only, so the model state at the start of eval is bit-equivalent
  to the original (pre-preempt) state. (V4 acknowledged train re-runs
  as a trade-off; that trade-off is removed here.)
- **No callback semantic shift.** Eval-phase callbacks observe the same
  `train_progress.num_epochs_completed` value they always have.
- **No churn on `_train_epoch_impl` ordering or its callback consumers.**

## Files

- `torchtnt/framework/_loop_utils.py` — adds `_has_pending_fit_eval`
  helper.
- `torchtnt/framework/train.py` — imports the helper, adds the pre-loop
  catch-up in `_train_impl` gated on `EntryPoint.FIT`. The end-of-epoch
  sequence in `_train_epoch_impl` is otherwise unchanged from the
  pre-D106718514 baseline.
- `torchtnt/tests/framework/test_fit.py` — adds
  `test_fit_resume_mid_eval_runs_pending_eval` regression test that
  pre-populates progress counters to simulate a mid-eval preempt save
  and asserts the catch-up runs eval to completion without re-running
  train.

## Trade-off (resume behavior)

Unlike V4, the resumed attempt does NOT re-run the train phase. The
model parameters loaded from the `EPHEMERAL_PREEMPTION` checkpoint
reflect post-train state at preempt time, the catch-up runs only the
pending eval, and the resume is bit-equivalent to "resume eval only at
step N+1" (as much as the eval dataloader allows; eval-side dataloader
recovery is owned by D106584397).

## Tracking

`/home/mayanksaini/gdrive/01_projects/preemption_recovery/tnt_fit_skips_eval_on_resume.bug.md`
— this revision implements **Option 2** ("make `_is_done` aware of
`eval_progress` for fit-style units") rather than Option 1
("move `increment_epoch` after `_evaluate_impl`") attempted in V1–V4.

Differential Revision: D106718514


