### PR TITLE
Suppress type errors for Pyre upgrade - torchtnt (#1065)

### DIFF
--- a/tests/framework/test_loop_utils.py
+++ b/tests/framework/test_loop_utils.py
@@ -12,6 +12,8 @@ from typing import cast, Dict
 
 import torch
 from torch import distributed as dist, nn
+
+# pyre-fixme[21]: Could not find module `torch.ao.quantization.pt2e.export_utils`.
 from torch.ao.quantization.pt2e.export_utils import model_is_exported
 from torch.distributed import launcher
 from torch.utils.data import DataLoader

--- a/torchtnt/framework/auto_unit.py
+++ b/torchtnt/framework/auto_unit.py
@@ -311,6 +311,8 @@ class _AutoUnitMixin(Generic[TData]):
         if self._prefetch_stream:
             with get_timing_context(state, f"{self.__class__.__name__}.wait_stream"):
                 # wait on the CUDA stream to complete the host to device copy
+                # pyre-fixme[6]: For 1st argument expected `Union[Stream, Stream]`
+                #  but got `Optional[Stream]`.
                 torch.cuda.current_stream().wait_stream(self._prefetch_stream)
 
         # get the next batch which was stored by _prefetch_next_batch


### PR DESCRIPTION
Summary:

This diff was automatically generated by the Pyre per-target upgrade tool.

It adds `# pyre-fixme` or `pyrefly: ignore` comments to suppress type errors that will be introduced by an upcoming Pyre or Pyrefly release. These suppressions allow the upgrade to proceed without breaking existing code.

wed - upgrade new suppression fix

#pyreupgrade

Differential Revision: D108163348


