### PR TITLE
Add restore_metrics option to RestoreOptions

### DIFF
--- a/torchtnt/framework/callbacks/_checkpoint_utils.py
+++ b/torchtnt/framework/callbacks/_checkpoint_utils.py
@@ -88,6 +88,7 @@ def _remove_app_state_keys(
     remove_modules: bool = False,
     remove_optimizers: bool = False,
     remove_lr_schedulers: bool = False,
+    remove_metrics: bool = False,
 ) -> None:
     if remove_modules:
         # remove all module keys from app_state
@@ -103,6 +104,11 @@ def _remove_app_state_keys(
         # remove all lr scheduler keys from app_state
         for lr_scheduler_keys in unit.tracked_lr_schedulers().keys():
             app_state.pop(lr_scheduler_keys, None)
+
+    if remove_metrics:
+        # remove all metric keys from app_state
+        for metric_keys in unit.tracked_metrics().keys():
+            app_state.pop(metric_keys, None)
 
 
 def _prepare_app_state_for_checkpoint(
@@ -173,6 +179,7 @@ def _prepare_app_state_for_restore(
         remove_modules=not restore_options.restore_modules,
         remove_optimizers=not restore_options.restore_optimizers,
         remove_lr_schedulers=not restore_options.restore_lr_schedulers,
+        remove_metrics=not restore_options.restore_metrics,
     )
 
     return app_state

--- a/torchtnt/framework/callbacks/checkpointer_types.py
+++ b/torchtnt/framework/callbacks/checkpointer_types.py
@@ -42,6 +42,7 @@ class RestoreOptions:
         restore_predict_progress: Whether to restore the prediction progress state.
         restore_optimizers: Whether to restore the optimizer states.
         restore_lr_schedulers: Whether to restore the lr scheduler states.
+        restore_metrics: Whether to restore the metric states.
         strict: Whether to strictly restore app state and the module state dict.
         init_optim_states: Whether to initialize the optimizer state. Defaults to True. Toggle off
             if running into issues with loading optimizer state. This will reset optimizer state,
@@ -54,5 +55,6 @@ class RestoreOptions:
     restore_predict_progress: bool = True
     restore_optimizers: bool = True
     restore_lr_schedulers: bool = True
+    restore_metrics: bool = True
     strict: bool = True
     init_optim_states: bool = True


### PR DESCRIPTION
Summary:
Add a `restore_metrics` field to `RestoreOptions` (default `True`) that controls
whether metric state is included in checkpoint restore. When set to `False`,
metric keys are excluded from the app_state during restore, preventing DCP
shape mismatches caused by dynamically-sized metric tensors (e.g. `error_storage`
that grows during eval).

The DCP pre-flight shape validation (D99405921, April 2026) now catches shape
mismatches between checkpoint metric tensors (populated after eval) and freshly
initialized metrics (empty on restart). This causes preemption recovery to fail
for any project using `_add_state` with dynamically-sized tensors in torcheval
metrics.

Since metrics are transient eval state recomputed each eval pass, excluding them
from restore is safe and correct. Projects can opt in via YAML config:
```yaml
restore_options:
  _target_: torchtnt.framework.callbacks.checkpointer_types.RestoreOptions
  restore_metrics: false
```

Reviewed By: galrotem

Differential Revision: D106843518


