### PR TITLE
Distributed-aware DCP reader for per-rank checkpoints (#1067)

### DIFF
--- a/tests/framework/callbacks/test_dcp_saver.py
+++ b/tests/framework/callbacks/test_dcp_saver.py
@@ -40,6 +40,7 @@ from torchtnt.framework._test_utils import (
     generate_random_dataloader,
     get_dummy_train_state,
 )
+from torchtnt.framework.callbacks._checkpoint_utils import _PHASE_DL_STATE_KEY_MAPPING
 from torchtnt.framework.callbacks.checkpointer_types import KnobOptions, RestoreOptions
 from torchtnt.framework.callbacks.dcp_saver import DistributedCheckpointSaver
 from torchtnt.framework.evaluate import evaluate
@@ -47,7 +48,11 @@ from torchtnt.framework.fit import fit
 from torchtnt.framework.predict import predict
 from torchtnt.framework.state import State
 from torchtnt.framework.train import train
-from torchtnt.utils.checkpoint import BestCheckpointConfig, get_latest_checkpoint_path
+from torchtnt.utils.checkpoint import (
+    BestCheckpointConfig,
+    get_latest_checkpoint_path,
+    Phase,
+)
 from torchtnt.utils.distributed import get_global_rank, spawn_multi_process
 from torchtnt.utils.env import seed
 from torchtnt.utils.test_utils import skip_if_not_distributed
@@ -971,6 +976,56 @@ class DistributedCheckpointSaverTest(unittest.TestCase):
                         [*mock_load.call_args[0][0]["app_state"].state_dict().keys()],
                         expected_keys_with_dls,
                     )
+
+    def test_maybe_add_dataloader_per_rank_metadata_fallback(self) -> None:
+        # For per-rank checkpoints (saved without a dir-level manifest), the global
+        # read_metadata() raises. _maybe_add_dataloader_to_app_state should fall back
+        # to the rank-local read_metadata(rank=...), mirroring dcp's _load_state_dict.
+        train_dl_key = _PHASE_DL_STATE_KEY_MAPPING[Phase.TRAIN]
+        rank_metadata = Metadata(
+            state_dict_metadata={f"app_state.{train_dl_key}": MagicMock()}
+        )
+
+        storage_reader = MagicMock(spec=PerRankAwareStorageReader)
+        storage_reader.read_metadata.side_effect = lambda *args, **kwargs: (
+            rank_metadata if "rank" in kwargs else _raise_no_global_metadata()
+        )
+
+        stateful_dataloader = DummyStatefulDataLoader(
+            dataloader=generate_random_dataloader(10, 2, 2)
+        )
+
+        app_state = DistributedCheckpointSaver._maybe_add_dataloader_to_app_state(
+            app_state={},
+            checkpoint_path=None,
+            storage_reader=storage_reader,
+            train_dataloader=stateful_dataloader,
+        )
+
+        # The global read failed, so the per-rank read must have been called with rank=.
+        rank_calls = [
+            call
+            for call in storage_reader.read_metadata.call_args_list
+            if "rank" in call.kwargs
+        ]
+        self.assertEqual(len(rank_calls), 1)
+        self.assertEqual(rank_calls[0].kwargs["rank"], get_global_rank())
+
+        # The dataloader from the rank-local metadata is added to the app state.
+        self.assertIn(train_dl_key, app_state)
+        self.assertIs(app_state[train_dl_key], stateful_dataloader)
+
+
+def _raise_no_global_metadata() -> Metadata:
+    raise AssertionError("Unknown module type rank_0")
+
+
+class PerRankAwareStorageReader:
+    """Reader whose read_metadata accepts a ``rank`` kwarg, so the per-rank fallback guard
+    (``"kwargs" in inspect.signature(...).parameters``) is satisfied during testing."""
+
+    def read_metadata(self, **kwargs: Any) -> Metadata:
+        raise NotImplementedError
 
 
 class DummyStatefulDataLoader:

--- a/torchtnt/framework/callbacks/dcp_saver.py
+++ b/torchtnt/framework/callbacks/dcp_saver.py
@@ -6,6 +6,7 @@
 
 # pyre-strict
 
+import inspect
 import logging
 import time
 from concurrent.futures import Future
@@ -57,7 +58,7 @@ from torchtnt.framework.unit import (
 )
 from torchtnt.framework.utils import get_timing_context
 from torchtnt.utils.checkpoint import BestCheckpointConfig, CheckpointPath, Phase
-from torchtnt.utils.distributed import get_or_create_gloo_pg
+from torchtnt.utils.distributed import get_global_rank, get_or_create_gloo_pg
 from torchtnt.utils.rank_zero_log import rank_zero_info, rank_zero_warn
 from torchtnt.utils.stateful import MultiStateful, Stateful
 from typing_extensions import TypeAlias
@@ -398,7 +399,7 @@ class DistributedCheckpointSaver(BaseCheckpointer):
         )
 
     @staticmethod
-    def _maybe_add_dataloader_to_app_state(
+    def _maybe_add_dataloader_to_app_state(  # noqa: C901
         app_state: Dict[str, Stateful],
         checkpoint_path: Optional[CheckpointPath],
         storage_reader: StorageReader,
@@ -436,7 +437,30 @@ class DistributedCheckpointSaver(BaseCheckpointer):
 
         # check if any of the candidate phases has a dataloader saved in the checkpoint. If so, include
         # it in the app state. More than one dataloader may be present if using fit.
-        metadata = storage_reader.read_metadata()
+        # Use global metadata if available, otherwise fall back to rank local metadata.
+        # This mirrors the fallback in torch.distributed.checkpoint's _load_state_dict so
+        # that per-rank checkpoints (saved without a dir-level manifest) can be read here,
+        # which happens before dcp.load() runs its own fallback.
+        metadata = None
+        try:
+            metadata = storage_reader.read_metadata()
+        except Exception:
+            logger.warning(
+                "Global metadata is not found. Falling back to rank local metadata.",
+                exc_info=True,
+            )
+
+        if (
+            metadata is None
+            and "kwargs" in inspect.signature(storage_reader.read_metadata).parameters
+        ):
+            metadata = storage_reader.read_metadata(rank=get_global_rank())
+
+        if metadata is None:
+            raise RuntimeError(
+                "Failed to read checkpoint metadata for dataloader restoration."
+            )
+
         for key in metadata.state_dict_metadata.keys():
             for phase in candidate_dataloaders.keys():
                 if (dl_key := _PHASE_DL_STATE_KEY_MAPPING[phase]) in key:


### PR DESCRIPTION
Summary:

### This Stack
Stands up the Qwen3.5-MoE-397B-A17B IFM v4.7 teacher end-to-end on an EP=8/TP=1 (no tensor-parallel) recipe. It covers the three pieces that do not exist at this scale yet: the self-contained training configs + SFT-stage recipe; the checkpoint infrastructure that makes per-rank distributed (no-allgather) save, discovery, resume, and DCP->consolidated-HF convert work at 397B; and the vLLM EvalHub inference + L3 scorer that rank the trained teacher apple-to-apple against the 4B/27B/122B baselines.

### This Diff
The torchtnt DCP reader assumes single-writer metadata, so reading back a per-rank (distributed-save) checkpoint -- e.g. to restore dataloader state -- fails when that global metadata is absent. Teaches reader selection to recognize per-rank checkpoints and fall back to per-rank metadata. This is the torchtnt-side complement to the framework's distributed-aware discovery.

Reviewed By: galrotem

Differential Revision: D109374000


