### PR TITLE
GlobalMeshCoordinator.fsdp_mesh: 2-D wrapping mesh for HSDP

### DIFF
--- a/tests/utils/test_device_mesh.py
+++ b/tests/utils/test_device_mesh.py
@@ -134,6 +134,44 @@ class TestGlobalMeshCoordinator(unittest.TestCase):
         tc.assertEqual(get_dp_mesh_size(gmc), 2)
         tc.assertEqual(get_dp_local_rank(gmc), get_global_rank() // 2)
 
+    def test_fsdp_mesh(self) -> None:
+        spawn_multi_process(4, "gloo", self._test_fsdp_mesh)
+
+    @staticmethod
+    def _test_fsdp_mesh() -> None:
+        """fsdp_mesh preserves the 2-D (dp_replicate, fsdp) grid under HSDP."""
+        tc = unittest.TestCase()
+
+        # dp_replicate=1 → 1-D fsdp mesh, identical to dense_fsdp_mesh.
+        gmc = GlobalMeshCoordinator(
+            dp_shard=-1, dp_replicate=1, tp=None, device_type="cpu"
+        )
+        tc.assertEqual(gmc.fsdp_mesh.ndim, 1)
+        tc.assertEqual(gmc.fsdp_mesh.mesh_dim_names, ("fsdp",))
+        tc.assertEqual(gmc.fsdp_mesh.size(), 4)
+
+        # dp_replicate=2 (world=4) → HSDP path: un-flattened 2-D mesh, whereas
+        # dp_mesh flattens to the 1-D dp_dense composite axis. This 2-D mesh is
+        # exactly what fully_shard consumes to do HSDP.
+        gmc = GlobalMeshCoordinator(
+            dp_shard=-1, dp_replicate=2, tp=None, device_type="cpu"
+        )
+        tc.assertEqual(gmc.fsdp_mesh.ndim, 2)
+        tc.assertEqual(gmc.fsdp_mesh.mesh_dim_names, ("dp_replicate", "fsdp"))
+        tc.assertEqual(gmc.fsdp_mesh.size(), 4)
+        tc.assertEqual(gmc.fsdp_mesh["dp_replicate"].size(), 2)
+        tc.assertEqual(gmc.fsdp_mesh["fsdp"].size(), 2)
+        # dp_mesh stays the flattened 1-D composite for DP-group consumers.
+        tc.assertEqual(gmc.dp_mesh.ndim, 1)
+
+        # tp=2, dp_replicate=1 → 1-D fsdp mesh of size world / tp = 2.
+        gmc = GlobalMeshCoordinator(
+            dp_shard=-1, dp_replicate=1, tp=2, device_type="cpu"
+        )
+        tc.assertEqual(gmc.fsdp_mesh.ndim, 1)
+        tc.assertEqual(gmc.fsdp_mesh.mesh_dim_names, ("fsdp",))
+        tc.assertEqual(gmc.fsdp_mesh.size(), 2)
+
 
 class TestSharedAxisRegimeValidator(unittest.TestCase):
     """3-regime validator coverage (SA-A: plan §2.1)."""

--- a/torchtnt/utils/device_mesh.py
+++ b/torchtnt/utils/device_mesh.py
@@ -126,6 +126,28 @@ class GlobalMeshCoordinator:
         return self.device_mesh._dense_view["fsdp"]
 
     @property
+    def fsdp_mesh(self) -> DeviceMesh:
+        """FSDP2 wrapping mesh for DENSE params, preserving the HSDP 2-D grid.
+
+        Unlike :attr:`dense_fsdp_mesh` — which FLATTENS ``(dp_replicate, fsdp)``
+        into one 1-D axis so DP-group / dataloader consumers see a single
+        composite data-parallel mesh — this returns the UN-flattened 2-D
+        ``(dp_replicate, fsdp)`` mesh when ``dp_replicate > 1``. Passing that
+        2-D mesh to ``fully_shard`` yields true HSDP: parameters are sharded
+        within each replica group (the ``fsdp`` axis) and replicated across
+        groups (the ``dp_replicate`` axis).
+
+        Falls back to the 1-D ``fsdp`` sub-mesh when ``dp_replicate == 1``
+        (no replication -> plain FSDP ``FULL_SHARD``), so callers that do not
+        opt into HSDP see identical behavior to :attr:`dense_fsdp_mesh`.
+        """
+        if self._dp_replicate_enabled:
+            # pyre-ignore[16]
+            return self.device_mesh._dense_view["dp_replicate", "fsdp"]
+        # pyre-ignore[16]
+        return self.device_mesh._dense_view["fsdp"]
+
+    @property
     def tp_mesh(self) -> Optional[DeviceMesh]:
         """TP grid of size ``tp``. Returns ``None`` when ``tp == 1``.
 


### PR DESCRIPTION
Summary:
## Goal
Add `GlobalMeshCoordinator.fsdp_mesh`, an accessor that exposes the un-flattened 2-D `(dp_replicate, fsdp)` device mesh needed to drive [HSDP](https://arxiv.org/abs/2304.11277) (hybrid sharded data parallel) through FSDP2's `fully_shard`.

## Background
- FSDP2 performs HSDP only when `fully_shard` receives a 2-D `(replicate, shard)` mesh; a 1-D mesh means plain `FULL_SHARD` across the whole world.
- The existing `dp_mesh` / `dense_fsdp_mesh` flattens `(dp_replicate, fsdp)` into one composite axis (for the data-parallel process group and dataloader), which is 1-D and cannot express HSDP.

## What it adds
- `fsdp_mesh` returns the un-flattened 2-D `(dp_replicate, fsdp)` mesh when `dp_replicate>1`, and the 1-D `fsdp` sub-mesh otherwise, so non-HSDP callers see behavior identical to `dense_fsdp_mesh`.
- `dp_mesh` is unchanged; this only exposes a new view of the mesh already built by `create_device_mesh`.

Reviewed By: vintipandey

Differential Revision: D114130027


