### PR TITLE
Decide checkpoint phase-awareness from the checkpoint name only

### DIFF
--- a/tests/utils/test_checkpoint.py
+++ b/tests/utils/test_checkpoint.py
@@ -258,6 +258,21 @@ class CheckpointPathTest(unittest.TestCase):
                     metric_data=MetricData("eval_loss", 6.486097566010406e18),
                 ),
             ),
+            # phase-naive checkpoints under a dirpath that contains a phase
+            # marker are still phase-naive
+            (
+                "foo/eval_step_sweeps/epoch_2_step_1_acc=0.98",
+                CheckpointPath(
+                    "foo/eval_step_sweeps",
+                    epoch=2,
+                    step={Phase.NONE: 1},
+                    metric_data=MetricData("acc", 0.98),
+                ),
+            ),
+            (
+                "foo/train_step_dir/epoch_2_step_1",
+                CheckpointPath("foo/train_step_dir", epoch=2, step=1),
+            ),
         ]
         for path, expected_ckpt in valid_paths:
             parsed_ckpt = CheckpointPath.from_str(path)

--- a/torchtnt/utils/checkpoint.py
+++ b/torchtnt/utils/checkpoint.py
@@ -160,9 +160,13 @@ class CheckpointPath:
         Raises:
             ValueError: If the path is malformed (either non-parsable, or contains wrong data types)
         """
+        # Only the checkpoint name (the final path component) decides this. If we
+        # looked at the whole path, a dirpath that happens to contain
+        # "train_step"/"eval_step"/"predict_step" would flip a phase-naive
+        # checkpoint onto the phase-aware regex.
+        ckpt_name = checkpoint_path.rstrip("/").rsplit("/", 1)[-1]
         is_phase_aware = any(
-            phase in checkpoint_path
-            for phase in ["train_step", "eval_step", "predict_step"]
+            phase in ckpt_name for phase in ["train_step", "eval_step", "predict_step"]
         )
         regex = self.PHASE_AWARE_REGEX if is_phase_aware else self.PHASE_NAIVE_REGEX
         path_match = regex.match(checkpoint_path)


### PR DESCRIPTION
Summary:

`CheckpointPath._populate_from_str` picks between the phase-aware and phase-naive regex by testing for `train_step` / `eval_step` / `predict_step` anywhere in the path string, which includes the user-supplied dirpath. A phase-naive checkpoint that happens to live under a directory containing one of those substrings gets routed onto the phase-aware regex, and there are two ways that goes wrong:

- Silent corruption. `foo/eval_step_sweeps/epoch_2_step_1_acc=0.98` parses, but `(?:_(\w+)=(...))?` swallows `_step_1_acc=0.98` as the metric, so the result has `step={}` and a metric named `step_1_acc`.
- Hard failure. `foo/train_step_dir/epoch_2_step_1` (no metric) matches neither branch of the phase-aware regex and raises `ValueError: Attempted to parse malformed checkpoint path`.

Both are reachable from ordinary use. `CheckpointPath.path` produces exactly these strings, so the serialize then parse round-trip breaks; `__setstate__` calls `_populate_from_str`, so unpickling a CheckpointPath raises, which matters because this class is broadcast across ranks; and `get_latest_checkpoint_path` / `get_checkpoint_dirpaths` / `CheckpointManager` discovery break for anyone whose output directory is named something like `eval_step_sweeps`.

The dirpath has no bearing on whether the checkpoint itself is phase-aware, so the fix looks at the final path component only.

Test plan:

Added two entries to the existing `valid_paths` table in `CheckpointPathTest::test_from_str`, one per failure mode above. `test_from_str` fails before the change and the file passes after: `pytest tests/utils/test_checkpoint.py` gives 28 passed on torch 2.13 CPU, Python 3.12.