### PR TITLE
Enable Pyrefly in fbcode/torchtnt

### DIFF
--- a/examples/auto_unit_example.py
+++ b/examples/auto_unit_example.py
@@ -47,6 +47,7 @@ def _generate_dataset(num_samples: int, input_dim: int) -> Dataset[Batch]:
     # TODO: use datapipes/dataloaderV2
     data = torch.randn(num_samples, input_dim)
     labels = torch.randint(low=0, high=2, size=(num_samples,))
+    # pyrefly: ignore [bad-return]
     return TensorDataset(data, labels)
 
 

--- a/examples/mingpt/char_dataset.py
+++ b/examples/mingpt/char_dataset.py
@@ -45,6 +45,7 @@ class CharDataset(Dataset):
     def __len__(self) -> int:
         return len(self.data) - self.block_size
 
+    # pyrefly: ignore [bad-override-param-name]
     def __getitem__(self, idx: int) -> Tuple[torch.Tensor, torch.Tensor]:
         # grab a chunk of (block_size + 1) characters from the data
         chunk = self.data[idx : idx + self.block_size + 1]

--- a/examples/mingpt/main.py
+++ b/examples/mingpt/main.py
@@ -144,6 +144,7 @@ def main(args: Namespace) -> None:
         opt_cfg=OptimizerConfig(learning_rate=args.lr, weight_decay=args.weight_decay),
         module=module,
         device=device,
+        # pyrefly: ignore [bad-argument-type]
         strategy="ddp" if torch.distributed.is_initialized() else None,
         log_every_n_steps=args.log_every_n_steps,
         gradient_accumulation_steps=4,

--- a/examples/train_unit_example.py
+++ b/examples/train_unit_example.py
@@ -42,6 +42,7 @@ def _generate_dataset(num_samples: int, input_dim: int) -> Dataset[Batch]:
     """Returns a dataset of random inputs and labels for binary classification."""
     data = torch.randn(num_samples, input_dim)
     labels = torch.randint(low=0, high=2, size=(num_samples,))
+    # pyrefly: ignore [bad-return]
     return TensorDataset(data, labels)
 
 

--- a/tests/framework/callbacks/test_base_checkpointer.py
+++ b/tests/framework/callbacks/test_base_checkpointer.py
@@ -820,7 +820,9 @@ class BaseCheckpointerTest(unittest.TestCase):
         tc = unittest.TestCase()
         tc.assertIsNotNone(checkpoint_cb._process_group)
         tc.assertEqual(
-            checkpoint_cb._process_group._get_backend_name(), dist.Backend.GLOO
+            # pyrefly: ignore [missing-attribute]
+            checkpoint_cb._process_group._get_backend_name(),
+            dist.Backend.GLOO,
         )
         # check that a new process group was created
         tc.assertNotEqual(checkpoint_cb._process_group, dist.group.WORLD)

