### PR TITLE
Run pending fit eval before train loop

### DIFF
--- a/tests/framework/test_fit.py
+++ b/tests/framework/test_fit.py
@@ -73,6 +73,7 @@ class FitTest(unittest.TestCase):
             my_unit.eval_progress.num_steps_completed,
             max_epochs * expected_eval_steps_per_epoch,
         )
+        self.assertFalse(my_unit.eval_progress.eval_pending)
 
     def test_fit_evaluate_every_n_steps(self) -> None:
         """
@@ -125,6 +126,111 @@ class FitTest(unittest.TestCase):
             my_unit.eval_progress.num_steps_completed,
             expected_num_evaluate_calls * expected_eval_steps_per_epoch,
         )
+        self.assertFalse(my_unit.eval_progress.eval_pending)
+
+    def test_fit_resume_pending_eval_runs_eval_before_train_done_check(self) -> None:
+        input_dim = 2
+        train_dataset_len = 8
+        eval_dataset_len = 4
+        batch_size = 2
+        max_epochs = 1
+        expected_eval_steps_per_epoch = eval_dataset_len // batch_size
+
+        my_unit = DummyFitUnit(input_dim=input_dim)
+        my_unit.train_progress._num_epochs_completed = max_epochs
+        my_unit.train_progress._num_steps_completed = (
+            train_dataset_len // batch_size
+        ) * max_epochs
+        my_unit.eval_progress.mark_eval_pending()
+
+        train_dataloader = generate_random_dataloader(
+            train_dataset_len, input_dim, batch_size
+        )
+        eval_dataloader = generate_random_dataloader(
+            eval_dataset_len, input_dim, batch_size
+        )
+
+        with patch.object(
+            my_unit, "eval_step", wraps=my_unit.eval_step
+        ) as mock_eval_step:
+            fit(
+                my_unit,
+                train_dataloader=train_dataloader,
+                eval_dataloader=eval_dataloader,
+                max_epochs=max_epochs,
+                evaluate_every_n_epochs=1,
+            )
+
+        self.assertEqual(mock_eval_step.call_count, expected_eval_steps_per_epoch)
+        self.assertEqual(my_unit.eval_progress.num_epochs_completed, 1)
+        self.assertFalse(my_unit.eval_progress.eval_pending)
+        self.assertEqual(my_unit.train_progress.num_epochs_completed, max_epochs)
+
+    def test_fit_resume_pending_eval_runs_eval_before_next_train_step(self) -> None:
+        input_dim = 2
+        train_dataset_len = 4
+        eval_dataset_len = 4
+        batch_size = 2
+
+        my_unit = DummyFitUnit(input_dim=input_dim)
+        my_unit.train_progress._num_steps_completed = 1
+        my_unit.train_progress._num_steps_completed_in_epoch = 1
+        my_unit.eval_progress.mark_eval_pending()
+
+        train_dataloader = generate_random_dataloader(
+            train_dataset_len, input_dim, batch_size
+        )
+        eval_dataloader = generate_random_dataloader(
+            eval_dataset_len, input_dim, batch_size
+        )
+
+        call_order = MagicMock()
+        with patch.object(my_unit, "eval_step", wraps=my_unit.eval_step) as eval_step:
+            with patch.object(
+                my_unit, "train_step", wraps=my_unit.train_step
+            ) as train_step:
+                call_order.attach_mock(eval_step, "eval_step")
+                call_order.attach_mock(train_step, "train_step")
+
+                fit(
+                    my_unit,
+                    train_dataloader=train_dataloader,
+                    eval_dataloader=eval_dataloader,
+                    max_steps=2,
+                    evaluate_every_n_epochs=None,
+                    evaluate_every_n_steps=1,
+                )
+
+        call_names = [mock_call[0] for mock_call in call_order.mock_calls]
+        self.assertEqual(call_names[0], "eval_step")
+        self.assertIn("train_step", call_names)
+        self.assertLess(0, call_names.index("train_step"))
+        self.assertFalse(my_unit.eval_progress.eval_pending)
+
+    def test_fit_eval_exception_leaves_eval_pending(self) -> None:
+        input_dim = 2
+        dataset_len = 4
+        batch_size = 2
+
+        my_unit = DummyFitUnit(input_dim=input_dim)
+        train_dataloader = generate_random_dataloader(
+            dataset_len, input_dim, batch_size
+        )
+        eval_dataloader = generate_random_dataloader(dataset_len, input_dim, batch_size)
+
+        with patch.object(
+            my_unit, "eval_step", side_effect=RuntimeError("eval failed")
+        ):
+            with self.assertRaisesRegex(RuntimeError, "eval failed"):
+                fit(
+                    my_unit,
+                    train_dataloader=train_dataloader,
+                    eval_dataloader=eval_dataloader,
+                    max_epochs=1,
+                    evaluate_every_n_epochs=1,
+                )
+
+        self.assertTrue(my_unit.eval_progress.eval_pending)
 
     def test_fit_stop(self) -> None:
         Batch = Tuple[torch.Tensor, torch.Tensor]

--- a/tests/utils/test_progress.py
+++ b/tests/utils/test_progress.py
@@ -29,6 +29,7 @@ class ProgressTest(unittest.TestCase):
             num_epochs_completed=2,
             num_steps_completed=8,
             num_steps_completed_in_epoch=4,
+            eval_pending=True,
         )
 
         state_dict = progress.state_dict()
@@ -38,12 +39,30 @@ class ProgressTest(unittest.TestCase):
         self.assertEqual(new_progress.num_epochs_completed, 0)
         self.assertEqual(new_progress.num_steps_completed, 0)
         self.assertEqual(new_progress.num_steps_completed_in_epoch, 0)
+        self.assertFalse(new_progress.eval_pending)
 
         new_progress.load_state_dict(state_dict)
 
         self.assertEqual(new_progress.num_epochs_completed, 2)
         self.assertEqual(new_progress.num_steps_completed, 8)
         self.assertEqual(new_progress.num_steps_completed_in_epoch, 4)
+        self.assertTrue(new_progress.eval_pending)
+
+    def test_progress_load_state_dict_defaults_eval_pending_to_false(self) -> None:
+        progress = Progress(eval_pending=True)
+
+        progress.load_state_dict(
+            {
+                "num_epochs_completed": 2,
+                "num_steps_completed": 8,
+                "num_steps_completed_in_epoch": 4,
+            }
+        )
+
+        self.assertEqual(progress.num_epochs_completed, 2)
+        self.assertEqual(progress.num_steps_completed, 8)
+        self.assertEqual(progress.num_steps_completed_in_epoch, 4)
+        self.assertFalse(progress.eval_pending)
 
     def test_estimated_steps_in_epoch(self) -> None:
 

--- a/torchtnt/framework/train.py
+++ b/torchtnt/framework/train.py
@@ -7,7 +7,7 @@
 # pyre-strict
 
 import logging
-from typing import Iterable, List, Optional
+from typing import cast, Iterable, List, Optional
 
 import torch
 from pyre_extensions import none_throws
@@ -24,7 +24,7 @@ from torchtnt.framework._loop_utils import (
 from torchtnt.framework.callback import Callback
 from torchtnt.framework.evaluate import _evaluate_impl
 from torchtnt.framework.state import ActivePhase, EntryPoint, PhaseState, State
-from torchtnt.framework.unit import TTrainData, TTrainUnit
+from torchtnt.framework.unit import EvalUnit, TTrainData, TTrainUnit
 from torchtnt.framework.utils import get_timing_context
 from torchtnt.utils.timer import get_timer_summary, TimerProtocol
 from torchtnt.utils.version import is_torch_version_geq
@@ -141,6 +141,8 @@ def _train_impl(
     train_unit.on_train_start(state)
     callback_handler.on_train_start(state, train_unit)
 
+    _maybe_run_pending_fit_eval(state, train_unit, callback_handler)
+
     while not (
         state.should_stop
         or _is_done(
@@ -161,6 +163,40 @@ def _train_impl(
     # This ensures that side-effects made by the loop are reset before
     # returning back to the user
     _reset_module_training_mode(tracked_modules, prior_module_train_states)
+
+
+def _maybe_run_pending_fit_eval(
+    state: State,
+    train_unit: TTrainUnit,
+    callback_handler: CallbackHandler,
+) -> None:
+    if (
+        state.should_stop
+        or state.entry_point != EntryPoint.FIT
+        or state.eval_state is None
+    ):
+        return
+    eval_unit = cast(EvalUnit[object], train_unit)
+    if not eval_unit.eval_progress.eval_pending:
+        return
+    logger.info("Detected pending eval from a previous fit attempt; running eval.")
+    _run_fit_eval(state, train_unit, callback_handler)
+
+
+def _run_fit_eval(
+    state: State,
+    train_unit: TTrainUnit,
+    callback_handler: CallbackHandler,
+) -> None:
+    eval_unit = cast(EvalUnit[object], train_unit)
+    eval_unit.eval_progress.mark_eval_pending()
+    _evaluate_impl(
+        state,
+        eval_unit,
+        callback_handler,
+    )
+    eval_unit.eval_progress.mark_eval_completed()
+    state._active_phase = ActivePhase.TRAIN
 
 
 def _train_epoch_impl(
@@ -245,15 +281,8 @@ def _train_epoch_impl(
                 % evaluate_every_n_steps
                 == 0
             ):
-                _evaluate_impl(
-                    state,
-                    # pyre-fixme[6]: For 2nd argument expected `EvalUnit[Any]` but
-                    #  got `TrainUnit[Any]`.
-                    train_unit,
-                    callback_handler,
-                )
+                _run_fit_eval(state, train_unit, callback_handler)
                 logger.info("Finished evaluation. Resuming training epoch")
-                state._active_phase = ActivePhase.TRAIN
 
         except StopIteration:
             stop_iteration_reached = True
@@ -293,13 +322,6 @@ def _train_epoch_impl(
         and train_unit.train_progress.num_epochs_completed % evaluate_every_n_epochs
         == 0
     ):
-        _evaluate_impl(
-            state,
-            # pyre-fixme[6]: For 2nd argument expected `EvalUnit[Any]` but got
-            #  `TrainUnit[Any]`.
-            train_unit,
-            callback_handler,
-        )
-        state._active_phase = ActivePhase.TRAIN
+        _run_fit_eval(state, train_unit, callback_handler)
 
     logger.info("Ended train epoch")

--- a/torchtnt/utils/progress.py
+++ b/torchtnt/utils/progress.py
@@ -18,11 +18,13 @@ class Progress:
         num_epochs_completed: int = 0,
         num_steps_completed: int = 0,
         num_steps_completed_in_epoch: int = 0,
+        eval_pending: bool = False,
     ) -> None:
         self._num_epochs_completed: int = num_epochs_completed
         self._num_steps_completed: int = num_steps_completed
         self._num_steps_completed_in_epoch: int = num_steps_completed_in_epoch
         self._num_steps_completed_in_prev_epoch: int = 0
+        self._eval_pending: bool = eval_pending
 
     @property
     def num_epochs_completed(self) -> int:
@@ -44,6 +46,11 @@ class Progress:
         """Number of steps completed in the previous completed epoch."""
         return self._num_steps_completed_in_prev_epoch
 
+    @property
+    def eval_pending(self) -> bool:
+        """Whether a fit-triggered eval epoch started but did not complete."""
+        return self._eval_pending
+
     def increment_step(self) -> None:
         """Increment the step counts completed and completed within the epoch."""
         self._num_steps_completed += 1
@@ -55,12 +62,21 @@ class Progress:
         self._num_steps_completed_in_prev_epoch = self._num_steps_completed_in_epoch
         self._num_steps_completed_in_epoch = 0
 
+    def mark_eval_pending(self) -> None:
+        """Mark that a fit-triggered eval epoch is pending completion."""
+        self._eval_pending = True
+
+    def mark_eval_completed(self) -> None:
+        """Mark that a fit-triggered eval epoch completed."""
+        self._eval_pending = False
+
     def state_dict(self) -> Dict[str, Any]:
         """Returns a state_dict of a Progress instance in accordance with Stateful protocol."""
         return {
             "num_epochs_completed": self._num_epochs_completed,
             "num_steps_completed": self._num_steps_completed,
             "num_steps_completed_in_epoch": self._num_steps_completed_in_epoch,
+            "eval_pending": self._eval_pending,
         }
 
     def load_state_dict(self, state_dict: Dict[str, Any]) -> None:
@@ -68,6 +84,7 @@ class Progress:
         self._num_epochs_completed = state_dict["num_epochs_completed"]
         self._num_steps_completed = state_dict["num_steps_completed"]
         self._num_steps_completed_in_epoch = state_dict["num_steps_completed_in_epoch"]
+        self._eval_pending = state_dict.get("eval_pending", False)
 
     def get_progress_string(self) -> str:
         return f"completed epochs: {self.num_epochs_completed}, completed steps: {self.num_steps_completed}, completed steps in current epoch: {self.num_steps_completed_in_epoch}."


### PR DESCRIPTION
Summary:
**Motivation**

When a `fit` job is preempted after train has scheduled eval but before that eval epoch completes, resuming must drain the pending eval without re-entering `_train_epoch_impl` first. This matters for the final eval, where `_is_done` would otherwise skip eval entirely, and for middle-epoch step-triggered eval, where entering `_train_epoch_impl` first would run train before the pending eval.

**Implementation**

Use the `Progress.eval_pending` flag introduced in the parent diff. `_train_impl` checks `_maybe_run_pending_fit_eval()` immediately after `on_train_start` and before the train loop. `_maybe_run_pending_fit_eval()` is a side-effect-only helper that no-ops for non-`FIT`, stopped states, missing eval state, or `eval_pending=False`. `_run_fit_eval()` wraps framework-triggered fit evals: it marks eval pending before `_evaluate_impl()`, clears it only after `_evaluate_impl()` returns successfully, and restores `ActivePhase.TRAIN`. The step-triggered and epoch-triggered fit eval call sites use this wrapper, so exceptions leave the checkpointed flag set for recovery.

Differential Revision: D107317519


