### PR TITLE
Fix `_maybe_set_distributed_sampler_epoch` to handle `MultiDataLoader`

### DIFF
--- a/torchtnt/framework/_loop_utils.py
+++ b/torchtnt/framework/_loop_utils.py
@@ -33,6 +33,7 @@ except Exception:
         pass
 
 
+from torchtnt.utils.data.multi_dataloader import MultiDataLoader
 from torchtnt.utils.progress import Progress
 
 _logger: logging.Logger = logging.getLogger(__name__)
@@ -96,6 +97,9 @@ def _maybe_set_distributed_sampler_epoch(
             dataloader.sampler.set_epoch(current_epoch)
         elif isinstance(dataloader.batch_sampler, _DistributedSampler):
             dataloader.batch_sampler.set_epoch(current_epoch)
+    elif isinstance(dataloader, MultiDataLoader):
+        for child in dataloader.individual_dataloaders.values():
+            _maybe_set_distributed_sampler_epoch(child, current_epoch)
 
 
 def _set_module_training_mode(


### PR DESCRIPTION
Summary:
`_maybe_set_distributed_sampler_epoch` only handles plain
`torch.utils.data.DataLoader` instances. When the train dataloader is a
`MultiDataLoader` (used by the Cascade multi-task pipeline), the
`isinstance(dataloader, DataLoader)` check fails silently and
`set_epoch()` is never called on any child sampler.

This means `DistributedSampler.epoch` stays at 0 for the entire run,
so the sampler draws the same random indices every epoch.

Fix: recurse into `MultiDataLoader.individual_dataloaders` and call
`_maybe_set_distributed_sampler_epoch` on each child.

Reviewed By: galrotem

Differential Revision: D114246690


