### PR TITLE
Add `eval_pending` to `Progress`

### DIFF
--- a/tests/utils/test_progress.py
+++ b/tests/utils/test_progress.py
@@ -29,6 +29,7 @@ class ProgressTest(unittest.TestCase):
             num_epochs_completed=2,
             num_steps_completed=8,
             num_steps_completed_in_epoch=4,
+            eval_pending=True,
         )
 
         state_dict = progress.state_dict()
@@ -38,12 +39,30 @@ class ProgressTest(unittest.TestCase):
         self.assertEqual(new_progress.num_epochs_completed, 0)
         self.assertEqual(new_progress.num_steps_completed, 0)
         self.assertEqual(new_progress.num_steps_completed_in_epoch, 0)
+        self.assertFalse(new_progress.eval_pending)
 
         new_progress.load_state_dict(state_dict)
 
         self.assertEqual(new_progress.num_epochs_completed, 2)
         self.assertEqual(new_progress.num_steps_completed, 8)
         self.assertEqual(new_progress.num_steps_completed_in_epoch, 4)
+        self.assertTrue(new_progress.eval_pending)
+
+    def test_progress_load_state_dict_defaults_eval_pending_to_false(self) -> None:
+        progress = Progress(eval_pending=True)
+
+        progress.load_state_dict(
+            {
+                "num_epochs_completed": 2,
+                "num_steps_completed": 8,
+                "num_steps_completed_in_epoch": 4,
+            }
+        )
+
+        self.assertEqual(progress.num_epochs_completed, 2)
+        self.assertEqual(progress.num_steps_completed, 8)
+        self.assertEqual(progress.num_steps_completed_in_epoch, 4)
+        self.assertFalse(progress.eval_pending)
 
     def test_estimated_steps_in_epoch(self) -> None:
 

--- a/torchtnt/utils/progress.py
+++ b/torchtnt/utils/progress.py
@@ -18,11 +18,13 @@ class Progress:
         num_epochs_completed: int = 0,
         num_steps_completed: int = 0,
         num_steps_completed_in_epoch: int = 0,
+        eval_pending: bool = False,
     ) -> None:
         self._num_epochs_completed: int = num_epochs_completed
         self._num_steps_completed: int = num_steps_completed
         self._num_steps_completed_in_epoch: int = num_steps_completed_in_epoch
         self._num_steps_completed_in_prev_epoch: int = 0
+        self._eval_pending: bool = eval_pending
 
     @property
     def num_epochs_completed(self) -> int:
@@ -44,6 +46,11 @@ class Progress:
         """Number of steps completed in the previous completed epoch."""
         return self._num_steps_completed_in_prev_epoch
 
+    @property
+    def eval_pending(self) -> bool:
+        """Whether a fit-triggered eval epoch started but did not complete."""
+        return self._eval_pending
+
     def increment_step(self) -> None:
         """Increment the step counts completed and completed within the epoch."""
         self._num_steps_completed += 1
@@ -55,12 +62,21 @@ class Progress:
         self._num_steps_completed_in_prev_epoch = self._num_steps_completed_in_epoch
         self._num_steps_completed_in_epoch = 0
 
+    def mark_eval_pending(self) -> None:
+        """Mark that a fit-triggered eval epoch is pending completion."""
+        self._eval_pending = True
+
+    def mark_eval_completed(self) -> None:
+        """Mark that a fit-triggered eval epoch completed."""
+        self._eval_pending = False
+
     def state_dict(self) -> Dict[str, Any]:
         """Returns a state_dict of a Progress instance in accordance with Stateful protocol."""
         return {
             "num_epochs_completed": self._num_epochs_completed,
             "num_steps_completed": self._num_steps_completed,
             "num_steps_completed_in_epoch": self._num_steps_completed_in_epoch,
+            "eval_pending": self._eval_pending,
         }
 
     def load_state_dict(self, state_dict: Dict[str, Any]) -> None:
@@ -68,6 +84,7 @@ class Progress:
         self._num_epochs_completed = state_dict["num_epochs_completed"]
         self._num_steps_completed = state_dict["num_steps_completed"]
         self._num_steps_completed_in_epoch = state_dict["num_steps_completed_in_epoch"]
+        self._eval_pending = state_dict.get("eval_pending", False)
 
     def get_progress_string(self) -> str:
         return f"completed epochs: {self.num_epochs_completed}, completed steps: {self.num_steps_completed}, completed steps in current epoch: {self.num_steps_completed_in_epoch}."


### PR DESCRIPTION
Summary:
**Motivation**

`fit` needs a durable way to know that a framework-triggered eval epoch started but did not finish. Inferring that from `train_progress` and `eval_progress` is brittle, especially when `evaluate_every_n_steps` and `evaluate_every_n_epochs` can both contribute to `eval_progress.num_epochs_completed`. We also need old checkpoints that predate this field to keep loading.

**Implementation**

Add `eval_pending` to `Progress`, expose `mark_eval_pending()` and `mark_eval_completed()`, and include the flag in `state_dict()`. `load_state_dict()` reads `eval_pending` with a default of `False`, so checkpoints written before this field existed remain loadable. This diff is scaffolding only and does not change loop behavior.

Differential Revision: D107313682


