### PR TITLE
test_base_checkpointer: de-flake test_directory_path_synced

### DIFF
--- a/tests/framework/callbacks/test_base_checkpointer.py
+++ b/tests/framework/callbacks/test_base_checkpointer.py
@@ -89,8 +89,10 @@ class BaseCheckpointSaver(BaseCheckpointer):
         self, state: State, unit: AppStateMixin, checkpoint_id: str, hook: str
     ) -> bool:
         self._latest_checkpoint_path = checkpoint_id
-        if not os.path.exists(checkpoint_id):
-            os.mkdir(checkpoint_id)
+        # exist_ok guards against a benign race: in distributed tests every rank
+        # shares rank 0's synced dirpath and generates the same checkpoint path,
+        # so concurrent ranks may create this directory at the same time.
+        os.makedirs(checkpoint_id, exist_ok=True)
         return True
 
     @staticmethod


### PR DESCRIPTION
Summary:
`test_directory_path_synced` spawns two gloo ranks that both run
`BaseCheckpointer.on_train_epoch_end`. Both the checkpoint dirpath and the
generated checkpoint path are broadcast from rank 0, so every rank ends up
creating the identical directory under rank 0's temp dir.

The test's `_checkpoint_impl` created that directory with a check-then-create
sequence:

    if not os.path.exists(checkpoint_id):
        os.mkdir(checkpoint_id)

With concurrent ranks this is a TOCTOU race: both ranks observe the path as
missing, both call `os.mkdir`, and the loser raises `FileExistsError`, so the
test fails intermittently.

Make the creation idempotent with `os.makedirs(checkpoint_id, exist_ok=True)`.
Concurrent ranks creating the same synced path is now benign, which removes the
nondeterminism without changing what the test exercises.

Reviewed By: galrotem

Differential Revision: D113800273