--- a/tests/framework/callbacks/test_dcp_saver.py
+++ b/tests/framework/callbacks/test_dcp_saver.py
@@ -311,7 +311,10 @@ class DistributedCheckpointSaverTest(unittest.TestCase):
                 module=torch.nn.Linear(input_dim, 2), strategy="ddp"
             )
             optim_equal = check_state_dict_eq(
-                my_new_unit.optimizer.state_dict(), my_unit.optimizer.state_dict()
+                # pyrefly: ignore [missing-attribute]
+                my_new_unit.optimizer.state_dict(),
+                # pyrefly: ignore [missing-attribute]
+                my_unit.optimizer.state_dict(),
             )
             tc.assertFalse(optim_equal)
             module_equal = check_state_dict_eq(
@@ -323,7 +326,12 @@ class DistributedCheckpointSaverTest(unittest.TestCase):
             dcp_cb.restore(ckpt_path, my_new_unit)
 
             assert_state_dict_eq(
-                tc, my_new_unit.optimizer.state_dict(), my_unit.optimizer.state_dict()
+                # pyrefly: ignore [missing-attribute]
+                tc,
+                # pyrefly: ignore [missing-attribute]
+                my_new_unit.optimizer.state_dict(),
+                # pyrefly: ignore [missing-attribute]
+                my_unit.optimizer.state_dict(),
             )
             assert_state_dict_eq(
                 tc, my_new_unit.module.state_dict(), my_unit.module.state_dict()
@@ -987,6 +995,7 @@ class DummySavePlanner(DefaultSavePlanner):
     def __init__(self) -> None:
         super().__init__()
 
+    # pyrefly: ignore [bad-override]
     def set_up_planner(
         self,
         state_dict: STATE_DICT_TYPE,
@@ -1000,6 +1009,7 @@ class DummyLoadPlanner(DefaultLoadPlanner):
     def __init__(self) -> None:
         super().__init__()
 
+    # pyrefly: ignore [bad-override]
     def set_up_planner(
         self,
         state_dict: STATE_DICT_TYPE,

--- a/tests/framework/callbacks/test_dcp_saver_gpu.py
+++ b/tests/framework/callbacks/test_dcp_saver_gpu.py
@@ -106,13 +106,19 @@ class DistributedCheckpointSaverGPUTest(unittest.TestCase):
                 module=torch.nn.Linear(input_dim, 2), strategy="fsdp"
             )
             tc.assertNotEqual(
-                my_new_unit.optimizer.state_dict(), my_unit.optimizer.state_dict()
+                # pyrefly: ignore [missing-attribute]
+                my_new_unit.optimizer.state_dict(),
+                # pyrefly: ignore [missing-attribute]
+                my_unit.optimizer.state_dict(),
             )
             # get latest checkpoint
             ckpt_path = os.path.join(temp_dir, f"epoch_{max_epochs}_train_step_10")
             dcp_cb.restore(ckpt_path, my_new_unit)
             tc.assertEqual(
-                my_new_unit.optimizer.state_dict(), my_unit.optimizer.state_dict()
+                # pyrefly: ignore [missing-attribute]
+                my_new_unit.optimizer.state_dict(),
+                # pyrefly: ignore [missing-attribute]
+                my_unit.optimizer.state_dict(),
             )
         finally:
             dist.barrier()  # avoid race condition
@@ -156,13 +162,19 @@ class DistributedCheckpointSaverGPUTest(unittest.TestCase):
                 module=torch.nn.Linear(input_dim, 2), strategy="fsdp"
             )
             tc.assertNotEqual(
-                my_new_unit.optimizer.state_dict(), my_unit.optimizer.state_dict()
+                # pyrefly: ignore [missing-attribute]
+                my_new_unit.optimizer.state_dict(),
+                # pyrefly: ignore [missing-attribute]
+                my_unit.optimizer.state_dict(),
             )
             # get latest checkpoint
             ckpt_path = os.path.join(temp_dir, f"epoch_{max_epochs}_train_step_10")
             dcp_cb.restore_with_id(checkpoint_id=ckpt_path, unit=my_new_unit)
             tc.assertEqual(
-                my_new_unit.optimizer.state_dict(), my_unit.optimizer.state_dict()
+                # pyrefly: ignore [missing-attribute]
+                my_new_unit.optimizer.state_dict(),
+                # pyrefly: ignore [missing-attribute]
+                my_unit.optimizer.state_dict(),
             )
         finally:
             dist.barrier()  # avoid race condition

--- a/tests/framework/callbacks/test_empty_dataloader_detector.py
+++ b/tests/framework/callbacks/test_empty_dataloader_detector.py
@@ -187,6 +187,7 @@ class EmptyDataloaderDetectorCallbackTest(unittest.TestCase):
             def __len__(self) -> int:
                 return 0
 
+            # pyrefly: ignore [bad-override-param-name]
             def __getitem__(self, idx: int) -> Batch:
                 raise IndexError("Empty dataset")
 

--- a/tests/framework/callbacks/test_torchsnapshot_saver.py
+++ b/tests/framework/callbacks/test_torchsnapshot_saver.py
@@ -304,7 +304,10 @@ class TorchSnapshotSaverTest(unittest.TestCase):
                 module=torch.nn.Linear(input_dim, 2), strategy="ddp"
             )
             optim_equal = check_state_dict_eq(
-                my_new_unit.optimizer.state_dict(), my_unit.optimizer.state_dict()
+                # pyrefly: ignore [missing-attribute]
+                my_new_unit.optimizer.state_dict(),
+                # pyrefly: ignore [missing-attribute]
+                my_unit.optimizer.state_dict(),
             )
             tc.assertFalse(optim_equal)
             module_equal = check_state_dict_eq(
@@ -316,7 +319,12 @@ class TorchSnapshotSaverTest(unittest.TestCase):
             snapshot_cb.restore(ckpt_path, my_new_unit)
 
             assert_state_dict_eq(
-                tc, my_new_unit.optimizer.state_dict(), my_unit.optimizer.state_dict()
+                # pyrefly: ignore [missing-attribute]
+                tc,
+                # pyrefly: ignore [missing-attribute]
+                my_new_unit.optimizer.state_dict(),
+                # pyrefly: ignore [missing-attribute]
+                my_unit.optimizer.state_dict(),
             )
             assert_state_dict_eq(
                 tc, my_new_unit.module.state_dict(), my_unit.module.state_dict()

--- a/tests/framework/callbacks/test_torchsnapshot_saver_gpu.py
+++ b/tests/framework/callbacks/test_torchsnapshot_saver_gpu.py
@@ -60,13 +60,19 @@ class TorchSnapshotSaverGPUTest(unittest.TestCase):
                 module=torch.nn.Linear(input_dim, 2), strategy="fsdp"
             )
             tc.assertNotEqual(
-                my_new_unit.optimizer.state_dict(), my_unit.optimizer.state_dict()
+                # pyrefly: ignore [missing-attribute]
+                my_new_unit.optimizer.state_dict(),
+                # pyrefly: ignore [missing-attribute]
+                my_unit.optimizer.state_dict(),
             )
             # get latest checkpoint
             ckpt_path = os.path.join(temp_dir, f"epoch_{max_epochs}_train_step_10")
             snapshot_cb.restore(ckpt_path, my_new_unit)
             tc.assertEqual(
-                my_new_unit.optimizer.state_dict(), my_unit.optimizer.state_dict()
+                # pyrefly: ignore [missing-attribute]
+                my_new_unit.optimizer.state_dict(),
+                # pyrefly: ignore [missing-attribute]
+                my_unit.optimizer.state_dict(),
             )
         finally:
             dist.barrier()  # avoid race condition

--- a/tests/framework/test_app_state_mixin.py
+++ b/tests/framework/test_app_state_mixin.py
@@ -257,6 +257,7 @@ class AppStateMixinTest(unittest.TestCase):
 
         auto_unit = DummyAutoUnit(module=module)
         auto_unit.module2 = torch.nn.Linear(10, 10).to(device)
+        # pyrefly: ignore [missing-attribute]
         auto_unit.optim2 = torch.optim.Adam(auto_unit.module2.parameters())
 
         with patch(

--- a/tests/framework/test_auto_unit.py
+++ b/tests/framework/test_auto_unit.py
@@ -88,7 +88,9 @@ class TestAutoUnit(unittest.TestCase):
         train_dl = generate_random_dataloader(dataset_len, input_dim, batch_size)
         train(auto_unit, train_dataloader=train_dl, max_epochs=max_epochs)
         self.assertEqual(
-            auto_unit.lr_scheduler.step.call_count, expected_steps_per_epoch
+            # pyrefly: ignore [missing-attribute]
+            auto_unit.lr_scheduler.step.call_count,
+            expected_steps_per_epoch,
         )
 
     def test_lr_scheduler_epoch(self) -> None:
@@ -110,6 +112,7 @@ class TestAutoUnit(unittest.TestCase):
         train_dl = generate_random_dataloader(dataset_len, input_dim, batch_size)
 
         train(auto_unit, train_dataloader=train_dl, max_epochs=max_epochs)
+        # pyrefly: ignore [missing-attribute]
         self.assertEqual(auto_unit.lr_scheduler.step.call_count, max_epochs)
 
     def test_mixed_precision_invalid_str(self) -> None:
@@ -218,6 +221,7 @@ class TestAutoUnit(unittest.TestCase):
             self.assertEqual(update_swa_mock.call_count, 2)
 
         auto_unit.train_progress = Progress()  # reset progress
+        # pyrefly: ignore [missing-attribute]
         auto_unit.swa_params.step_or_epoch_update_freq = 2
         with patch.object(auto_unit, "_update_swa") as update_swa_mock:
             train(auto_unit, dataloader, max_epochs=1, max_steps_per_epoch=6)
@@ -226,7 +230,9 @@ class TestAutoUnit(unittest.TestCase):
 
         auto_unit.step_lr_interval = "epoch"
         auto_unit.train_progress = Progress()  # reset progress
+        # pyrefly: ignore [missing-attribute]
         auto_unit.swa_params.warmup_steps_or_epochs = 1
+        # pyrefly: ignore [missing-attribute]
         auto_unit.swa_params.step_or_epoch_update_freq = 1
         with patch.object(auto_unit, "_update_swa") as update_swa_mock:
             with patch.object(auto_unit.lr_scheduler, "step") as lr_scheduler_step_mock:
@@ -500,6 +506,7 @@ class TestAutoUnit(unittest.TestCase):
 
         my_unit = LastBatchAutoUnit(
             module=my_module,
+            # pyrefly: ignore [bad-argument-type]
             expected_steps_per_epoch=expected_steps_per_epoch,
         )
 
@@ -628,7 +635,11 @@ class TestAutoUnit(unittest.TestCase):
             batch = auto_unit._get_next_batch(state, first_data_iter)
         self.assertEqual(batch, 1)
         self._assert_next_batch_dicts(
-            auto_unit, train_prefetched=True, train_next_batch=2
+            # pyrefly: ignore [bad-argument-type]
+            auto_unit,
+            train_prefetched=True,
+            # pyrefly: ignore [bad-argument-type]
+            train_next_batch=2,
         )
 
         with move_data_to_device_mock:
@@ -636,7 +647,11 @@ class TestAutoUnit(unittest.TestCase):
         # prefetched data is still from the previous data iter even though the new data iter is passed
         self.assertEqual(batch, 2)
         self._assert_next_batch_dicts(
-            auto_unit, train_prefetched=True, train_next_batch=3
+            # pyrefly: ignore [bad-argument-type]
+            auto_unit,
+            train_prefetched=True,
+            # pyrefly: ignore [bad-argument-type]
+            train_next_batch=3,
         )
 
         with move_data_to_device_mock:
@@ -669,7 +684,11 @@ class TestAutoUnit(unittest.TestCase):
             batch = auto_unit._get_next_batch(state, train_data_iter)
         self.assertEqual(batch, 1)
         self._assert_next_batch_dicts(
-            auto_unit, train_prefetched=True, train_next_batch=2
+            # pyrefly: ignore [bad-argument-type]
+            auto_unit,
+            train_prefetched=True,
+            # pyrefly: ignore [bad-argument-type]
+            train_next_batch=2,
         )
 
         state._active_phase = ActivePhase.EVALUATE
@@ -679,8 +698,10 @@ class TestAutoUnit(unittest.TestCase):
         self._assert_next_batch_dicts(
             auto_unit,
             train_prefetched=True,
+            # pyrefly: ignore [bad-argument-type]
             train_next_batch=2,
             eval_prefetched=True,
+            # pyrefly: ignore [bad-argument-type]
             eval_next_batch=4,
         )
 
@@ -691,10 +712,13 @@ class TestAutoUnit(unittest.TestCase):
         self._assert_next_batch_dicts(
             auto_unit,
             train_prefetched=True,
+            # pyrefly: ignore [bad-argument-type]
             train_next_batch=2,
             eval_prefetched=True,
+            # pyrefly: ignore [bad-argument-type]
             eval_next_batch=4,
             predict_prefetched=True,
+            # pyrefly: ignore [bad-argument-type]
             predict_next_batch=6,
         )
 
@@ -735,10 +759,12 @@ class TestAutoUnit(unittest.TestCase):
         data = [1, 2, 3]
         auto_unit = DummyAutoUnit(module=torch.nn.Linear(2, 2), enable_prefetch=True)
 
+        # pyrefly: ignore [bad-argument-type]
         _ = auto_unit._get_next_batch(get_dummy_train_state(), iter(data))
         self.assertEqual(auto_unit._phase_to_next_batch[ActivePhase.TRAIN], 2)
 
         auto_unit = DummyAutoUnit(module=torch.nn.Linear(2, 2), enable_prefetch=False)
+        # pyrefly: ignore [bad-argument-type]
         _ = auto_unit._get_next_batch(get_dummy_train_state(), iter(data))
         self.assertIsNone(auto_unit._phase_to_next_batch[ActivePhase.TRAIN])
 
@@ -772,11 +798,14 @@ class TestAutoUnit(unittest.TestCase):
 
             # Check if set_requires_gradient_sync is called with the correct boolean
             if (step + 1) % auto_unit.gradient_accumulation_steps == 0:
+                # pyrefly: ignore [missing-attribute]
                 auto_unit.module.set_requires_gradient_sync.assert_called_with(True)
             else:
+                # pyrefly: ignore [missing-attribute]
                 auto_unit.module.set_requires_gradient_sync.assert_called_with(False)
 
             # Reset mock for the next iteration
+            # pyrefly: ignore [missing-attribute]
             auto_unit.module.set_requires_gradient_sync.reset_mock()
 
             auto_unit.train_progress.increment_step()

--- a/tests/framework/test_auto_unit_gpu.py
+++ b/tests/framework/test_auto_unit_gpu.py
@@ -49,6 +49,7 @@ class DummySWAAutoUnit(DummyAutoUnit):
         if state.active_phase == ActivePhase.TRAIN:
             outputs = self.module(inputs)
         else:
+            # pyrefly: ignore [not-callable]
             outputs = self.swa_model(inputs) if self.swa_model else self.module(inputs)
 
         loss = torch.nn.functional.cross_entropy(outputs, targets)
@@ -97,6 +98,7 @@ class TestAutoUnitGPU(unittest.TestCase):
         state = get_dummy_train_state(dummy_iterable)
         auto_unit.train_step(
             state=state,
+            # pyrefly: ignore [bad-argument-type]
             data=auto_unit.get_next_train_batch(state, iter(dummy_iterable)),
         )
         mock_autocast.assert_called_with(
@@ -119,6 +121,7 @@ class TestAutoUnitGPU(unittest.TestCase):
         state = get_dummy_train_state(dummy_iterable)
         auto_unit.train_step(
             state=state,
+            # pyrefly: ignore [bad-argument-type]
             data=auto_unit.get_next_train_batch(state, iter(dummy_iterable)),
         )
         mock_autocast.assert_called_with(
@@ -194,8 +197,11 @@ class TestAutoUnitGPU(unittest.TestCase):
         train(auto_unit, dataloader, max_epochs=1, max_steps_per_epoch=5)
         train(auto_unit_fsdp, dataloader, max_epochs=1, max_steps_per_epoch=5)
 
+        # pyrefly: ignore [missing-attribute]
         swa_params = list(auto_unit.swa_model.module.parameters())
+        # pyrefly: ignore [bad-argument-type]
         with FSDP.summon_full_params(auto_unit_fsdp.swa_model):
+            # pyrefly: ignore [missing-attribute]
             swa_fsdp_params = list(auto_unit_fsdp.swa_model.module.parameters())
 
             # Iterate and compare each parameter
@@ -294,10 +300,15 @@ class TestAutoUnitGPU(unittest.TestCase):
             evaluate_every_n_epochs=1,
         )
 
+        # pyrefly: ignore [missing-attribute]
         swa_params = list(auto_unit.swa_model.parameters())
+        # pyrefly: ignore [missing-attribute]
         swa_buffers = list(auto_unit.swa_model.buffers())
+        # pyrefly: ignore [bad-argument-type]
         with FSDP.summon_full_params(auto_unit_fsdp.swa_model):
+            # pyrefly: ignore [missing-attribute]
             swa_fsdp_params = auto_unit_fsdp.swa_model.parameters()
+            # pyrefly: ignore [missing-attribute]
             swa_fsdp_buffers = auto_unit_fsdp.swa_model.buffers()
 
             # Iterate and compare each parameter
@@ -369,7 +380,10 @@ class TestAutoUnitGPU(unittest.TestCase):
         # for the first step no_sync should be called since we accumulate gradients
         with patch.object(auto_unit.module, "no_sync") as no_sync_mock:
             auto_unit.train_step(
-                state=state, data=auto_unit.get_next_train_batch(state, dummy_iterator)
+                # pyrefly: ignore [bad-argument-type]
+                state=state,
+                # pyrefly: ignore [bad-argument-type]
+                data=auto_unit.get_next_train_batch(state, dummy_iterator),
             )
             no_sync_mock.assert_called_once()
 
@@ -377,7 +391,10 @@ class TestAutoUnitGPU(unittest.TestCase):
         # for the second step no_sync should not be called since we run optimizer step
         with patch.object(auto_unit.module, "no_sync") as no_sync_mock:
             auto_unit.train_step(
-                state=state, data=auto_unit.get_next_train_batch(state, dummy_iterator)
+                # pyrefly: ignore [bad-argument-type]
+                state=state,
+                # pyrefly: ignore [bad-argument-type]
+                data=auto_unit.get_next_train_batch(state, dummy_iterator),
             )
             no_sync_mock.assert_not_called()
 
@@ -404,7 +421,10 @@ class TestAutoUnitGPU(unittest.TestCase):
         # for the first step no_sync should be called since we accumulate gradients
         with patch.object(auto_unit.module, "no_sync") as no_sync_mock:
             auto_unit.train_step(
-                state=state, data=auto_unit.get_next_train_batch(state, dummy_iterator)
+                # pyrefly: ignore [bad-argument-type]
+                state=state,
+                # pyrefly: ignore [bad-argument-type]
+                data=auto_unit.get_next_train_batch(state, dummy_iterator),
             )
             no_sync_mock.assert_called_once()
 
@@ -412,7 +432,10 @@ class TestAutoUnitGPU(unittest.TestCase):
         # for the second step no_sync should not be called since we run optimizer step
         with patch.object(auto_unit.module, "no_sync") as no_sync_mock:
             auto_unit.train_step(
-                state=state, data=auto_unit.get_next_train_batch(state, dummy_iterator)
+                # pyrefly: ignore [bad-argument-type]
+                state=state,
+                # pyrefly: ignore [bad-argument-type]
+                data=auto_unit.get_next_train_batch(state, dummy_iterator),
             )
             no_sync_mock.assert_not_called()
 

--- a/tests/framework/test_callback_handler.py
+++ b/tests/framework/test_callback_handler.py
@@ -306,8 +306,10 @@ class CallbackHandlerTest(unittest.TestCase):
 
         for hook in remaining_callback_hooks:
             kwargs = {hook: dummy_fn}
+            # pyrefly: ignore [bad-argument-type]
             callbacks.append(Lambda(**kwargs))
 
+        # pyrefly: ignore [bad-argument-type]
         implemented_cbs = _get_implemented_callback_mapping(callbacks)
         for hook in remaining_callback_hooks:
             self.assertIn(hook, implemented_cbs)
@@ -328,18 +330,22 @@ class CallbackHandlerTest(unittest.TestCase):
             callback_name = "first_callback"
 
             def on_train_start(self, state: State, unit: TTrainUnit) -> None:
+                # pyrefly: ignore [missing-attribute]
                 unit.on_train_start_callback_order.append(self.callback_name)
 
             def on_train_end(self, state: State, unit: TTrainUnit) -> None:
+                # pyrefly: ignore [missing-attribute]
                 unit.on_train_end_callback_order.append(self.callback_name)
 
         class SecondCallback(Callback):
             callback_name = "second_callback"
 
             def on_train_start(self, state: State, unit: TTrainUnit) -> None:
+                # pyrefly: ignore [missing-attribute]
                 unit.on_train_start_callback_order.append(self.callback_name)
 
             def on_train_end(self, state: State, unit: TTrainUnit) -> None:
+                # pyrefly: ignore [missing-attribute]
                 unit.on_train_end_callback_order.append(self.callback_name)
 
         unit = DummyUnit()

--- a/tests/framework/test_evaluate.py
+++ b/tests/framework/test_evaluate.py
@@ -169,10 +169,12 @@ class EvaluateTest(unittest.TestCase):
             def on_eval_end(self, state: State, unit: TEvalUnit) -> None:
                 assertInTest(
                     "data_wait_time",
+                    # pyrefly: ignore [missing-attribute]
                     state.eval_state.iteration_timer.recorded_durations,
                 )
                 assertInTest(
                     "eval_iteration_time",
+                    # pyrefly: ignore [missing-attribute]
                     state.eval_state.iteration_timer.recorded_durations,
                 )
 

--- a/tests/framework/test_predict.py
+++ b/tests/framework/test_predict.py
@@ -142,10 +142,12 @@ class PredictTest(unittest.TestCase):
             def on_predict_end(self, state: State, unit: TPredictUnit) -> None:
                 assertInTest(
                     "data_wait_time",
+                    # pyrefly: ignore [missing-attribute]
                     state.predict_state.iteration_timer.recorded_durations,
                 )
                 assertInTest(
                     "predict_iteration_time",
+                    # pyrefly: ignore [missing-attribute]
                     state.predict_state.iteration_timer.recorded_durations,
                 )
 

--- a/tests/framework/test_train.py
+++ b/tests/framework/test_train.py
@@ -162,10 +162,12 @@ class TrainTest(unittest.TestCase):
             def on_train_end(self, state: State, unit: TTrainUnit) -> None:
                 assertInTest(
                     "data_wait_time",
+                    # pyrefly: ignore [missing-attribute]
                     state.train_state.iteration_timer.recorded_durations,
                 )
                 assertInTest(
                     "train_iteration_time",
+                    # pyrefly: ignore [missing-attribute]
                     state.train_state.iteration_timer.recorded_durations,
                 )
 
@@ -315,4 +317,5 @@ class TrainUnitWithError(TrainUnit[Batch]):
             raise ValueError("foo")
 
 
+# pyrefly: ignore [redefinition]
 Batch = Tuple[torch.Tensor, torch.Tensor]

--- a/tests/framework/test_unit_utils.py
+++ b/tests/framework/test_unit_utils.py
@@ -35,6 +35,7 @@ class UnitUtilsTest(unittest.TestCase):
 
         self.assertFalse(_step_requires_iterator(foo.bar))
         self.assertTrue(_step_requires_iterator(foo.baz))
+        # pyrefly: ignore [bad-argument-type]
         self.assertTrue(_step_requires_iterator(dummy))
 
     def test_find_optimizers_for_module(self) -> None:

--- a/tests/utils/data/test_data_prefetcher.py
+++ b/tests/utils/data/test_data_prefetcher.py
@@ -23,6 +23,7 @@ class DataPrefetcherTest(unittest.TestCase):
         """Returns a dataset of random inputs and labels for binary classification."""
         data = torch.randn(num_samples, input_dim)
         labels = torch.randint(low=0, high=2, size=(num_samples,))
+        # pyrefly: ignore [bad-return]
         return TensorDataset(data, labels)
 
     def test_device_data_prefetcher(self) -> None:

--- a/tests/utils/data/test_data_prefetcher_gpu.py
+++ b/tests/utils/data/test_data_prefetcher_gpu.py
@@ -22,6 +22,7 @@ class DataPrefetcherGPUTest(unittest.TestCase):
         """Returns a dataset of random inputs and labels for binary classification."""
         data = torch.randn(num_samples, input_dim)
         labels = torch.randint(low=0, high=2, size=(num_samples,))
+        # pyrefly: ignore [bad-return]
         return TensorDataset(data, labels)
 
     @skip_if_not_gpu

--- a/tests/utils/loggers/test_anomaly_logger.py
+++ b/tests/utils/loggers/test_anomaly_logger.py
@@ -45,6 +45,7 @@ class TestAnomalyLogger(unittest.TestCase):
             "torchtnt.utils.loggers.anomaly_logger.logging.Logger.warning",
             side_effect=warning_container.append,
         ):
+            # pyrefly: ignore [bad-instantiation]
             logger = AnomalyLogger(
                 tracked_metrics=tracked_metrics,
             )
@@ -59,6 +60,7 @@ class TestAnomalyLogger(unittest.TestCase):
         "torchtnt.utils.loggers.anomaly_logger.AnomalyLogger.on_anomaly_detected",
     )
     def test_log(self, mock_on_anomaly_detected: MagicMock) -> None:
+        # pyrefly: ignore [bad-instantiation]
         logger = AnomalyLogger(
             tracked_metrics=[
                 TrackedMetric(
@@ -124,6 +126,7 @@ class TestAnomalyLogger(unittest.TestCase):
         "torchtnt.utils.loggers.anomaly_logger.AnomalyLogger.on_anomaly_detected",
     )
     def test_log_dict(self, mock_on_anomaly_detected: MagicMock) -> None:
+        # pyrefly: ignore [bad-instantiation]
         logger = AnomalyLogger(
             tracked_metrics=[
                 TrackedMetric(
@@ -180,6 +183,7 @@ class TestAnomalyLogger(unittest.TestCase):
         side_effect=Exception("test exception"),
     )
     def test_on_anomaly_callback_exception(self, _) -> None:
+        # pyrefly: ignore [bad-instantiation]
         logger = AnomalyLogger(
             tracked_metrics=[
                 TrackedMetric(

--- a/tests/utils/test_checkpoint_gpu.py
+++ b/tests/utils/test_checkpoint_gpu.py
@@ -69,8 +69,10 @@ class TestCheckpointUtilsGPU(unittest.TestCase):
 
         tc.assertEqual(
             {str(x) for x in ckpt_dirpaths},
+            # pyrefly: ignore [no-matching-overload]
             {os.path.join(temp_dir, path) for path in paths},
         )
 
         if get_global_rank() == 0:
+            # pyrefly: ignore [bad-argument-type]
             shutil.rmtree(temp_dir)

--- a/tests/utils/test_device_mesh.py
+++ b/tests/utils/test_device_mesh.py
@@ -90,6 +90,7 @@ class TestGlobalMeshCoordinator(unittest.TestCase):
             dp_shard=-1, dp_replicate=1, tp=4, device_type="cpu"
         )
         tc.assertIsNotNone(gmc.tp_mesh)
+        # pyrefly: ignore [missing-attribute]
         tc.assertEqual(gmc.tp_mesh.size(), 4)
 
     def test_dp_mesh(self) -> None:

--- a/tests/utils/test_memory.py
+++ b/tests/utils/test_memory.py
@@ -217,7 +217,10 @@ class MemoryTest(unittest.TestCase):
         inputs = RandomModuleList()
         tensor_map = get_tensor_size_bytes_map(inputs)
         self.assertEqual(
-            len(tensor_map), 2 * len(inputs.metric_list[0].window_buffer.buffers) + 6
+            # pyrefly: ignore [missing-attribute]
+            len(tensor_map),
+            # pyrefly: ignore [missing-attribute]
+            2 * len(inputs.metric_list[0].window_buffer.buffers) + 6,
         )
         for metric in inputs.metric_list:
             metric = cast(RandomModule, metric)

--- a/tests/utils/test_prepare_module.py
+++ b/tests/utils/test_prepare_module.py
@@ -261,9 +261,13 @@ class PrepareModelTest(unittest.TestCase):
             cast_forward_inputs=False,
         )
         new_mp_policy = _check_and_convert_mp_policy_dtypes(mp_policy)
+        # pyrefly: ignore [missing-attribute]
         self.assertEqual(new_mp_policy.param_dtype, torch.bfloat16)
+        # pyrefly: ignore [missing-attribute]
         self.assertEqual(new_mp_policy.reduce_dtype, torch.float16)
+        # pyrefly: ignore [missing-attribute]
         self.assertEqual(new_mp_policy.output_dtype, None)
+        # pyrefly: ignore [missing-attribute]
         self.assertFalse(new_mp_policy.cast_forward_inputs)
 
         # pyre-ignore: Incompatible parameter type [6] (intentional for this test)

--- a/torchtnt/framework/_callback_handler.py
+++ b/torchtnt/framework/_callback_handler.py
@@ -42,6 +42,7 @@ def _has_method_override(
     if instance_method is None:
         return False
 
+    # pyrefly: ignore [missing-attribute]
     return instance_method.__code__ != base_method.__code__
 
 

--- a/torchtnt/framework/_test_utils.py
+++ b/torchtnt/framework/_test_utils.py
@@ -268,6 +268,7 @@ def generate_random_dataset(num_samples: int, input_dim: int) -> Dataset[Batch]:
     """Returns a dataset of random inputs and labels for binary classification."""
     data = torch.randn(num_samples, input_dim)
     labels = torch.randint(low=0, high=2, size=(num_samples,))
+    # pyrefly: ignore [bad-return]
     return TensorDataset(data, labels)
 
 

--- a/torchtnt/framework/auto_unit.py
+++ b/torchtnt/framework/auto_unit.py
@@ -419,6 +419,7 @@ class AutoPredictUnit(_AutoUnitMixin[TPredictData], PredictUnit[TPredictData]):
         """
         pass
 
+    # pyrefly: ignore [bad-override]
     def get_next_predict_batch(
         self, state: State, data_iter: Iterator[TPredictData]
     ) -> Union[Iterator[TPredictData], TPredictData]:
@@ -1002,6 +1003,7 @@ class AutoUnit(
 
         return total_grad_norm
 
+    # pyrefly: ignore [bad-override]
     def get_next_train_batch(
         self, state: State, data_iter: Iterator[TData]
     ) -> Union[Iterator[TData], TData]:
@@ -1010,6 +1012,7 @@ class AutoUnit(
             return data_iter
         return self._get_next_batch(state, data_iter)
 
+    # pyrefly: ignore [bad-override]
     def get_next_eval_batch(
         self, state: State, data_iter: Iterator[TData]
     ) -> Union[Iterator[TData], TData]:
@@ -1018,6 +1021,7 @@ class AutoUnit(
             return data_iter
         return self._get_next_batch(state, data_iter)
 
+    # pyrefly: ignore [bad-override]
     def get_next_predict_batch(
         self, state: State, data_iter: Iterator[TData]
     ) -> Union[Iterator[TData], TData]:
@@ -1026,6 +1030,7 @@ class AutoUnit(
             return data_iter
         return self._get_next_batch(state, data_iter)
 
+    # pyrefly: ignore [bad-override]
     def get_next_test_batch(
         self, state: State, data_iter: Iterator[TData]
     ) -> Union[Iterator[TData], TData]:

--- a/torchtnt/framework/callbacks/base_csv_writer.py
+++ b/torchtnt/framework/callbacks/base_csv_writer.py
@@ -53,6 +53,7 @@ class BaseCSVWriter(Callback, ABC):
         self.output_path: str = os.path.join(dir_path, filename)
         fs = get_filesystem(self.output_path)
         self._file: TextIO = fs.open(self.output_path, mode="a")
+        # pyrefly: ignore [missing-attribute]
         self._writer: csv._writer = csv.writer(self._file, delimiter=delimiter)
 
     @abstractmethod

--- a/torchtnt/framework/callbacks/dcp_saver.py
+++ b/torchtnt/framework/callbacks/dcp_saver.py
@@ -64,6 +64,7 @@ from typing_extensions import TypeAlias
 
 logger: logging.Logger = logging.getLogger(__name__)
 
+# pyrefly: ignore [not-a-type]
 TDataloader: TypeAlias = Union[
     Iterable[TTrainData], Iterable[TEvalData], Iterable[TPredictData]
 ]

--- a/torchtnt/framework/callbacks/tensorboard_parameter_monitor.py
+++ b/torchtnt/framework/callbacks/tensorboard_parameter_monitor.py
@@ -40,7 +40,9 @@ class TensorBoardParameterMonitor(Callback):
 
     def __init__(self, logger: Union[TensorBoardLogger, SummaryWriter]) -> None:
         if isinstance(logger, TensorBoardLogger):
+            # pyrefly: ignore [bad-assignment]
             logger = logger.writer
+        # pyrefly: ignore [bad-assignment]
         self._writer: Optional[SummaryWriter] = logger
 
     def on_train_epoch_end(self, state: State, unit: TTrainUnit) -> None:

--- a/torchtnt/framework/fit.py
+++ b/torchtnt/framework/fit.py
@@ -155,6 +155,7 @@ def fit(
         # Run test phase after training completes, if test_dataloader was provided
         if test_dataloader is not None:
             with torch.no_grad():
+                # pyrefly: ignore [bad-argument-type]
                 _test_impl(state, unit, callback_handler)
 
         logger.info("Finished fit")

--- a/torchtnt/framework/unit.py
+++ b/torchtnt/framework/unit.py
@@ -149,27 +149,33 @@ class AppStateMixin:
     def __setattr__(self, name: str, value: object) -> None:
         # Check first for metrics since some libraries subclass nn.Module as well
         if isinstance(value, MetricStateful):
+            # pyrefly: ignore [bad-argument-type]
             self._update_attr(name, value, self.__dict__.get("_metrics"))
         elif isinstance(value, torch.nn.Module):
+            # pyrefly: ignore [bad-argument-type]
             self._update_attr(name, value, self.__dict__.get("_modules"))
         elif isinstance(value, torch.optim.Optimizer):
+            # pyrefly: ignore [bad-argument-type]
             self._update_attr(name, value, self.__dict__.get("_optimizers"))
         elif isinstance(value, TLRScheduler):
             self._update_attr(
                 name,
                 value,
+                # pyrefly: ignore [bad-argument-type]
                 self.__dict__.get("_lr_schedulers"),
             )
         elif isinstance(value, Progress):
             self._update_attr(
                 name,
                 value,
+                # pyrefly: ignore [bad-argument-type]
                 self.__dict__.get("_progress"),
             )
         elif isinstance(value, Stateful) and not inspect.isclass(value):
             self._update_attr(
                 name,
                 value,
+                # pyrefly: ignore [bad-argument-type]
                 self.__dict__.get("_misc_statefuls"),
             )
         else:

--- a/torchtnt/utils/checkpoint.py
+++ b/torchtnt/utils/checkpoint.py
@@ -325,6 +325,7 @@ class CheckpointPath:
     def __repr__(self) -> str:
         return f"CheckpointPath(dirpath={self.dirpath}, epoch={self.epoch}, step={self.step}, metric_data={self.metric_data})"
 
+    # pyrefly: ignore [bad-override]
     def __eq__(self, other: "CheckpointPath") -> bool:
         return (
             self.dirpath == other.dirpath

--- a/torchtnt/utils/data/iterators.py
+++ b/torchtnt/utils/data/iterators.py
@@ -94,6 +94,7 @@ class MultiIterator(Iterator[Dict[str, Any]]):
         pass
 
 
+# pyrefly: ignore [invalid-inheritance]
 class StoppingMechanism(StrEnum):
     ALL_DATASETS_EXHAUSTED = "ALL_DATASETS_EXHAUSTED"
     SMALLEST_DATASET_EXHAUSTED = "SMALLEST_DATASET_EXHAUSTED"
@@ -182,6 +183,7 @@ class RoundRobinIterator(MultiIterator):
             }
         except StopIteration:
             if (
+                # pyrefly: ignore [missing-attribute]
                 self.iteration_strategy.stopping_mechanism
                 == StoppingMechanism.SMALLEST_DATASET_EXHAUSTED
             ):
@@ -282,9 +284,11 @@ class AllDatasetBatchesIterator(MultiIterator):
         batch_dict = {}
         for iterator in self.individual_iterators:
             try:
+                # pyrefly: ignore [unsupported-operation]
                 batch_dict[iterator] = next(self.individual_iterators[iterator])
             except StopIteration:
                 if (
+                    # pyrefly: ignore [missing-attribute]
                     self.iteration_strategy.stopping_mechanism
                     == StoppingMechanism.SMALLEST_DATASET_EXHAUSTED
                 ):
@@ -302,6 +306,7 @@ class AllDatasetBatchesIterator(MultiIterator):
                         self.individual_iterators[iterator] = iter(
                             self.individual_dataloaders[iterator]
                         )
+                        # pyrefly: ignore [unsupported-operation]
                         batch_dict[iterator] = next(self.individual_iterators[iterator])
 
         if len(batch_dict) == 0:

--- a/torchtnt/utils/data/multi_dataloader.py
+++ b/torchtnt/utils/data/multi_dataloader.py
@@ -110,6 +110,7 @@ class MultiDataLoader:
                 logger.info("Storing iterator state in MultiDataLoader state_dict")
                 # we make an implicit assumption here that none of the dataloaders have the "iterator_state" key in order to be backwards compatible
                 # with already saved checkpoints (we don't want to modify the dataloaders stateful names)
+                # pyrefly: ignore [unsupported-operation]
                 state_dict["iterator_state"] = iterator_state
 
         return state_dict

--- a/torchtnt/utils/data/synthetic_data.py
+++ b/torchtnt/utils/data/synthetic_data.py
@@ -54,6 +54,7 @@ class AbstractRandomDataset(Dataset, abc.ABC, Generic[TItem]):
         """
         return self.size
 
+    # pyrefly: ignore [bad-override-param-name]
     def __getitem__(self, idx: int) -> TItem:
         """
         Fetch a dataset item by index.

--- a/torchtnt/utils/device.py
+++ b/torchtnt/utils/device.py
@@ -79,10 +79,13 @@ def copy_data_to_device(
 
     data_type = type(data)
     if issubclass(data_type, defaultdict):
+        # pyrefly: ignore [bad-return]
         return data_type(
+            # pyrefly: ignore [missing-attribute]
             data.default_factory,
             {
                 k: copy_data_to_device(v, device, *args, **kwargs)
+                # pyrefly: ignore [missing-attribute]
                 for k, v in data.items()
             },
         )
@@ -100,12 +103,15 @@ def copy_data_to_device(
             }
         )
     elif issubclass(data_type, list):
+        # pyrefly: ignore [bad-return, not-iterable]
         return data_type(copy_data_to_device(e, device, *args, **kwargs) for e in data)
     elif issubclass(data_type, tuple):
         if hasattr(data, "_asdict") and hasattr(data, "_fields"):
+            # pyrefly: ignore [bad-return]
             return data_type(
                 **copy_data_to_device(data._asdict(), device, *args, **kwargs)
             )
+        # pyrefly: ignore [bad-return, not-iterable]
         return data_type(copy_data_to_device(e, device, *args, **kwargs) for e in data)
     # checking for __dataclass_fields__ is official way to check if data is a dataclass
     elif hasattr(data, "__dataclass_fields__"):
@@ -114,10 +120,12 @@ def copy_data_to_device(
                 field.name: copy_data_to_device(
                     getattr(data, field.name), device, *args, **kwargs
                 )
+                # pyrefly: ignore [bad-argument-type]
                 for field in fields(data)
                 if field.init
             }
         )
+        # pyrefly: ignore [bad-argument-type]
         for field in fields(data):
             if not field.init:
                 setattr(
@@ -159,6 +167,7 @@ def record_data_in_stream(data: T, stream: torch.cuda.streams.Stream) -> None:
 
     # Redundant isinstance(data, tuple) check is required here to make pyre happy
     if _is_named_tuple(data) and isinstance(data, tuple):
+        # pyrefly: ignore [missing-attribute]
         record_data_in_stream(data._asdict(), stream)
     elif isinstance(data, (list, tuple)):
         for e in data:
@@ -270,7 +279,9 @@ def get_nvidia_smi_gpu_stats(device: torch.device) -> GPUStats:  # pragma: no-co
         "utilization_gpu_percent": stats[0],
         "utilization_memory_percent": stats[1],
         "fan_speed_percent": stats[2],
+        # pyrefly: ignore [bad-assignment]
         "memory_used_mb": stats[3],
+        # pyrefly: ignore [bad-assignment]
         "memory_free_mb": stats[4],
         "temperature_gpu_celsius": stats[5],
         "temperature_memory_celsius": stats[6],

--- a/torchtnt/utils/distributed.py
+++ b/torchtnt/utils/distributed.py
@@ -675,6 +675,7 @@ def rank_zero_read_and_broadcast(
             return cast(TReturn, ret)
 
         # Otherwise, broadcast result from rank 0 to all ranks
+        # pyrefly: ignore [bad-argument-type]
         pg = PGWrapper(process_group)
         path_container = [ret]
         pg.broadcast_object_list(path_container, 0)

--- a/torchtnt/utils/env.py
+++ b/torchtnt/utils/env.py
@@ -137,6 +137,7 @@ def seed(seed: int, deterministic: Optional[Union[str, int]] = None) -> None:
     _log.info(f"Setting seed to {seed}")
 
     torch.manual_seed(seed)
+    # pyrefly: ignore [bad-argument-type]
     np.random.seed(seed)
     random.seed(seed)
     os.environ["PYTHONHASHSEED"] = str(seed)

--- a/torchtnt/utils/event_handlers.py
+++ b/torchtnt/utils/event_handlers.py
@@ -70,13 +70,16 @@ def log_interval(
     unique_id = _generate_random_int64()
     if metadata is None:
         metadata = {}
+    # pyrefly: ignore [no-matching-overload]
     metadata.update({"action": "start", "unique_id": unique_id})
+    # pyrefly: ignore [bad-argument-type]
     start_event = Event(name=name, metadata=metadata)
     log_event(start_event)
 
     yield
 
     metadata["action"] = "end"
+    # pyrefly: ignore [bad-argument-type]
     end_event = Event(name=name, metadata=metadata)
     log_event(end_event)
 

--- a/torchtnt/utils/flops.py
+++ b/torchtnt/utils/flops.py
@@ -35,6 +35,7 @@ def _matmul_flop_jit(inputs: Tuple[torch.Tensor], _outputs: Tuple[Any]) -> Numbe
     assert len(input_shapes) == 2, input_shapes
     assert input_shapes[0][-1] == input_shapes[1][-2], input_shapes
     flop = inputs[0].numel() * input_shapes[-1][-1]
+    # pyrefly: ignore [bad-return]
     return flop
 
 
@@ -52,6 +53,7 @@ def _addmm_flop_jit(inputs: Tuple[torch.Tensor], _outputs: Tuple[Any]) -> Number
     batch_size, input_dim = input_shapes[0]
     output_dim = input_shapes[1][1]
     flops = batch_size * input_dim * output_dim
+    # pyrefly: ignore [bad-return]
     return flops
 
 
@@ -95,6 +97,7 @@ def _conv_flop_count(
         * reduce(operator.mul, w_shape, 1)
         * reduce(operator.mul, conv_shape, 1)
     )
+    # pyrefly: ignore [bad-return]
     return flop
 
 
@@ -125,7 +128,9 @@ def _conv_backward_flop_jit(
 
     grad_out_shape, x_shape, w_shape = [cast(torch.Tensor, i).shape for i in inputs[:3]]
     output_mask = inputs[-1]
+    # pyrefly: ignore [bad-index]
     fwd_transposed = inputs[7]
+    # pyrefly: ignore [bad-assignment]
     flop_count: Number = 0
 
     if cast(Tuple[bool], output_mask)[0]:
@@ -134,7 +139,9 @@ def _conv_backward_flop_jit(
         flop_count = flop_count + _conv_flop_count(
             grad_out_shape, w_shape, grad_input_shape, not fwd_transposed
         )
+    # pyrefly: ignore [bad-index]
     if cast(Tuple[bool], output_mask)[1]:
+        # pyrefly: ignore [bad-index]
         grad_weight_shape = outputs[1].shape
         # pyre-fixme[58]: `+` is not supported for operand types `int` and `Number`.
         flop_count += _conv_flop_count(
@@ -147,6 +154,7 @@ def _conv_backward_flop_jit(
     return flop_count
 
 
+# pyrefly: ignore [bad-assignment]
 flop_mapping: Dict[Callable[..., Any], Callable[[Tuple[Any], Tuple[Any]], Number]] = {
     aten.mm: _matmul_flop_jit,
     aten.matmul: _matmul_flop_jit,
@@ -232,6 +240,7 @@ class FlopTensorDispatchMode(TorchDispatchMode):
         outs = _normalize_tuple(rs)
 
         if func in flop_mapping:
+            # pyrefly: ignore [bad-argument-type]
             flop_count = flop_mapping[func](args, outs)
             for par in self._parents:
                 # pyre-fixme [58]

--- a/torchtnt/utils/memory.py
+++ b/torchtnt/utils/memory.py
@@ -38,6 +38,7 @@ def get_tensor_size_bytes_map(
         if isinstance(attribute, torch.Tensor):
             tensor_map[attribute] = attribute.size().numel() * attribute.element_size()
         elif _is_named_tuple(attribute):
+            # pyrefly: ignore [missing-attribute]
             attributes_q.extend(attribute._asdict().values())
         elif isinstance(attribute, Mapping):
             attributes_q.extend(attribute.values())

--- a/torchtnt/utils/misc.py
+++ b/torchtnt/utils/misc.py
@@ -57,18 +57,27 @@ def transfer_batch_norm_stats(
     for src_batch_norm_module, dst_batch_norm_module in zip(
         src_batch_norm_modules, dst_batch_norm_modules
     ):
+        # pyrefly: ignore [missing-attribute]
         dst_batch_norm_module.running_mean.detach().copy_(
+            # pyrefly: ignore [missing-attribute]
             src_batch_norm_module.running_mean.to(
+                # pyrefly: ignore [missing-attribute]
                 dst_batch_norm_module.running_mean.device
             )
         )
+        # pyrefly: ignore [missing-attribute]
         dst_batch_norm_module.running_var.detach().copy_(
+            # pyrefly: ignore [missing-attribute]
             src_batch_norm_module.running_var.to(
+                # pyrefly: ignore [missing-attribute]
                 dst_batch_norm_module.running_var.device
             )
         )
+        # pyrefly: ignore [missing-attribute]
         dst_batch_norm_module.num_batches_tracked.detach().copy_(
+            # pyrefly: ignore [missing-attribute]
             src_batch_norm_module.num_batches_tracked.to(
+                # pyrefly: ignore [missing-attribute]
                 dst_batch_norm_module.num_batches_tracked.device
             )
         )

--- a/torchtnt/utils/module_summary.py
+++ b/torchtnt/utils/module_summary.py
@@ -640,6 +640,7 @@ def _parse_batch_shape(batch: torch.Tensor) -> Union[TUnknown, List[int]]:
 
     if isinstance(batch, (list, tuple)):
         shape = [_parse_batch_shape(el) for el in batch]
+        # pyrefly: ignore [bad-return]
         return shape
 
     return _UNKNOWN_SIZE

--- a/torchtnt/utils/oom.py
+++ b/torchtnt/utils/oom.py
@@ -96,6 +96,7 @@ def log_memory_snapshot(output_dir: str, file_prefix: Optional[str] = None) -> N
     save_dir = os.path.join(output_dir, f"{file_prefix}_rank{rank}")
     try:
         snapshot = torch.cuda.memory._snapshot()
+        # pyrefly: ignore [bad-argument-type]
         _dump_snapshot(save_dir, snapshot)
         logger.info(f"Logged memory snapshot to {save_dir}")
     except Exception as e:

--- a/torchtnt/utils/prepare_module.py
+++ b/torchtnt/utils/prepare_module.py
@@ -327,7 +327,9 @@ def prepare_ddp(
         device_ids = [device.index]
     params_dict = asdict(strategy)
     # remove ddp comm hook variables from params dict
+    # pyrefly: ignore [unsupported-delete]
     del params_dict["comm_state"]
+    # pyrefly: ignore [unsupported-delete]
     del params_dict["comm_hook"]
 
     materialize_meta_params(module, device)
@@ -336,6 +338,7 @@ def prepare_ddp(
     module = module.to(device)
 
     # remove sync batch norm from params dict before converting module
+    # pyrefly: ignore [unsupported-delete]
     del params_dict["sync_batchnorm"]
     if strategy.sync_batchnorm:
         if device.type == "cuda":
@@ -345,6 +348,7 @@ def prepare_ddp(
                 f"SyncBatchNorm layers only work with GPU modules. Skipping the conversion because the device type is {device.type}."
             )
 
+    # pyrefly: ignore [unexpected-keyword]
     module = DDP(module, device_ids=device_ids, **params_dict)
     if strategy.comm_hook:
         module.register_comm_hook(state=strategy.comm_state, hook=strategy.comm_hook)
@@ -887,6 +891,7 @@ def _check_and_convert_mp_policy_dtypes(
     Returns new MixedPrecisionPolicy as its attributes are frozen (cannot assign new values to fields)
     """
 
+    # pyrefly: ignore [missing-attribute]
     dtypes = (mp_policy.param_dtype, mp_policy.reduce_dtype, mp_policy.output_dtype)
     dtypes = filter(None, dtypes)
     for dtype in dtypes:
@@ -895,13 +900,19 @@ def _check_and_convert_mp_policy_dtypes(
                 f"MixedPrecisionPolicy requires all dtypes to be torch.dtype or string. Got dtype={dtype} with type {type(dtype)}"
             )
 
+    # pyrefly: ignore [missing-attribute]
     param_dtype = mp_policy.param_dtype
+    # pyrefly: ignore [missing-attribute]
     reduce_dtype = mp_policy.reduce_dtype
+    # pyrefly: ignore [missing-attribute]
     output_dtype = mp_policy.output_dtype
+    # pyrefly: ignore [missing-attribute]
     if isinstance(mp_policy.param_dtype, str):
         param_dtype = convert_precision_str_to_dtype(mp_policy.param_dtype)
+    # pyrefly: ignore [missing-attribute]
     if isinstance(mp_policy.reduce_dtype, str):
         reduce_dtype = convert_precision_str_to_dtype(mp_policy.reduce_dtype)
+    # pyrefly: ignore [missing-attribute]
     if isinstance(mp_policy.output_dtype, str):
         output_dtype = convert_precision_str_to_dtype(mp_policy.output_dtype)
 
@@ -909,6 +920,7 @@ def _check_and_convert_mp_policy_dtypes(
         param_dtype=param_dtype,
         reduce_dtype=reduce_dtype,
         output_dtype=output_dtype,
+        # pyrefly: ignore [missing-attribute]
         cast_forward_inputs=mp_policy.cast_forward_inputs,
     )
 

--- a/torchtnt/utils/swa.py
+++ b/torchtnt/utils/swa.py
@@ -93,7 +93,9 @@ class AveragedModel(PyTorchAveragedModel):
             self.register_buffer(
                 "n_averaged", torch.tensor(0, dtype=torch.long, device=device)
             )
+            # pyrefly: ignore [bad-override-mutable-attribute]
             self.avg_fn: Optional[TSWA_avg_fn] = None
+            # pyrefly: ignore [bad-override-mutable-attribute]
             self.multi_avg_fn: Optional[TSWA_multi_avg_fn] = multi_avg_fn
             self.use_buffers: bool = use_buffers
         else:

--- a/torchtnt/utils/test_utils.py
+++ b/torchtnt/utils/test_utils.py
@@ -67,11 +67,14 @@ def is_asan_or_tsan() -> bool:
 
 
 def skip_if_asan(
+    # pyrefly: ignore [bad-specialization, not-a-type]
     func: Callable[TParams, TReturn],
+    # pyrefly: ignore [bad-specialization, not-a-type]
 ) -> Callable[TParams, Optional[TReturn]]:
     """Skip test run if we are in ASAN mode."""
 
     @wraps(func)
+    # pyrefly: ignore [not-a-type]
     def wrapper(*args: TParams.args, **kwargs: TParams.kwargs) -> Optional[TReturn]:
         if is_asan_or_tsan():
             print("Skipping test run since we are in ASAN mode.")

--- a/torchtnt/utils/tqdm.py
+++ b/torchtnt/utils/tqdm.py
@@ -50,6 +50,7 @@ def create_progress_bar(
     kwargs = {}
     if mininterval is not None:
         kwargs["mininterval"] = mininterval
+    # pyrefly: ignore [no-matching-overload]
     return tqdm(
         desc=f"{desc} {current_epoch}",
         total=total,


### PR DESCRIPTION
Summary:
Automated migration to enable Pyrefly type checking for `fbcode/torchtnt`.

- Added `python.set_pyrefly(True)` to PACKAGE file
- Suppressed pre-existing type errors

Pyrefly is Meta's next-generation Python type checker, replacing Pyre.

If you encounter issues, you can revert the PACKAGE change by removing
the `python.set_pyrefly(True)` line.
#pyreupgrade

Differential Revision: D108326467
