### PR TITLE
test_loop_utils: import model_is_exported from torchao (#1070)

### DIFF
--- a/tests/framework/test_loop_utils.py
+++ b/tests/framework/test_loop_utils.py
@@ -12,12 +12,10 @@ from typing import cast, Dict
 
 import torch
 from torch import distributed as dist, nn
-
-# pyre-fixme[21]: Could not find module `torch.ao.quantization.pt2e.export_utils`.
-from torch.ao.quantization.pt2e.export_utils import model_is_exported
 from torch.distributed import launcher
 from torch.utils.data import DataLoader
 from torch.utils.data.distributed import DistributedSampler
+from torchao.quantization.pt2e.export_utils import model_is_exported
 from torchtnt.framework._loop_utils import (
     _is_done,
     _is_epoch_done,

--- a/tests/utils/test_distributed.py
+++ b/tests/utils/test_distributed.py
@@ -9,7 +9,7 @@
 
 import os
 import unittest
-from typing import Callable, Literal, Optional, Union
+from typing import Callable, cast, Literal, Optional, Union
 from unittest.mock import MagicMock, patch
 from urllib.parse import parse_qs, urlparse
 
@@ -528,7 +528,7 @@ class DistributedTest(unittest.TestCase):
 
         # Test creating new gloo candidate pg - no op
         mock_destroy_process_group.reset_mock()
-        gloo_pg = dist.new_group(backend=dist.Backend.GLOO)
+        gloo_pg = cast(ProcessGroup, dist.new_group(backend=dist.Backend.GLOO))
         with get_or_create_gloo_pg(gloo_pg) as pg:
             tc.assertIs(pg, gloo_pg)
 
@@ -551,7 +551,7 @@ class DistributedTest(unittest.TestCase):
         # Test exception handling with existing pg - forward exception, group should not be destroyed
         mock_destroy_process_group.reset_mock()
         with tc.assertRaisesRegex(Exception, "Test Exception"):
-            gloo_pg = dist.new_group(backend=dist.Backend.GLOO)
+            gloo_pg = cast(ProcessGroup, dist.new_group(backend=dist.Backend.GLOO))
             with get_or_create_gloo_pg(gloo_pg) as pg:
                 tc.assertIs(pg, gloo_pg)
                 raise Exception("Test Exception")

--- a/torchtnt/framework/callbacks/base_checkpointer.py
+++ b/torchtnt/framework/callbacks/base_checkpointer.py
@@ -175,8 +175,11 @@ class BaseCheckpointer(Callback, metaclass=abc.ABCMeta):
         # we create a new gloo process group if different backend is being used
         if dist.get_backend(process_group) != dist.Backend.GLOO:
             rank_zero_info("Creating new gloo process group for checkpointing.")
-            self._process_group = dist.new_group(
-                timeout=timedelta(seconds=3600), backend=dist.Backend.GLOO
+            self._process_group = cast(
+                dist.ProcessGroup,
+                dist.new_group(
+                    timeout=timedelta(seconds=3600), backend=dist.Backend.GLOO
+                ),
             )
         else:
             self._process_group = process_group

--- a/torchtnt/utils/data/iterators.py
+++ b/torchtnt/utils/data/iterators.py
@@ -385,8 +385,8 @@ class RandomizedBatchSamplerIterator(MultiIterator):
                 name: torch.IntTensor([idx])
                 for idx, name in enumerate(self._iterator_names)
             }
-            self._process_group: dist.ProcessGroup = dist.new_group(
-                backend="gloo", ranks=None
+            self._process_group: dist.ProcessGroup = cast(
+                dist.ProcessGroup, dist.new_group(backend="gloo", ranks=None)
             )
 
         self._iterators_finished: List[str] = []

--- a/torchtnt/utils/distributed.py
+++ b/torchtnt/utils/distributed.py
@@ -9,6 +9,7 @@
 
 import logging
 import os
+import shutil
 import tempfile
 from contextlib import contextmanager
 from dataclasses import dataclass
@@ -557,7 +558,7 @@ def sync_bool(
 @dataclass
 class ProcessGroupSetupParams:
     backend: str
-    port: str
+    rdzv_file: str
     world_size: int
     timeout_s: int
 
@@ -571,7 +572,7 @@ def spawn_multi_process(
 ) -> List[TReturn]:
     """
     Spawn single node, multi-rank function.
-    Uses localhost and free port to communicate.
+    Ranks rendezvous over a unique per-call FileStore to communicate.
 
     Args:
         world_size: number of processes
@@ -589,35 +590,48 @@ def spawn_multi_process(
         A list, l, where l[i] is the return value of method(*method_args, **methods_kwargs) on rank i
     """
     mp_init_mode = "spawn" if torch.version.hip is not None else None
-    manager = SyncManager(ctx=multiprocessing.get_context(mp_init_mode))
-    manager.start()
-    mp_output_dict = manager.dict()
+    # Rendezvous over a unique per-call FileStore instead of a TCP port. A free
+    # port from get_free_port() is released before the child ranks bind, so it can
+    # be grabbed by another process or linger in TIME_WAIT, which made repeated
+    # single-node spawns flake with rendezvous timeouts. The temp dir is cleaned
+    # in the outer finally so it is removed even if the manager fails to start or
+    # to shut down.
+    rdzv_dir = tempfile.mkdtemp(prefix="tnt_spawn_pg_")
+    try:
+        manager = SyncManager(ctx=multiprocessing.get_context(mp_init_mode))
+        manager.start()
+        try:
+            mp_output_dict = manager.dict()
 
-    port = str(get_free_port())
-    torch.multiprocessing.spawn(
-        # torch.multiprocessing.spawn sends rank as the first param
-        # https://pytorch.org/docs/stable/multiprocessing.html#torch.multiprocessing.spawn
-        _init_pg_and_rank_and_launch_method,
-        args=(
-            ProcessGroupSetupParams(
-                backend=backend,
-                port=port,
-                world_size=world_size,
-                timeout_s=method_kwargs.pop("timeout_s", 60),
-            ),
-            mp_output_dict,
-            method,
-            method_args,
-            method_kwargs,
-        ),
-        nprocs=world_size,
-    )
+            torch.multiprocessing.spawn(
+                # torch.multiprocessing.spawn sends rank as the first param
+                # https://pytorch.org/docs/stable/multiprocessing.html#torch.multiprocessing.spawn
+                _init_pg_and_rank_and_launch_method,
+                args=(
+                    ProcessGroupSetupParams(
+                        backend=backend,
+                        rdzv_file=os.path.join(rdzv_dir, "rdzv"),
+                        world_size=world_size,
+                        timeout_s=method_kwargs.pop("timeout_s", 60),
+                    ),
+                    mp_output_dict,
+                    method,
+                    method_args,
+                    method_kwargs,
+                ),
+                nprocs=world_size,
+            )
 
-    output_list = []
-    for i in range(world_size):
-        output_list.append(mp_output_dict[i])
+            output_list = []
+            for i in range(world_size):
+                output_list.append(mp_output_dict[i])
 
-    return output_list
+            return output_list
+        finally:
+            # Release the manager so repeated spawns do not leak a helper process or fds.
+            manager.shutdown()
+    finally:
+        shutil.rmtree(rdzv_dir, ignore_errors=True)
 
 
 def _init_pg_and_rank_and_launch_method(
@@ -628,14 +642,14 @@ def _init_pg_and_rank_and_launch_method(
     args: List[object],
     kwargs: Dict[str, object],
 ) -> None:
-    os.environ["MASTER_ADDR"] = "localhost"
-    os.environ["MASTER_PORT"] = pg_setup_params.port
     os.environ["WORLD_SIZE"] = str(pg_setup_params.world_size)
     os.environ["LOCAL_RANK"] = str(rank)
+    store = dist.FileStore(pg_setup_params.rdzv_file, pg_setup_params.world_size)
     dist.init_process_group(
         rank=rank,
         world_size=pg_setup_params.world_size,
         backend=pg_setup_params.backend,
+        store=store,
         timeout=timedelta(  # setting up timeout for distributed collectives
             seconds=pg_setup_params.timeout_s
         ),


### PR DESCRIPTION
Summary:

## Goal
Make `test_loop_utils` importable again. It still referenced the removed `torch.ao.quantization.pt2e` path, so the whole module failed to collect and every case in it (including `test_is_epoch_done`) was reported FATAL.

## Background
- `model_is_exported` moved out of core torch into the standalone [torchao](https://github.com/pytorch/ao) package at `torchao.quantization.pt2e.export_utils`.
- The source module `_loop_utils.py` was migrated to the torchao path in D92006625; this test module was missed.

## What it changes
- `test_loop_utils.py`: import `model_is_exported` from `torchao.quantization.pt2e.export_utils` and drop the obsolete `pyre-fixme[21]` suppression.
- `BUCK`: add an explicit `//pytorch/ao:torchao` dep, since the test now imports torchao directly instead of leaning on a transitive dep.

Reviewed By: twmoveon

Differential Revision: D113698731


